### PR TITLE
Minor fix to Databricks Apps deployment script

### DIFF
--- a/src/deploy.py
+++ b/src/deploy.py
@@ -248,6 +248,10 @@ starlette==0.40.0
                 str(databricks_dist), 
                 workspace_dir
             ]
+
+            if profile is not None:
+                import_cmd.append("--profile")
+                import_cmd.append(profile)
             
             logger.info(f"About to run command: {' '.join(import_cmd)}")
             logger.info(f"Uploading from: {databricks_dist}")


### PR DESCRIPTION
When deploying the app to Databricks Apps using the deploy.sh script, it mostly uses the Databricks SDK but for the file upload part it relies on the Databricks CLI. When calling the Databricks CLI to upload files, it was missing the profile argument. Therefore, for anyone trying to deploy the app to a different profile than the DEFAULT one, it would fail.

This change adds a minor fix by checking if the profile has been set on the deployment script. If so, it appends the profile argument to make sure it uploads the source code to the correct Databricks workspace.