### PR TITLE
fix(models): remove Claude Fable 5 from model list (suspended by Anthropic)

### DIFF
--- a/src/backend/src/seeds/model_configs.py
+++ b/src/backend/src/seeds/model_configs.py
@@ -265,13 +265,6 @@ DEFAULT_MODELS = {
         "context_window": 1000000,
         "max_output_tokens": 64000
     },
-    "databricks-claude-fable-5": {
-        "name": "databricks-claude-fable-5",
-        "temperature": 0.7,
-        "provider": "databricks",
-        "context_window": 1000000,
-        "max_output_tokens": 64000
-    },
     "databricks-claude-sonnet-4": {
         "name": "databricks-claude-sonnet-4",
         "temperature": 0.7,
@@ -473,6 +466,11 @@ REMOVED_MODEL_KEYS = [
     # ENDPOINT_NOT_FOUND. Never in DEFAULT_MODELS; prune it from any DB it was
     # manually added to. Use databricks-gemini-3-flash / 2-5-flash instead.
     "databricks-gemini-3-1-flash-lite",
+    # Anthropic suspended Claude Fable 5 on 2026-06-12 (US export-control
+    # directive); the endpoint returns TEMPORARILY_UNAVAILABLE for all callers.
+    # Prune it from any DB it was seeded/added to so it leaves the model picker.
+    # Re-add to DEFAULT_MODELS (and drop from here) if the suspension is lifted.
+    "databricks-claude-fable-5",
 ]
 
 async def seed_async():


### PR DESCRIPTION
## What

Removes `databricks-claude-fable-5` from `MODEL_CONFIGS` (`src/backend/src/seeds/model_configs.py`).

## Why

Anthropic **suspended Claude Fable 5 and Mythos 5 on 2026-06-12**, days after the 2026-06-09 launch, under a US government export-control directive (restriction on foreign-national access that couldn't be enforced selectively, so the models were disabled for all customers). The serving endpoint now returns `TEMPORARILY_UNAVAILABLE` for every caller, so the model should not be offered in Kasal's model picker.

## Notes

- The `model_rejects_temperature()` helper in `src/utils/model_config.py` keeps its `claude-fable` branch: it is harmless (matches nothing now) and defensive should the suspension be lifted and the model re-added.
- The seed file only affects fresh deploys; the already-deployed Lakebase `modelconfig` row was removed separately so the live app dropdown no longer lists it.
- Suspension is reported as **temporary**; if Fable returns, re-adding the single `MODEL_CONFIGS` entry restores it.

This pull request and its description were written by Isaac.