### PR TITLE
feat(ucmv): persist raw M-Query + DAX and expose UI downloads

### DIFF
--- a/src/backend/src/engines/crewai/tools/custom/mquery_conversion_pipeline_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/mquery_conversion_pipeline_tool.py
@@ -657,6 +657,20 @@ class MqueryConversionPipelineTool(BaseTool):
                 logger.warning(f"[Cache] Failed to save M-Query cache: {_save_err}")
             # ────────────────────────────────────────────────────────────────
 
+            # ── Durable raw M-Query persistence (Lakebase / conversion_history) ─
+            try:
+                run_sync(self._save_to_conversion_history(
+                    raw_extract=self._build_raw_mquery_extract(result),
+                    formatted_output=formatted_output,
+                    workspace_id=workspace_id,
+                    dataset_id=dataset_id,
+                    status="success",
+                    model_count=result.get("model_count", 0),
+                ))
+            except Exception as _hist_err:
+                logger.warning(f"[MQueryTool] conversion_history persistence skipped: {_hist_err}")
+            # ────────────────────────────────────────────────────────────────
+
             return formatted_output
 
         except Exception as e:
@@ -735,6 +749,108 @@ class MqueryConversionPipelineTool(BaseTool):
                 metadata=metadata,
                 report_id=None,
             )
+
+    # ── Durable raw M-Query persistence (conversion_history / Lakebase) ────────
+
+    @staticmethod
+    def _build_raw_mquery_extract(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Collect the full, untruncated original M-Query per table.
+
+        Unlike the same-day cache (which stores a 500-char-truncated Markdown
+        report), this returns the complete raw source expression for every table
+        so it can be persisted and retrieved verbatim later.
+        """
+        extract: List[Dict[str, Any]] = []
+        for model_name, model_data in (result.get("models") or {}).items():
+            for table_name, conversions in (model_data.get("tables") or {}).items():
+                for conv in conversions or []:
+                    expr_type = getattr(conv, "expression_type", None)
+                    extract.append({
+                        "model": model_name,
+                        "table": table_name,
+                        "expression_type": (
+                            expr_type.value if hasattr(expr_type, "value")
+                            else (str(expr_type) if expr_type else "")
+                        ),
+                        "success": bool(getattr(conv, "success", False)),
+                        "original_mquery": getattr(conv, "original_expression", None) or "",
+                        "databricks_sql": (
+                            getattr(conv, "databricks_sql", None)
+                            or getattr(conv, "create_view_sql", None) or ""
+                        ),
+                    })
+        return extract
+
+    async def _save_to_conversion_history(
+        self,
+        raw_extract: List[Dict[str, Any]],
+        formatted_output: str,
+        workspace_id: str,
+        dataset_id: Optional[str],
+        status: str,
+        model_count: int,
+    ) -> None:
+        """Persist the full raw M-Query extract to conversion_history (fail-open).
+
+        This is the durable, queryable counterpart to the same-day cache: the
+        untruncated source M-Query lands in ``input_data.mquery_raw`` and is
+        retrievable afterwards via ``GET /conversion-history`` (filter by
+        ``source_format=powerbi_mquery`` / ``execution_id``) or
+        ``GET /conversion-history/{id}``. Any failure here is non-fatal — it must
+        never break the conversion itself.
+        """
+        try:
+            from src.schemas.conversion import ConversionHistoryCreate
+            from src.utils.user_context import UserContext
+
+            table_count = len(raw_extract)
+            history_data = ConversionHistoryCreate(
+                execution_id=(getattr(self, "trace_context", None) or {}).get("job_id"),
+                source_format="powerbi_mquery",
+                target_format="sql",
+                input_data={
+                    "workspace_id": workspace_id,
+                    "dataset_id": dataset_id or "",
+                    "mquery_raw": raw_extract,
+                },
+                input_summary=(
+                    f"M-Query extract: {table_count} table(s) from workspace {workspace_id}"
+                )[:500],
+                output_data={
+                    "formatted_output": formatted_output,
+                    "model_count": model_count,
+                    "table_count": table_count,
+                },
+                output_summary=(
+                    f"Converted {table_count} table(s) across {model_count} model(s)"
+                )[:500],
+                configuration={
+                    "workspace_id": workspace_id,
+                    "dataset_id": dataset_id,
+                },
+                status=status,
+                measure_count=table_count,
+            )
+
+            group_id = None
+            try:
+                group_context = UserContext.get_group_context()
+                if group_context:
+                    group_id = getattr(group_context, "primary_group_id", None)
+            except Exception as _gc_err:
+                logger.debug(f"[MQueryTool] Could not resolve group_id for history: {_gc_err}")
+
+            async with ToolSessionProvider.conversion_repo() as repo:
+                record = await repo.create(history_data.model_dump())
+                if group_id:
+                    record.group_id = group_id
+                await repo.session.commit()
+                logger.info(
+                    f"[MQueryTool] Saved conversion_history record id={record.id} "
+                    f"(source_format=powerbi_mquery, tables={table_count}, status={status})"
+                )
+        except Exception as e:
+            logger.warning(f"[MQueryTool] Failed to save conversion_history (non-fatal): {e}")
 
     # ─────────────────────────────────────────────────────────────────────────
 
@@ -929,6 +1045,7 @@ class MqueryConversionPipelineTool(BaseTool):
         validated: list = []
         inserted: list = []
         skipped: list = []
+        raw_extract: List[Dict[str, Any]] = []
 
         try:
             async with MQueryConnector(mq_cfg) as connector:
@@ -948,6 +1065,15 @@ class MqueryConversionPipelineTool(BaseTool):
                             expr_type_str = (et.value if hasattr(et, "value") else str(et)) if et else "other"
 
                         lane = self._classify_table(expr_type_str, raw_expr)
+
+                        # Capture the full, untruncated original M-Query for durable persistence.
+                        raw_extract.append({
+                            "model": model.name,
+                            "table": tname,
+                            "expression_type": expr_type_str,
+                            "lane": lane,
+                            "original_mquery": raw_expr,
+                        })
 
                         if lane == "databricks":
                             logger.info(f"[Validation] Databricks table: {tname}")
@@ -983,7 +1109,22 @@ class MqueryConversionPipelineTool(BaseTool):
             logger.error(f"[Validation] Error: {e}", exc_info=True)
             return f"Error during validation: {e}"
 
-        return self._format_validation_report(validated, inserted, skipped, target)
+        report = self._format_validation_report(validated, inserted, skipped, target)
+
+        # ── Durable raw M-Query persistence (Lakebase / conversion_history) ─
+        try:
+            await self._save_to_conversion_history(
+                raw_extract=raw_extract,
+                formatted_output=report,
+                workspace_id=workspace_id,
+                dataset_id=dataset_id,
+                status="success",
+                model_count=len(models),
+            )
+        except Exception as _hist_err:
+            logger.warning(f"[MQueryTool] conversion_history persistence skipped: {_hist_err}")
+
+        return report
 
     # ── Databricks table: convert + validate ──────────────────────────────────
 

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -268,6 +268,7 @@ class UCMetricViewGeneratorTool(BaseTool):
             'limitations': results.get('limitations', {}),
             'validation': validation_results,
             'measures_with_dax': _measures_for_validation,
+            'mquery_raw': mquery_entries if isinstance(mquery_entries, list) else [],
             'specs_summary': {
                 k: {
                     'view_name': v.get('view_name'),
@@ -296,7 +297,125 @@ class UCMetricViewGeneratorTool(BaseTool):
         except Exception as _tmp_err:
             logger.debug(f"[UCMVGenerator] Could not write /tmp fallback: {_tmp_err}")
 
+        # ── Durable raw DAX persistence (Lakebase / conversion_history) ──────
+        try:
+            _run_async(self._save_dax_to_conversion_history(
+                raw_dax=self._build_raw_dax_extract(_measures_for_validation),
+                yaml_output=yaml_output,
+                sql_output=sql_output,
+                workspace_id=_get('workspace_id'),
+                dataset_id=_get('dataset_id'),
+                catalog=catalog,
+                schema=schema,
+            ))
+        except Exception as _hist_err:
+            logger.warning(f"[UCMVGenerator] conversion_history persistence skipped: {_hist_err}")
+        # ────────────────────────────────────────────────────────────────────
+
         return output_json
+
+    # ------------------------------------------------------------------
+    # Durable raw DAX persistence (conversion_history / Lakebase)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_raw_dax_extract(measures: Any) -> list:
+        """Collect the full, untruncated original DAX expression per measure.
+
+        Mirrors the M-Query extract produced by the MQuery Conversion Pipeline:
+        the complete raw source DAX is retained verbatim so it can be persisted
+        and retrieved later, rather than only living in the transient result.
+        """
+        extract = []
+        if not isinstance(measures, list):
+            return extract
+        for m in measures:
+            if not isinstance(m, dict):
+                continue
+            extract.append({
+                'measure_name': m.get('measure_name') or m.get('original_name') or '',
+                'original_name': m.get('original_name') or m.get('measure_name') or '',
+                'dax_expression': m.get('dax_expression') or '',
+                'proposed_allocation': m.get('proposed_allocation') or '',
+            })
+        return extract
+
+    async def _save_dax_to_conversion_history(
+        self,
+        raw_dax: list,
+        yaml_output: Any,
+        sql_output: Any,
+        workspace_id: Optional[str],
+        dataset_id: Optional[str],
+        catalog: Optional[str],
+        schema: Optional[str],
+    ) -> None:
+        """Persist the full raw DAX extract to conversion_history (fail-open).
+
+        Durable, queryable counterpart to the transient tool result: the
+        untruncated source DAX lands in ``input_data.dax_raw`` and is retrievable
+        afterwards via ``GET /conversion-history`` (filter by
+        ``source_format=powerbi_dax`` / ``execution_id``) or
+        ``GET /conversion-history/{id}``. Any failure here is non-fatal — it must
+        never break the generation itself.
+        """
+        try:
+            from src.engines.crewai.tools.tool_session_provider import ToolSessionProvider
+            from src.schemas.conversion import ConversionHistoryCreate
+            from src.utils.user_context import UserContext
+
+            measure_count = len(raw_dax)
+            history_data = ConversionHistoryCreate(
+                execution_id=(getattr(self, "trace_context", None) or {}).get("job_id"),
+                source_format="powerbi_dax",
+                target_format="uc_metrics",
+                input_data={
+                    "workspace_id": workspace_id or "",
+                    "dataset_id": dataset_id or "",
+                    "dax_raw": raw_dax,
+                },
+                input_summary=(
+                    f"DAX extract: {measure_count} measure(s)"
+                    + (f" from workspace {workspace_id}" if workspace_id else "")
+                )[:500],
+                output_data={
+                    "yaml": yaml_output,
+                    "sql": sql_output,
+                    "catalog": catalog,
+                    "schema": schema,
+                },
+                output_summary=(
+                    f"Generated UC metric views for {measure_count} measure(s)"
+                )[:500],
+                configuration={
+                    "workspace_id": workspace_id,
+                    "dataset_id": dataset_id,
+                    "catalog": catalog,
+                    "schema": schema,
+                },
+                status="success",
+                measure_count=measure_count,
+            )
+
+            group_id = None
+            try:
+                group_context = UserContext.get_group_context()
+                if group_context:
+                    group_id = getattr(group_context, "primary_group_id", None)
+            except Exception as _gc_err:
+                logger.debug(f"[UCMVGenerator] Could not resolve group_id for history: {_gc_err}")
+
+            async with ToolSessionProvider.conversion_repo() as repo:
+                record = await repo.create(history_data.model_dump())
+                if group_id:
+                    record.group_id = group_id
+                await repo.session.commit()
+                logger.info(
+                    f"[UCMVGenerator] Saved conversion_history record id={record.id} "
+                    f"(source_format=powerbi_dax, measures={measure_count})"
+                )
+        except Exception as e:
+            logger.warning(f"[UCMVGenerator] Failed to save conversion_history (non-fatal): {e}")
 
     # ------------------------------------------------------------------
     # PBI API input validation (SSRF prevention)

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_mquery_conversion_pipeline_tool.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_mquery_conversion_pipeline_tool.py
@@ -1866,3 +1866,151 @@ class TestExecuteWithValidation:
                 result = self._run(self.tool._execute_with_validation(cfg))
 
         assert "No semantic models" in result
+
+
+# ===========================================================================
+# Durable raw M-Query persistence (conversion_history / Lakebase)
+# ===========================================================================
+
+from types import SimpleNamespace
+
+
+class TestBuildRawMqueryExtract:
+    """_build_raw_mquery_extract collects full untruncated M-Query per table."""
+
+    def _conv(self, original, sql="SELECT 1", success=True, expr_type="native_query"):
+        return SimpleNamespace(
+            expression_type=SimpleNamespace(value=expr_type),
+            success=success,
+            original_expression=original,
+            databricks_sql=sql,
+            create_view_sql=None,
+        )
+
+    def test_collects_untruncated_expression(self):
+        long_expr = "let Source = " + ("X" * 2000) + " in Source"
+        result = {
+            "models": {
+                "Model A": {
+                    "tables": {
+                        "Fact_Sales": [self._conv(long_expr)],
+                    }
+                }
+            }
+        }
+        extract = MqueryConversionPipelineTool._build_raw_mquery_extract(result)
+        assert len(extract) == 1
+        # Full expression retained — NOT truncated at 500 chars like the cache report
+        assert extract[0]["original_mquery"] == long_expr
+        assert len(extract[0]["original_mquery"]) > 500
+        assert extract[0]["model"] == "Model A"
+        assert extract[0]["table"] == "Fact_Sales"
+        assert extract[0]["expression_type"] == "native_query"
+        assert extract[0]["success"] is True
+
+    def test_multiple_models_and_tables_flattened(self):
+        result = {
+            "models": {
+                "M1": {"tables": {"T1": [self._conv("q1")], "T2": [self._conv("q2")]}},
+                "M2": {"tables": {"T3": [self._conv("q3")]}},
+            }
+        }
+        extract = MqueryConversionPipelineTool._build_raw_mquery_extract(result)
+        assert len(extract) == 3
+        assert {e["table"] for e in extract} == {"T1", "T2", "T3"}
+
+    def test_falls_back_to_create_view_sql(self):
+        conv = SimpleNamespace(
+            expression_type=SimpleNamespace(value="table_from_rows"),
+            success=True,
+            original_expression="let x in x",
+            databricks_sql=None,
+            create_view_sql="CREATE VIEW v AS SELECT 1",
+        )
+        result = {"models": {"M": {"tables": {"T": [conv]}}}}
+        extract = MqueryConversionPipelineTool._build_raw_mquery_extract(result)
+        assert extract[0]["databricks_sql"] == "CREATE VIEW v AS SELECT 1"
+
+    def test_empty_result_returns_empty_list(self):
+        assert MqueryConversionPipelineTool._build_raw_mquery_extract({}) == []
+        assert MqueryConversionPipelineTool._build_raw_mquery_extract({"models": {}}) == []
+
+    def test_missing_original_expression_becomes_empty_string(self):
+        conv = SimpleNamespace(
+            expression_type=None, success=False,
+            original_expression=None, databricks_sql=None, create_view_sql=None,
+        )
+        result = {"models": {"M": {"tables": {"T": [conv]}}}}
+        extract = MqueryConversionPipelineTool._build_raw_mquery_extract(result)
+        assert extract[0]["original_mquery"] == ""
+        assert extract[0]["expression_type"] == ""
+
+
+class TestSaveToConversionHistory:
+    """_save_to_conversion_history persists to conversion_history, fail-open."""
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro) if False else run_sync(coro)
+
+    def test_persists_record_with_raw_mquery(self):
+        tool = MqueryConversionPipelineTool()
+        raw_extract = [{"model": "M", "table": "T", "original_mquery": "let x in x",
+                        "expression_type": "native_query", "success": True, "databricks_sql": "SELECT 1"}]
+
+        captured = {}
+        mock_repo = MagicMock()
+        mock_record = SimpleNamespace(id=42, group_id=None)
+
+        async def _create(data):
+            captured["data"] = data
+            return mock_record
+        mock_repo.create = AsyncMock(side_effect=_create)
+        mock_repo.session = MagicMock()
+        mock_repo.session.commit = AsyncMock()
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _repo_ctx():
+            yield mock_repo
+
+        with patch(
+            "src.engines.crewai.tools.tool_session_provider.ToolSessionProvider.conversion_repo",
+            _repo_ctx,
+        ):
+            self._run(tool._save_to_conversion_history(
+                raw_extract=raw_extract, formatted_output="report",
+                workspace_id=WORKSPACE_ID, dataset_id=DATASET_ID,
+                status="success", model_count=1,
+            ))
+
+        data = captured["data"]
+        assert data["source_format"] == "powerbi_mquery"
+        assert data["target_format"] == "sql"
+        assert data["input_data"]["mquery_raw"] == raw_extract
+        assert data["input_data"]["workspace_id"] == WORKSPACE_ID
+        assert data["status"] == "success"
+        mock_repo.session.commit.assert_awaited_once()
+
+    def test_fail_open_on_repo_error(self):
+        """A repository failure must NOT raise — conversion must not break."""
+        tool = MqueryConversionPipelineTool()
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _boom_ctx():
+            raise RuntimeError("db down")
+            yield  # pragma: no cover
+
+        with patch(
+            "src.engines.crewai.tools.tool_session_provider.ToolSessionProvider.conversion_repo",
+            _boom_ctx,
+        ):
+            # Should swallow the error and return None
+            result = self._run(tool._save_to_conversion_history(
+                raw_extract=[], formatted_output="r",
+                workspace_id=WORKSPACE_ID, dataset_id=None,
+                status="success", model_count=0,
+            ))
+        assert result is None

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_uc_metric_view_generator_tool.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_uc_metric_view_generator_tool.py
@@ -48,3 +48,118 @@ class TestUCMetricViewGeneratorTool:
         result = tool._run(measures_json='bad json')
         data = json.loads(result)
         assert 'error' in data
+
+
+# ===========================================================================
+# Durable raw DAX persistence (conversion_history / Lakebase)
+# ===========================================================================
+
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+class TestBuildRawDaxExtract:
+    """_build_raw_dax_extract collects full untruncated DAX per measure."""
+
+    def test_collects_untruncated_dax(self):
+        long_dax = "CALCULATE(SUM(fact[amount]), " + ("X" * 2000) + ")"
+        measures = [{
+            'measure_name': 'total_sales',
+            'original_name': 'Total Sales',
+            'dax_expression': long_dax,
+            'proposed_allocation': 'fact_sales',
+        }]
+        extract = UCMetricViewGeneratorTool._build_raw_dax_extract(measures)
+        assert len(extract) == 1
+        assert extract[0]['dax_expression'] == long_dax
+        assert len(extract[0]['dax_expression']) > 500
+        assert extract[0]['measure_name'] == 'total_sales'
+        assert extract[0]['proposed_allocation'] == 'fact_sales'
+
+    def test_multiple_measures(self):
+        measures = [
+            {'measure_name': 'm1', 'dax_expression': 'SUM(a)'},
+            {'measure_name': 'm2', 'dax_expression': 'AVG(b)'},
+        ]
+        extract = UCMetricViewGeneratorTool._build_raw_dax_extract(measures)
+        assert len(extract) == 2
+        assert {e['measure_name'] for e in extract} == {'m1', 'm2'}
+
+    def test_non_list_returns_empty(self):
+        assert UCMetricViewGeneratorTool._build_raw_dax_extract(None) == []
+        assert UCMetricViewGeneratorTool._build_raw_dax_extract("not a list") == []
+
+    def test_skips_non_dict_entries(self):
+        extract = UCMetricViewGeneratorTool._build_raw_dax_extract(
+            [{'measure_name': 'ok', 'dax_expression': 'SUM(a)'}, "garbage", 42]
+        )
+        assert len(extract) == 1
+        assert extract[0]['measure_name'] == 'ok'
+
+    def test_missing_dax_becomes_empty_string(self):
+        extract = UCMetricViewGeneratorTool._build_raw_dax_extract([{'measure_name': 'm'}])
+        assert extract[0]['dax_expression'] == ''
+
+
+class TestSaveDaxToConversionHistory:
+    """_save_dax_to_conversion_history persists to conversion_history, fail-open."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_persists_record_with_raw_dax(self):
+        tool = UCMetricViewGeneratorTool()
+        raw_dax = [{'measure_name': 'total_sales', 'original_name': 'Total Sales',
+                    'dax_expression': 'SUM(fact[amount])', 'proposed_allocation': 'fact'}]
+
+        captured = {}
+        mock_repo = MagicMock()
+        mock_record = SimpleNamespace(id=7, group_id=None)
+
+        async def _create(data):
+            captured["data"] = data
+            return mock_record
+        mock_repo.create = AsyncMock(side_effect=_create)
+        mock_repo.session = MagicMock()
+        mock_repo.session.commit = AsyncMock()
+
+        @asynccontextmanager
+        async def _repo_ctx():
+            yield mock_repo
+
+        with patch(
+            "src.engines.crewai.tools.tool_session_provider.ToolSessionProvider.conversion_repo",
+            _repo_ctx,
+        ):
+            self._run(tool._save_dax_to_conversion_history(
+                raw_dax=raw_dax, yaml_output={"v": "yaml"}, sql_output={"v": "sql"},
+                workspace_id="ws-1", dataset_id="ds-1", catalog="main", schema="default",
+            ))
+
+        data = captured["data"]
+        assert data["source_format"] == "powerbi_dax"
+        assert data["target_format"] == "uc_metrics"
+        assert data["input_data"]["dax_raw"] == raw_dax
+        assert data["input_data"]["workspace_id"] == "ws-1"
+        assert data["measure_count"] == 1
+        mock_repo.session.commit.assert_awaited_once()
+
+    def test_fail_open_on_repo_error(self):
+        tool = UCMetricViewGeneratorTool()
+
+        @asynccontextmanager
+        async def _boom_ctx():
+            raise RuntimeError("db down")
+            yield  # pragma: no cover
+
+        with patch(
+            "src.engines.crewai.tools.tool_session_provider.ToolSessionProvider.conversion_repo",
+            _boom_ctx,
+        ):
+            result = self._run(tool._save_dax_to_conversion_history(
+                raw_dax=[], yaml_output={}, sql_output={},
+                workspace_id=None, dataset_id=None, catalog="main", schema="default",
+            ))
+        assert result is None

--- a/src/frontend/src/components/Jobs/UCMVResultViewer.tsx
+++ b/src/frontend/src/components/Jobs/UCMVResultViewer.tsx
@@ -80,6 +80,10 @@ export interface UCMVResult {
   sql: Record<string, string>;
   stats: Record<string, UCMVStats> | UCMVStats;
   migration_report?: string;
+  /** Raw source measures with their original DAX expressions (echoed from the generator). */
+  measures_with_dax?: unknown[];
+  /** Raw source M-Query entries (echoed from the generator). */
+  mquery_raw?: unknown[];
 }
 
 interface UCMVResultViewerProps {
@@ -487,6 +491,20 @@ const UCMVResultViewer: React.FC<UCMVResultViewerProps> = ({ result, editable = 
     URL.revokeObjectURL(url);
   }, [result.sql, viewNames]);
 
+  // Download raw JSON (original DAX measures or original M-Query) as a file
+  const downloadJson = useCallback((data: unknown[], filename: string) => {
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const hasDax = Array.isArray(result.measures_with_dax) && result.measures_with_dax.length > 0;
+  const hasMquery = Array.isArray(result.mquery_raw) && result.mquery_raw.length > 0;
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 400 }}>
       {/* Header */}
@@ -530,6 +548,30 @@ const UCMVResultViewer: React.FC<UCMVResultViewerProps> = ({ result, editable = 
           >
             Download SQL
           </Button>
+          {hasDax && (
+            <Tooltip title="Download the original DAX measure expressions as JSON">
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<DownloadIcon />}
+                onClick={() => downloadJson(result.measures_with_dax as unknown[], 'original_dax_measures.json')}
+              >
+                Download DAX
+              </Button>
+            </Tooltip>
+          )}
+          {hasMquery && (
+            <Tooltip title="Download the original M-Query source as JSON">
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<DownloadIcon />}
+                onClick={() => downloadJson(result.mquery_raw as unknown[], 'original_mquery.json')}
+              >
+                Download M-Query
+              </Button>
+            </Tooltip>
+          )}
         </Box>
       </Box>
 


### PR DESCRIPTION
## What & why

During a Power BI → Databricks migration, the transpiled YAML/SQL was downloadable from the UCMV result plane, but the **original raw M-Query and DAX were discarded** — the only trace was a 500-char-truncated, 1-day-TTL cache report. This makes it impossible to audit "what was the original source vs. what it became" after the fact.

This PR durably persists the **full, untruncated** raw M-Query and DAX, and lets users download them from the UI.

## Backend

**No DB schema change** — writes into the existing `ConversionHistory` JSON columns (`input_data` / `output_data`).

- **MQuery Conversion Pipeline tool** — persists the complete raw M-Query to `conversion_history` (`source_format=powerbi_mquery`, `input_data.mquery_raw`) on both the normal and DBSQL-validation paths. **Fail-open** — never breaks a conversion.
- **UC Metric View Generator tool** — persists the complete raw DAX (`source_format=powerbi_dax`, `input_data.dax_raw`), fail-open, and echoes `mquery_raw` into its result payload so the UI can offer it.
- **Retrieval reuses the existing** `GET /conversion-history` endpoints (filter by `source_format` / `execution_id`) and `GET /conversion-history/{id}` — no new endpoint.

## Frontend

- `UCMVResultViewer` gains **"Download DAX"** and **"Download M-Query"** buttons, conditionally rendered only when the raw data is present in the payload (older results without the fields simply don't show a dead button).

## Tests

- +15 backend unit tests: extract building (untruncated capture, multi-model flattening, SQL fallback, empty/missing-field handling), persisted record shape, and the fail-open guarantee.
- Backend suites green (UCMV 11/11, M-Query 176/176, combined 1264 passed). Frontend `tsc --noEmit` + `eslint` clean.

## Caveats

- Buttons appear only for **new** runs — the payload fields didn't exist in previously-stored results.
- The M-Query pipeline's same-day cache can short-circuit before persistence on a same-dataset re-run; the DAX path has no such cache.

This pull request and its description were written by Isaac.