### PR TITLE
docs(claude): fix stale CLAUDE.md info + document engine paths (light/crew/flow)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,20 @@ Project-wide instructions for Claude Code (claude.ai/code) when working with the
 
 ## Context Layering
 
-Claude reads context from multiple CLAUDE.md files:
+Claude reads context from multiple CLAUDE.md files. The closest one to the file
+you are editing wins on specifics:
 - **This file**: Project-wide patterns and rules
 - **src/backend/CLAUDE.md**: Backend-specific instructions
 - **src/frontend/CLAUDE.md**: Frontend-specific instructions
+- **Per-layer files** (added for precision):
+  - `src/backend/src/api/CLAUDE.md` — FastAPI routers
+  - `src/backend/src/services/CLAUDE.md` — business logic
+  - `src/backend/src/repositories/CLAUDE.md` — data access
+  - `src/backend/src/models/CLAUDE.md` — SQLAlchemy models + migrations
+  - `src/backend/src/engines/crewai/CLAUDE.md` — the CrewAI engine (post-refactor)
+  - `src/backend/src/engines/crewai/tools/CLAUDE.md` — custom tools
+  - `src/frontend/src/api/CLAUDE.md` — frontend service layer
+  - `src/frontend/src/components/CLAUDE.md` — React components
 
 ## Important Project Rules
 
@@ -54,11 +64,11 @@ Kasal is an AI agent workflow orchestration platform with a **clean architecture
 **Frontend (React + TypeScript)** → **API (FastAPI)** → **Services** → **Repositories** → **Database**
 
 ### Technology Stack
-- **Backend**: FastAPI + SQLAlchemy 2.0 + Alembic (Python 3.9+)
-- **Frontend**: React 18 + TypeScript + Material-UI + ReactFlow
+- **Backend**: FastAPI + SQLAlchemy 2.0 (async) + Alembic (Python 3.11, pinned `>=3.11,<3.12`)
+- **Frontend**: React 18 + TypeScript + Material-UI + ReactFlow, built with **Vite**
 - **AI Engine**: CrewAI framework for agent orchestration
-- **Database**: SQLite (dev) / PostgreSQL (prod)
-- **Authentication**: JWT tokens with Databricks OAuth
+- **Database**: SQLite (dev) / PostgreSQL / Databricks Lakebase (prod)
+- **Authentication**: Databricks OAuth (OBO / SPN); JWT for app sessions
 
 ### Project Structure
 ```

--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -5,12 +5,12 @@ Backend-specific instructions for Claude Code when working in the backend direct
 ## Commands
 
 ### Development
-- **Activate virtual environment**: `source ../../venv/bin/activate` (from backend dir) or `source venv/bin/activate` (from project root)
-- **Start server**: `./run.sh` (defaults to PostgreSQL) or `./run.sh sqlite` for SQLite
+- **Dependencies are managed with `uv`** (not Poetry). Install/sync: `uv sync` (or `uv sync --frozen`). The venv lives at `src/backend/.venv`.
+- **Start server**: `./run.sh` (defaults to PostgreSQL) or `./run.sh sqlite` for SQLite. `run.sh` runs `uv sync --frozen` then `.venv/bin/uvicorn src.main:app --reload`.
 - **Run tests**: `python run_tests.py` (runs all tests with linting)
 - **Run specific tests**: `python run_tests.py --type unit` or `python run_tests.py --type integration`
 - **Run tests with coverage**: `python run_tests.py --coverage --html-coverage`
-- **Run single test file**: `python -m pytest tests/unit/test_file.py -v`
+- **Run single test file**: `.venv/bin/python -m pytest tests/unit/test_file.py -v`
 
 ### Database
 - **Migrations**: `alembic upgrade head`
@@ -34,15 +34,27 @@ Backend-specific instructions for Claude Code when working in the backend direct
 ### Directory Structure
 ```
 src/
-├── api/             # FastAPI route handlers
-├── core/            # Dependencies, logging, UOW
-├── models/          # SQLAlchemy database models
+├── api/             # FastAPI route handlers (see api/CLAUDE.md)
+├── core/            # Dependencies, base repo/service, permissions, UoW, exceptions
+├── models/          # SQLAlchemy database models (see models/CLAUDE.md)
 ├── schemas/         # Pydantic validation schemas
-├── services/        # Business logic layer
-├── repositories/    # Data access layer
-├── engines/crewai/  # CrewAI engine implementation
-└── main.py          # Application entry point
+├── services/        # Business logic layer (see services/CLAUDE.md)
+├── repositories/    # Data access layer (see repositories/CLAUDE.md)
+├── engines/crewai/  # CrewAI engine — POST-REFACTOR layout (see engines/crewai/CLAUDE.md)
+└── main.py          # Application entry point (uvicorn target: src.main:app)
 ```
+
+### CrewAI engine (three execution paths)
+The engine has three answer paths selected by `execution_type`:
+- `"agent"` → **light** path = **ChatMode / chat answer mode**, a single agent run
+  in-process (`Agent.kickoff_async`) for sub-second latency.
+- `"crew"` → crew path, runs in a **subprocess** (`process_crew_executor.py`).
+- `"flow"` → flow path, also **subprocess**.
+
+The engine was restructured into `paths/{light_agent,crew,flow}/` over a shared
+`kernel/`, plus `infra/`, `memory/`, `guardrails/{core,demo}/`. The old
+`common/`, `helpers/`, `utils/`, `services/`, `mcp/` packages are gone. See
+`src/backend/src/engines/crewai/CLAUDE.md` for details.
 
 ## Database Patterns
 
@@ -196,14 +208,17 @@ Do NOT add telemetry to non-Databricks calls (e.g., PowerBI API, external APIs).
 ## AI Engine Integration
 
 ### CrewAI Integration Points
-- **Engine Service**: Main orchestration service
-- **Configuration Adapter**: Transforms frontend configs to CrewAI format
-- **Execution Runner**: Manages async execution workflows
-- **Tool Factory**: Extensible tool system with custom tools
+- **Engine Service** (`engines/crewai/crewai_engine_service.py`): the hub that dispatches to one of three paths.
+- **Three execution paths** (`engines/crewai/paths/`): `light_agent` (chat, in-process), `crew` (subprocess), `flow` (subprocess).
+- **Kernel** (`engines/crewai/kernel/`): path-agnostic single-source agent/task build logic shared by crew + flow.
+- **Configuration Adapter** (`config_adapter.py`): normalizes frontend configs to CrewAI shape.
+- **Tool Factory** (`engines/crewai/tools/`): extensible tool system (see tools/CLAUDE.md).
+
+See `engines/crewai/CLAUDE.md` for the full path model and the subprocess-boundary rules.
 
 ## Environment
 
-- Python 3.9+ required
-- Uses Poetry for dependency management (see pyproject.toml)
-- Database type controlled by environment variables
-- API keys for LLM services configured via environment
+- Python 3.11 required (pinned `>=3.11,<3.12` in `pyproject.toml`)
+- Dependencies managed with **uv** (`pyproject.toml` + `uv.lock`, both committed). Never hand-edit `uv.lock`; run `uv lock` then `uv sync`.
+- Database type controlled by environment variables / DB config (SQLite, PostgreSQL, or Databricks Lakebase)
+- API keys for LLM services configured via environment or the API Keys service

--- a/src/backend/src/api/CLAUDE.md
+++ b/src/backend/src/api/CLAUDE.md
@@ -1,0 +1,56 @@
+# API Layer CLAUDE.md
+
+Instructions for FastAPI route handlers in `src/backend/src/api/`.
+
+## Role of this layer
+
+Routers are the **thin HTTP boundary**. They translate requests into service
+calls and services results into responses. They contain **no business logic and
+no direct database access**. The only allowed chain is:
+
+```
+Router → Service → Repository → DB
+```
+
+## Conventions (match the existing files, e.g. `agents_router.py`)
+
+- One router per resource, file named `<resource>_router.py`, exposing a module
+  level `router = APIRouter(prefix="/<resource>", tags=["<resource>"])`.
+- Register the router in `api/__init__.py` (or the aggregation point) — a new
+  file alone does not wire it up.
+- Provide the service via a local DI provider and a typed alias:
+  ```python
+  async def get_agent_service(session: SessionDep) -> AgentService:
+      return AgentService(session=session)
+
+  AgentServiceDep = Annotated[AgentService, Depends(get_agent_service)]
+  ```
+- Inject `session: SessionDep` (from `src.core.dependencies`) — this is
+  `get_smart_db_session`, which routes SQLite/PostgreSQL/Lakebase automatically.
+  Do not import engines or session factories directly.
+- Use `response_model=<Schema>` and explicit `status_code=status.HTTP_*`. Return
+  Pydantic schemas from `src.schemas`, never ORM models directly.
+
+## Multi-tenancy and permissions (do not skip)
+
+- Every data endpoint takes `group_context: GroupContextDep` and passes it to the
+  service so reads/writes stay group-scoped. Missing this leaks data across
+  tenants.
+- Authorize with `check_role_in_context(group_context, [...])` from
+  `src.core.permissions`, or the `require_*` decorators. Comment which roles are
+  allowed (Admin / Editor / Operator).
+
+## Errors
+
+- Raise the domain exceptions from `src.core.exceptions`
+  (`NotFoundError`, `ConflictError`, `ForbiddenError`, `BadRequestError`, ...).
+  A global handler maps them to HTTP status codes. **Do not** hand-build
+  `HTTPException` for these cases and do not leak stack traces to clients.
+- Catch `IntegrityError` around writes and translate to `ConflictError`.
+
+## Async and safety
+
+- Every handler is `async def`. Never call blocking I/O directly.
+- Never put SQLAlchemy queries in a router — that belongs in a repository.
+- Keep secrets out of responses and logs (services already
+  encrypt/decrypt/mask sensitive `tool_configs`).

--- a/src/backend/src/engines/crewai/CLAUDE.md
+++ b/src/backend/src/engines/crewai/CLAUDE.md
@@ -1,0 +1,94 @@
+# CrewAI Engine CLAUDE.md
+
+Instructions for `src/backend/src/engines/crewai/`. **This layout is post-refactor
+(branch `refactor/crewai-engine-structure`).** Older docs/CLAUDE notes that show
+`common/`, `helpers/`, `utils/`, `services/`, `mcp/`, or top-level path files are
+stale — those packages are gone.
+
+## The three execution paths (this is the core mental model)
+
+The engine has **three distinct answer paths**. Opening a file, first ask "which
+path am I in?" The `execution_type` string selects it (see
+`services/execution_service.py`):
+
+| `execution_type` | Path | Entry point | Where it runs |
+|------------------|------|-------------|---------------|
+| `"agent"` | **light** (chat) | `paths/light_agent/light_agent_service.py::run_light_agent_execution` | **in-process**, `Agent.kickoff_async`, sub-second |
+| `"crew"` | **crew** | `paths/crew/execution_runner.py::run_crew_in_process` | **subprocess** (`services/process_crew_executor.py`) |
+| `"flow"` | **flow** | `paths/flow/flow_execution_runner.py::run_flow_in_process` | **subprocess** |
+
+`crewai_engine_service.py` is the **hub**: it resolves the path and delegates. It
+holds no path-specific business logic.
+
+### Light-agent = ChatMode
+The **light path is what powers ChatMode / the chat answer mode**. It is a SINGLE
+agent (no crew, no tasks/process, no planning/reasoning) run **in-process** for
+low latency, and it writes its own terminal status so a fast answer is fetchable
+over REST. Its memory wiring, tool/agent tracing, and A2UI surface composition
+mirror the crew path but must stay independent — do not merge light and crew
+build logic. The full chain is:
+
+```
+ChatMode UI → dispatcher/chat routes → ExecutionService (execution_type="agent")
+            → CrewAIExecutionService → CrewAIEngineService.run_light_agent_execution
+            → LightAgentService.run_light_agent_execution (in-process)
+```
+
+## Directory map (current)
+
+```
+engines/crewai/
+├── crewai_engine_service.py   # hub: dispatch crew/flow/light + status/cancel
+├── config_adapter.py          # config-shape normalization
+├── paths/                     # one package per execution path
+│   ├── light_agent/           # the chat/light single-agent path (in-process)
+│   ├── crew/                  # crew_preparation, execution_runner, agent/task adapters
+│   └── flow/                  # flow_runner_service, backend_flow, modules/
+├── kernel/                    # path-AGNOSTIC single-source build logic (was common/)
+│                              #   agent_builder, agent_tools, task_builder,
+│                              #   agent_security, model_conversion_handler, a2ui_runner...
+├── memory/                    # unified memory backends + crew_memory_service
+├── infra/                     # logging_config, trace_management, mlflow_integration, crew_logger
+├── guardrails/                # root=framework; core/=reusable; demo/=data_processing family
+├── config/                    # crew/embedder/manager config builders
+├── callbacks/                 # live callbacks only (streaming, execution, volume)
+├── security/                  # scanner pipeline, injection/secret detectors, capability manifest
+├── tools/                     # tool_factory + custom/ (see tools/CLAUDE.md)
+└── exporters/                 # Databricks App / notebook / python-project export + templates
+```
+
+## Rules
+
+- **Put path-specific code under `paths/<path>/`; put shared build logic in
+  `kernel/`.** If crew and flow need the same behavior, it belongs in `kernel/`
+  (single source of truth), not copied into both. `paths/crew/agent_adapter.py`
+  and `paths/flow/agent_adapter.py` share a basename on purpose — the directory
+  names the path, and both delegate to `kernel/`.
+- **Do not merge the light and crew paths.** They intentionally have separate
+  memory wiring and surface composition; the ~8 lines of glue that differ are not
+  duplication to eliminate.
+- **Subprocess boundary is the highest-risk area.** Crew and flow build inside a
+  spawned interpreter (`services/process_crew_executor.py`). After moving/renaming
+  any module the crew or flow path imports, verify with a **real subprocess run**,
+  not just in-process unit tests — module-path changes that pass in-process can
+  still break the spawned interpreter's import resolution.
+- **Lakebase in subprocesses**: the spawned interpreter must re-activate Lakebase
+  itself (`db.database_router.activate_lakebase_in_subprocess`); it is not
+  inherited from the parent's hot-swap.
+- **Guardrails**: build via `GuardrailFactory.create_guardrail`. Add reusable ones
+  under `guardrails/core/`, demo/one-off ones under `guardrails/demo/`. Keep the
+  `guardrails/__init__.py` barrel and `guardrail_factory` type registry in sync.
+- **Memory**: use the unified `memory_backend_factory` + `CrewMemoryService`. See
+  `src/backend/CLAUDE.md` for the crew-ID determinism and Vector Search schema
+  rules (do not hardcode index columns; never call `.value` on enum-valued
+  Pydantic fields).
+- **Naming caveats to know**: `infra/trace_management.py` is the execution-LOGS
+  writer (trace persistence moved to OTel/MLflow); `infra/crew_logger.py`
+  (`CrewLogger`) is **live** despite an old audit note — it is used by the engine
+  hub and several services.
+- All engine work is async; Databricks calls need User-Agent telemetry
+  (`src/backend/CLAUDE.md`).
+
+## Related
+- `tools/CLAUDE.md` — custom tools and the tool factory
+- `src/docs/crewai-engine-refactor-proposal.md` — the full refactor record (§7 = final state)

--- a/src/backend/src/services/CLAUDE.md
+++ b/src/backend/src/services/CLAUDE.md
@@ -1,0 +1,64 @@
+# Services Layer CLAUDE.md
+
+Instructions for the business-logic layer in `src/backend/src/services/`.
+
+## Role of this layer
+
+Services own **business logic and orchestration**. They validate rules,
+coordinate one or more repositories, enforce group isolation, and
+encrypt/decrypt sensitive data. They are called by routers and by the engine,
+never the reverse.
+
+## Conventions (match `agent_service.py`)
+
+- File named `<resource>_service.py`. Extend `BaseService[Model, CreateSchema]`
+  from `src.core.base_service` when doing standard CRUD.
+- Constructor takes `session` first and builds its repository from it:
+  ```python
+  def __init__(self, session: AsyncSession,
+               repository_class: Type[AgentRepository] = AgentRepository,
+               model_class: Type[Agent] = Agent):
+      super().__init__(session)
+      self.repository_class = repository_class
+      self.model_class = model_class
+      self.repository = repository_class(session)
+  ```
+  Injecting `repository_class`/`model_class` with defaults keeps the service unit
+  testable (pass a fake repository).
+- Accept the request-scoped `session` from the router. **Do not** open your own
+  engine/session for request work.
+
+## Two ways to get repositories (pick deliberately)
+
+1. **Request-scoped session** (the default): the router passes the DI session and
+   the service instantiates repositories on it. The router's `get_db`/smart
+   session commits at the end of the request.
+2. **`UnitOfWork`** (`src.core.unit_of_work`): use only for multi-repository
+   atomic work outside a single request (background tasks, seeders, engine
+   subprocesses) where you need explicit transaction control across repositories.
+   Do not mix a UoW session with the request session.
+
+## Group isolation (required)
+
+- Accept `group_context: GroupContext` (from `src.utils.user_context`) on any
+  method that reads or writes tenant data, and pass its `group_id` down to
+  repository filters. A service method that ignores group scoping is a data-leak
+  bug.
+- Stamp `group_id` and `created_by_email` on create.
+
+## Security
+
+- Encrypt sensitive fields before persisting and decrypt after reading, using the
+  helpers in `src.utils.sensitive_data_utils` (see `_encrypt_tool_configs_in_data`
+  / `_decrypt_agent_tool_configs`). Decrypted values are in-memory only — never
+  write them back to the DB or into logs.
+- For Databricks calls made from a service, add User-Agent telemetry
+  (see `src/backend/CLAUDE.md`).
+
+## Async
+
+- All methods are `async`. Never block the event loop (no sync DB drivers, no
+  `requests`, no `time.sleep`).
+- Do not `commit()` inside service CRUD helpers that run within a request — the
+  session lifecycle owns the transaction. Commit explicitly only when you own the
+  session (UoW / background task).

--- a/src/frontend/CLAUDE.md
+++ b/src/frontend/CLAUDE.md
@@ -4,22 +4,23 @@ Frontend-specific instructions for Claude Code when working in the frontend dire
 
 ## Commands
 
-### Development
+### Development (Vite-based)
 - **Install dependencies**: `npm install`
-- **Start dev server**: `npm start` (runs on http://localhost:3000)
-- **Build for production**: `npm run build`
-- **Run tests**: `npm test`
-- **Lint code**: `npm run lint`
+- **Start dev server**: `npm start` (alias for `vite`, runs on http://localhost:3000)
+- **Build for production**: `npm run build` (`tsc -b && vite build`, outputs to `dist/`)
+- **Run tests**: `npm test` (Vitest) or `npm run test:run` (single run)
+- **Lint code**: `npm run lint` (ESLint)
 - **Type check**: `npm run tsc`
 
 ## Architecture
 
 ### Technology Stack
-- React 18 with TypeScript
+- React 18 with TypeScript, bundled with **Vite** (not Create React App)
 - Material-UI (MUI) for components
 - ReactFlow for workflow visualization
-- Zustand for state management (migrated from Redux)
-- Axios for HTTP requests
+- **Zustand** for state management (primary; some legacy Redux Toolkit still present)
+- Axios for HTTP requests, wrapped by `apiClient`
+- **Vitest** + React Testing Library for tests (no Cypress in this repo)
 
 ### Directory Structure
 ```
@@ -57,21 +58,24 @@ src/
 
 ## Documentation Management
 
-When adding new documentation:
-1. Copy `.md` files from `../../docs/` to `public/docs/`
-2. Update `docSections` array in `src/components/Documentation/Documentation.tsx`
+User-facing docs live in `src/docs/` (project-wide rule). The copy to
+`public/docs/` is **automated by `src/build.py`** at build time (it recursively
+copies `.md` + image assets), so you do not copy files by hand. When adding a doc
+that should appear in the in-app Documentation viewer, update the `docSections`
+array in `src/components/Documentation/Documentation.tsx`.
 
-## Testing Strategy
+## Testing Strategy (Vitest)
 
 ### Test Types
 - **Component Tests**: React Testing Library
 - **Hook Tests**: Custom hooks testing
-- **E2E Tests**: Cypress for user workflows
+- Test files are colocated as `*.test.ts(x)` next to the code they cover
 
 ### Testing Commands
-- Run all tests: `npm test`
-- Run with coverage: `npm test -- --coverage`
-- Run specific test: `npm test -- --testNamePattern="TestName"`
+- Run all tests (watch): `npm test`
+- Run once (CI): `npm run test:run`
+- Run with coverage: `npm run test:run -- --coverage`
+- Run a single file: `npm run test:run -- src/path/File.test.tsx`
 
 ## Workflow Editor
 
@@ -84,9 +88,9 @@ When adding new documentation:
 ## Build Process
 
 ### Production Build
-- Run `npm run build` to create optimized production build
-- Output goes to `build/` directory
-- Static assets are copied to `../../frontend_static/` for deployment
+- Run `npm run build` (`tsc -b && vite build`) to create an optimized build
+- Output goes to the **`dist/`** directory (Vite default)
+- `src/build.py` copies `dist/` to `../../frontend_static/` for deployment
 
 ## Critical Rules
 
@@ -98,7 +102,7 @@ When adding new documentation:
 
 ## Environment
 
-- Node.js 16+ required
-- React 18 with TypeScript
+- Node.js 18+ recommended
+- React 18 with TypeScript, Vite dev server (HMR)
 - Development server auto-refreshes on file changes
-- Environment variables in `.env` file (not committed)
+- Environment variables use Vite's `VITE_` prefix (e.g. `VITE_API_URL`); `.env` is not committed


### PR DESCRIPTION
## Summary

Corrects outdated information in the existing `CLAUDE.md` files and adds per-layer instructions, including documentation of the three CrewAI execution paths (the light-agent / ChatMode path was previously undocumented).

## Fixes to existing CLAUDE.md files
- **Root, backend, frontend**: `Poetry` → `uv`, Python `3.9+` → `3.11` (`>=3.11,<3.12`), CRA → **Vite** (`build/` → `dist/`), `Cypress` → **Vitest**, manual docs copy → automated by `src/build.py`, and the correct venv path (`src/backend/.venv`).

## New per-layer CLAUDE.md files
- `src/backend/src/api/CLAUDE.md` — router → service DI, group context, permissions, domain exceptions.
- `src/backend/src/services/CLAUDE.md` — `BaseService`, session vs `UnitOfWork`, group isolation, sensitive-field encryption.
- `src/backend/src/engines/crewai/CLAUDE.md` — the **post-refactor** `paths/kernel/infra` layout and the **three execution paths**:
  - `"agent"` → **light** = ChatMode chat (in-process, `Agent.kickoff_async`)
  - `"crew"` → subprocess
  - `"flow"` → subprocess

## Verification
All facts re-checked against the current `refactor/crewai-engine-structure` tree: `[tool.uv]` + `requires-python` pin, Vite scripts, and the `paths/kernel/infra` engine dirs all confirmed present. Docs-only change (no code).