### PR TITLE
fix(llm-manager): floor max_tokens at 16 — Responses-API models reject smaller values

### DIFF
--- a/src/backend/src/core/llm_manager.py
+++ b/src/backend/src/core/llm_manager.py
@@ -755,7 +755,12 @@ class LLMManager:
         group_id = LLMManager._get_group_id_from_context(required=True)
         llm = await LLMManager.configure_crewai_llm(model, group_id, temperature)
         if max_tokens is not None:
-            llm.max_tokens = max_tokens
+            # Responses-API models (the GPT-5/Codex family, whether served by
+            # OpenAI or Databricks) reject max_output_tokens below 16 with
+            # "invalid max_output_tokens: integer below minimum value". Tiny
+            # caps only ever mean "ping / one-word reply", so floor the value
+            # centrally instead of teaching every caller the provider quirk.
+            llm.max_tokens = max(16, max_tokens)
         elif not getattr(llm, "max_tokens", None) and not getattr(llm, "max_completion_tokens", None):
             llm.max_tokens = 4000
         if extra_headers:

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -588,7 +588,10 @@ def _preflight_reflection(
             loop,
             messages=[{"role": "user", "content": "ping — reply with OK"}],
             model=model,
-            max_tokens=5,
+            # >= 16: Responses-API models (GPT-5/Codex family) reject smaller
+            # max_output_tokens outright; LLMManager floors this too, but the
+            # preflight should not depend on the safety net.
+            max_tokens=32,
             group_context=group_context,
             user_token=user_token,
         )

--- a/src/backend/tests/unit/core/test_llm_manager_comprehensive.py
+++ b/src/backend/tests/unit/core/test_llm_manager_comprehensive.py
@@ -184,6 +184,26 @@ class TestCompletion:
         assert mock_llm.max_tokens == 8000
 
     @pytest.mark.asyncio
+    async def test_completion_floors_tiny_max_tokens(self):
+        # Responses-API models (GPT-5/Codex family) reject max_output_tokens
+        # below 16 ("integer below minimum value") — the manager floors it so
+        # callers never need to know the provider quirk.
+        mock_llm = MagicMock()
+
+        with (
+            patch.object(LLMManager, "_get_group_id_from_context", return_value="group-1"),
+            patch.object(LLMManager, "configure_crewai_llm", new_callable=AsyncMock, return_value=mock_llm),
+            patch("src.core.llm_manager._run_llm_blocking", new_callable=AsyncMock, return_value="ok"),
+        ):
+            await LLMManager.completion(
+                messages=[{"role": "user", "content": "ping"}],
+                model="databricks-gpt-5-3-codex",
+                max_tokens=5,
+            )
+
+        assert mock_llm.max_tokens == 16
+
+    @pytest.mark.asyncio
     async def test_completion_emits_llm_span_when_trace_active(self):
         """When a trace is active, completion wraps the call in an LLM span and
         records model/messages as inputs and the response as outputs."""


### PR DESCRIPTION
## Summary

Targets the `prompt-optimization` branch (on top of the merged #68). Running crew optimization with `databricks-gpt-5-3-codex` failed instantly with `invalid max_output_tokens: integer below minimum value`.

**Root cause**: the GPT-5/Codex family (OpenAI- or Databricks-served) is backed by the Responses API, which enforces `max_output_tokens >= 16`. The optimization preflight pinged the reflection model with `max_tokens=5` — the only sub-16 call in the codebase. And because the reflection model defaults to the crew's model, picking Codex as the crew model made this 5-token ping the very first call of the run.

**Why only optimization ever failed**: crew agents get their LLM from `configure_crewai_llm` with the model config's cap (128000 for codex) and never set small explicit values — the failure mode structurally cannot occur in crew execution.

**Fix, per this branch's routing principle**: the provider quirk is owned by `LLMManager` — `completion()` floors explicit `max_tokens` at 16 for every caller, and the preflight asks for 32 so it doesn't lean on the safety net. Crew execution paths are untouched.

## Test plan
- [x] New `test_completion_floors_tiny_max_tokens` in the llm_manager suite
- [x] llm_manager + optimization suites pass (173 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)