### PR TITLE
perf(powerbi): M-Query performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ examples/uc_metric_view_migration/output/
 # MLflow
 mlruns/
 .mlruns/
+mlartifacts/
 
 # graphify knowledge graph output
 graphify-out/

--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,0 +1,3 @@
+{
+  "sync_reminder_last_shown": "2026-08-17"
+}

--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,3 +1,3 @@
 {
-  "sync_reminder_last_shown": "2026-08-17"
+  "sync_reminder_last_shown": "2026-08-26"
 }

--- a/scripts/ucmv_reevaluate.py
+++ b/scripts/ucmv_reevaluate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+"""Run the UCMV Re-evaluation sweep from the CLI (no crew needed).
+
+Finds previously-untranslatable DAX measures that TODAY's transpiler can recover,
+by replaying stored conversion history. Read-only: it proposes candidates and never
+modifies metric views.
+
+Usage (from src/backend/, so the venv + src package resolve):
+
+    # what capability level are we at?
+    .venv/bin/python ../../scripts/ucmv_reevaluate.py --capability
+
+    # sweep every dataset stored for a group
+    .venv/bin/python ../../scripts/ucmv_reevaluate.py --group-id bi-specialist
+
+    # specific datasets, and force a retry even if the fingerprint is unchanged
+    .venv/bin/python ../../scripts/ucmv_reevaluate.py --group-id g --datasets ds1,ds2 --force
+
+    # also allow the LLM path (COSTS TOKENS)
+    .venv/bin/python ../../scripts/ucmv_reevaluate.py --group-id g --use-llm
+
+Docs: src/docs/powerbi/ucmv-reevaluation-recoverable-measures.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+# Make the backend's `src` package importable no matter which directory this is
+# invoked from (repo root, scripts/, or src/backend/).
+_BACKEND = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        "src", "backend")
+if os.path.isdir(os.path.join(_BACKEND, "src")) and _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="UCMV re-evaluation sweep (read-only).")
+    p.add_argument("--group-id", default=None, help="Group/tenant to scope stored runs.")
+    p.add_argument("--datasets", default=None,
+                   help="Comma-separated PBI dataset ids (default: all for the group).")
+    p.add_argument("--force", action="store_true",
+                   help="Retry even when the capability fingerprint is unchanged.")
+    p.add_argument("--use-llm", action="store_true",
+                   help="Allow the LLM-first path (COSTS TOKENS per measure).")
+    p.add_argument("--include-impossible", action="store_true",
+                   help="Also retry permanent-limitation categories (usually wasted).")
+    p.add_argument("--max-measures", type=int, default=200,
+                   help="Cap retried measures per dataset (default 200).")
+    p.add_argument("--max-datasets", type=int, default=50,
+                   help="Cap datasets scanned (default 50).")
+    p.add_argument("--capability", action="store_true",
+                   help="Just print the current capability fingerprint and exit.")
+    p.add_argument("--json", action="store_true", help="Print the raw JSON report.")
+    args = p.parse_args()
+
+    from src.engines.crewai.tools.custom.metric_view_utils.capability_version import (
+        capability_summary,
+    )
+
+    if args.capability:
+        summary = capability_summary()
+        print(f"capability fingerprint : {summary['fingerprint']}")
+        print(f"translator patterns    : {summary['pattern_count']}")
+        print(f"skill corpus files     : {summary['skill_file_count']}")
+        for f in summary["skill_files"]:
+            print(f"    - {f}")
+        return 0
+
+    if not args.group_id and not args.datasets:
+        p.error("give --group-id and/or --datasets (nothing to scan otherwise)")
+
+    from src.engines.crewai.tools.custom.ucmv_reevaluation_tool import UCMVReevaluationTool
+
+    tool = UCMVReevaluationTool()
+    raw = tool._run(
+        group_id=args.group_id,
+        dataset_ids=args.datasets,
+        force=args.force,
+        use_llm=args.use_llm,
+        include_impossible=args.include_impossible,
+        max_measures_per_dataset=args.max_measures,
+        max_datasets=args.max_datasets,
+    )
+
+    if args.json:
+        print(raw)
+        return 0
+
+    report = json.loads(raw)
+    if report.get("error"):
+        print(f"ERROR: {report['error']}", file=sys.stderr)
+        return 1
+
+    cap = report.get("capability", {})
+    summary = report.get("summary", {})
+    print(f"\ncapability {cap.get('fingerprint')} "
+          f"({cap.get('pattern_count')} patterns, {cap.get('skill_file_count')} skill files)")
+    print(f"settings   {report.get('settings')}")
+    print(f"\nscanned {summary.get('datasets_scanned', 0)} dataset(s) | "
+          f"retried {summary.get('measures_retried', 0)} measure(s) | "
+          f"RECOVERABLE {summary.get('measures_recovered', 0)}\n")
+
+    for ds in report.get("datasets", []):
+        items = ds.get("newly_translatable") or []
+        head = f"  {ds.get('dataset_id') or '(unknown)'}"
+        if items:
+            print(f"{head}  → {len(items)} recoverable")
+            for m in items:
+                print(f"      {m['original_name']}  (used by {m.get('referenced_by', 0)})")
+                print(f"        was : {m.get('previous_category')} — {m.get('previous_skip_reason')}")
+                print(f"        now : {m['new_sql']}")
+        else:
+            note = ds.get("note") or "no gains"
+            print(f"{head}  → {note}")
+
+    if not summary.get("measures_recovered"):
+        print("\nNothing recoverable. If you expected gains, try --force (the stored run "
+              "may already be at the current capability level).")
+    else:
+        print("\nNothing was changed. Re-run the UCMV generator for the affected "
+              "dataset(s) to apply these.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/migrations/versions/20260812_powerbi_extraction_expressions.py
+++ b/src/backend/migrations/versions/20260812_powerbi_extraction_expressions.py
@@ -1,0 +1,39 @@
+"""add expressions column to powerbi_extraction
+
+Revision ID: 20260812_pbi_expressions
+Revises: 20260720_powerbi_extraction
+Create Date: 2026-08-12
+
+Persists the model's named/shared expressions (staging queries + parameters,
+parsed alongside admin_tables by parse_admin_expressions/parse_tmdl_expressions)
+so the UC Metric View Generator's DB fallback can rebuild mquery_json at full
+quality (resolve_mquery_with_context needs both admin_tables AND expressions).
+Existing deployed DBs are healed at startup by
+_ensure_powerbi_extraction_expressions_column (src/db/session.py) with the same
+column; this migration keeps the Alembic chain in sync. Idempotent on both
+paths (SQLite PRAGMA check / Postgres IF NOT EXISTS here; PRAGMA check /
+ADD COLUMN IF NOT EXISTS there).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260812_pbi_expressions"
+down_revision = "20260720_powerbi_extraction"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "powerbi_extraction" not in inspector.get_table_names():
+        return  # table doesn't exist yet on this DB — nothing to alter
+    existing_cols = {c["name"] for c in inspector.get_columns("powerbi_extraction")}
+    if "expressions" in existing_cols:
+        return  # startup self-heal already added it
+    op.add_column("powerbi_extraction", sa.Column("expressions", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("powerbi_extraction", "expressions")

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "mcp>=1.26.0,<1.27.0", # Required by crewai 1.14.5
     "mcpadapt",
     # Observability
-    "mlflow>=3.11,<4",  # >=3.11 required for Unity Catalog trace storage (OTel tables)
+    "mlflow>=3.11,<4", # >=3.11 required for Unity Catalog trace storage (OTel tables)
     "opentelemetry-sdk>=1.27.0,<2.0.0",
     "opentelemetry-api>=1.27.0,<2.0.0",
     "opentelemetry-exporter-otlp-proto-http>=1.27.0,<2.0.0",
@@ -78,6 +78,7 @@ dependencies = [
     "python-pptx",
     "wheel",
     "ollama>=0.6.2",
+    "gepa>=0.1.4",
 ]
 
 [dependency-groups]

--- a/src/backend/src/api/__init__.py
+++ b/src/backend/src/api/__init__.py
@@ -43,6 +43,7 @@ from src.api.mlflow_router import router as mlflow_router
 from src.api.models_router import router as models_router
 from src.api.powerbi_router import router as powerbi_router
 from src.api.prompt_improvement_router import router as prompt_improvement_router
+from src.api.prompt_optimization_router import router as prompt_optimization_router
 from src.api.scheduler_router import router as scheduler_router
 from src.api.schemas_router import router as schemas_router
 from src.api.sse_router import router as sse_router
@@ -92,6 +93,7 @@ api_router.include_router(crew_generation_router)
 api_router.include_router(task_generation_router)
 api_router.include_router(template_generation_router)
 api_router.include_router(prompt_improvement_router)
+api_router.include_router(prompt_optimization_router)
 api_router.include_router(executions_router)
 api_router.include_router(execution_history_router)
 api_router.include_router(execution_trace_router)
@@ -140,6 +142,7 @@ __all__ = [
     "crew_generation_router",
     "task_generation_router",
     "prompt_improvement_router",
+    "prompt_optimization_router",
     "template_generation_router",
     "executions_router",
     "execution_history_router",

--- a/src/backend/src/api/prompt_optimization_router.py
+++ b/src/backend/src/api/prompt_optimization_router.py
@@ -1,0 +1,228 @@
+"""
+API router for prompt optimization operations.
+
+Endpoints for running GEPA-based optimization of seeded prompt
+templates: start a background run, poll its status, and apply a
+completed proposal as a group-scoped template override.
+"""
+
+import logging
+
+from fastapi import APIRouter
+
+from src.core.dependencies import GroupContextDep, SessionDep
+from src.core.exceptions import BadRequestError, NotFoundError
+from src.schemas.prompt_optimization import (
+    CrewOptimizationRequest,
+    PromptOptimizationApplyResponse,
+    PromptOptimizationRequest,
+    PromptOptimizationRunList,
+    PromptOptimizationRunStatus,
+    PromptOptimizationStartResponse,
+)
+from src.services.prompt_optimization_service import PromptOptimizationService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/prompt-optimization",
+    tags=["prompt optimization"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+def _publish_user_context(group_context) -> None:
+    # CRITICAL: publish the request's group + user token to UserContext so
+    # LLMManager resolves auth the same way the dispatcher does (OBO for
+    # OpenAI-protocol models). The background task inherits this context via
+    # asyncio.create_task. Mirrors task_generation_router's suggest_guardrail.
+    from src.utils.user_context import UserContext
+
+    if group_context:
+        UserContext.set_group_context(group_context)
+        if group_context.access_token:
+            UserContext.set_user_token(group_context.access_token)
+
+
+@router.post("/optimize", response_model=PromptOptimizationStartResponse)
+async def start_optimization(
+    request: PromptOptimizationRequest,
+    group_context: GroupContextDep,
+    session: SessionDep,
+):
+    """
+    Start a prompt optimization run in the background.
+
+    Training examples come from the request (`examples`) or are mined from the
+    template's logged LLM interactions. Returns a run_id to poll. The proposed
+    template is NOT applied automatically — review it via the status endpoint
+    and apply explicitly.
+    """
+    _publish_user_context(group_context)
+    service = PromptOptimizationService(session)
+    try:
+        result = await service.start_optimization(request, group_context)
+    except ValueError as e:
+        raise BadRequestError(str(e))
+    return PromptOptimizationStartResponse(**result)
+
+
+@router.post("/optimize-crew", response_model=PromptOptimizationStartResponse)
+async def start_crew_optimization(
+    request: CrewOptimizationRequest,
+    group_context: GroupContextDep,
+    session: SessionDep,
+):
+    """
+    Start GEPA optimization of a saved crew's prompt fields in the background.
+
+    EXPENSIVE: every evaluation executes the crew for real (tools included) and
+    judges the final deliverable — max_metric_calls bounds the number of crew
+    executions. The proposal is NOT applied automatically.
+    """
+    _publish_user_context(group_context)
+    service = PromptOptimizationService(session)
+    try:
+        result = await service.start_crew_optimization(request, group_context)
+    except ValueError as e:
+        raise BadRequestError(str(e))
+    return PromptOptimizationStartResponse(**result)
+
+
+@router.get("/crew-evals/{crew_id}")
+async def list_crew_evals(
+    crew_id: str, group_context: GroupContextDep, session: SessionDep
+):
+    """List a crew's optimization-evaluation answers (local MLflow traces) so
+    they can be graded in-app. Empty when local MLflow mode is not enabled."""
+    service = PromptOptimizationService(session)
+    return {"evals": await service.list_crew_evals(crew_id)}
+
+
+@router.post("/crew-evals/{trace_id}/feedback")
+async def add_eval_feedback(
+    trace_id: str, body: dict, group_context: GroupContextDep, session: SessionDep
+):
+    """Attach a human grade (0-10, Feedback) and/or an expectation (ground
+    truth of what the answer SHOULD contain) to an evaluation answer.
+
+    Stored as MLflow assessments on the trace; the next optimization run folds
+    both into the judge's rubric.
+    """
+    service = PromptOptimizationService(session)
+    value = body.get("value")
+    if value is not None:
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            raise BadRequestError("Feedback 'value' must be a number 0-10")
+    try:
+        ok = await service.add_eval_feedback(
+            trace_id, value, body.get("comment"), body.get("expectation")
+        )
+    except ValueError as e:
+        raise BadRequestError(str(e))
+    return {"ok": ok}
+
+
+@router.get("/judges")
+async def list_judges(group_context: GroupContextDep, session: SessionDep):
+    """List registered LLM judges (local MLflow scorer registry)."""
+    service = PromptOptimizationService(session)
+    return {"judges": await service.list_judges()}
+
+
+@router.post("/judges")
+async def create_judge(body: dict, group_context: GroupContextDep, session: SessionDep):
+    """Create + register an LLM judge from Kasal: {name, instructions, model?}.
+
+    Registered judges automatically participate in crew-optimization scoring.
+    """
+    _publish_user_context(group_context)
+    service = PromptOptimizationService(session)
+    try:
+        result = await service.create_judge(
+            name=str(body.get("name") or ""),
+            instructions=str(body.get("instructions") or ""),
+            model=body.get("model"),
+            crew_id=body.get("crew_id"),
+            group_context=group_context,
+        )
+    except ValueError as e:
+        raise BadRequestError(str(e))
+    return result
+
+
+@router.post("/judges/{name}/assign")
+async def assign_judge(
+    name: str, body: dict, group_context: GroupContextDep, session: SessionDep
+):
+    """Assign a shared library judge to a crew: {crew_id}. The crew's runs use
+    only its assigned judges."""
+    service = PromptOptimizationService(session)
+    crew_id = str(body.get("crew_id") or "")
+    if not crew_id:
+        raise BadRequestError("crew_id is required")
+    try:
+        return await service.assign_judge(name, crew_id, group_context)
+    except ValueError as e:
+        raise BadRequestError(str(e))
+
+
+@router.delete("/judges/{name}")
+async def delete_judge(name: str, group_context: GroupContextDep, session: SessionDep):
+    """Delete a registered LLM judge by name."""
+    service = PromptOptimizationService(session)
+    try:
+        ok = await service.delete_judge(name)
+    except ValueError as e:
+        raise BadRequestError(str(e))
+    return {"ok": ok}
+
+
+@router.get("/runs", response_model=PromptOptimizationRunList)
+async def list_runs(group_context: GroupContextDep, session: SessionDep):
+    """List recent optimization runs for the caller's group."""
+    service = PromptOptimizationService(session)
+    return PromptOptimizationRunList(
+        runs=[
+            PromptOptimizationRunStatus(**r) for r in service.list_runs(group_context)
+        ]
+    )
+
+
+@router.get("/runs/{run_id}", response_model=PromptOptimizationRunStatus)
+async def get_run(run_id: str, group_context: GroupContextDep, session: SessionDep):
+    """Get the status/result of an optimization run, including the proposed template."""
+    service = PromptOptimizationService(session)
+    run = service.get_run(run_id, group_context)
+    if run is None:
+        raise NotFoundError(f"Optimization run '{run_id}' not found")
+    return PromptOptimizationRunStatus(**run)
+
+
+@router.post("/runs/{run_id}/cancel")
+async def cancel_run(run_id: str, group_context: GroupContextDep, session: SessionDep):
+    """Request a running optimization to stop (honored before the next crew
+    execution; an in-flight execution finishes first)."""
+    service = PromptOptimizationService(session)
+    try:
+        return service.cancel_run(run_id, group_context)
+    except ValueError as e:
+        raise NotFoundError(str(e))
+
+
+@router.post("/runs/{run_id}/apply", response_model=PromptOptimizationApplyResponse)
+async def apply_run(run_id: str, group_context: GroupContextDep, session: SessionDep):
+    """
+    Apply a completed run's proposed template as a group-scoped override.
+
+    The base template row is never mutated (the seeder overwrites base rows on
+    startup); reverting is a template reset in Prompt Configuration.
+    """
+    service = PromptOptimizationService(session)
+    try:
+        result = await service.apply_run(run_id, group_context)
+    except ValueError as e:
+        raise NotFoundError(str(e))
+    return PromptOptimizationApplyResponse(**result)

--- a/src/backend/src/api/prompt_optimization_router.py
+++ b/src/backend/src/api/prompt_optimization_router.py
@@ -169,6 +169,28 @@ async def assign_judge(
         raise BadRequestError(str(e))
 
 
+@router.put("/judges/{name}")
+async def update_judge(
+    name: str, body: dict, group_context: GroupContextDep, session: SessionDep
+):
+    """Update a judge's instructions and/or model: {instructions?, model?}.
+
+    `name` is the full registry name; editing a crew-scoped copy changes what
+    that crew's runs use, editing a library judge leaves assigned copies as-is.
+    """
+    _publish_user_context(group_context)
+    service = PromptOptimizationService(session)
+    try:
+        return await service.update_judge(
+            name=name,
+            instructions=body.get("instructions"),
+            model=body.get("model"),
+            group_context=group_context,
+        )
+    except ValueError as e:
+        raise BadRequestError(str(e))
+
+
 @router.delete("/judges/{name}")
 async def delete_judge(name: str, group_context: GroupContextDep, session: SessionDep):
     """Delete a registered LLM judge by name."""

--- a/src/backend/src/core/llm_manager.py
+++ b/src/backend/src/core/llm_manager.py
@@ -868,7 +868,7 @@ class LLMManager:
             "messages": messages,
             "temperature": temperature,
         }
-        for attr in ("api_key", "api_base"):
+        for attr in ("api_key", "api_base", "timeout"):
             val = getattr(llm, attr, None)
             if val:
                 call_kwargs[attr] = val

--- a/src/backend/src/db/session.py
+++ b/src/backend/src/db/session.py
@@ -685,7 +685,7 @@ async def _ensure_documentation_embeddings_columns(conn) -> None:
     built-in doc seeding, and group-scoped search (all reference the columns).
     Safe to run on every startup; the embedding column is unchanged here.
     """
-    is_sqlite = str(settings.DATABASE_URI).startswith("sqlite")
+    is_sqlite = conn.dialect.name == "sqlite"
     try:
         if is_sqlite:
             res = await conn.exec_driver_sql(
@@ -778,7 +778,7 @@ async def _ensure_chat_sessions_columns(conn) -> None:
     saving/reading previews and the running-job marker. Safe to run every
     startup; all columns are nullable with no default.
     """
-    is_sqlite = str(settings.DATABASE_URI).startswith("sqlite")
+    is_sqlite = conn.dialect.name == "sqlite"
     columns = [
         ("running_job_id", "VARCHAR"),
         ("preview_type", "VARCHAR(50)"),
@@ -812,7 +812,7 @@ async def _ensure_crew_columns(conn) -> None:
     existing table, so DBs created before this column existed (e.g. deployed
     customer instances) would silently drop the saved reasoning PlanningConfig
     on save/reload. Safe to run every startup; column is nullable JSON/TEXT."""
-    is_sqlite = str(settings.DATABASE_URI).startswith("sqlite")
+    is_sqlite = conn.dialect.name == "sqlite"
     try:
         if is_sqlite:
             res = await conn.exec_driver_sql("PRAGMA table_info(crews)")
@@ -843,7 +843,7 @@ async def _disable_bi_specialist_crew_memory(conn) -> None:
     is insert-only (it skips a group that already exists), so DBs seeded before
     this change keep memory on. This self-heals them. Safe to run every startup —
     it only flips rows that are still True, scoped to the bi-specialist group."""
-    is_sqlite = str(settings.DATABASE_URI).startswith("sqlite")
+    is_sqlite = conn.dialect.name == "sqlite"
     # SQLite stores booleans as 0/1; Postgres uses true/false. exec_driver_sql
     # with a literal keeps this dialect-agnostic enough for both.
     true_val = "1" if is_sqlite else "true"
@@ -869,7 +869,7 @@ async def _ensure_ui_config_columns(conn) -> None:
     created via create_all, but create_all never ALTERs an existing table — so DBs
     created before catalog_json/style_json existed would silently drop a workspace's
     A2UI catalog + branding on save/reload. Safe to run every startup (nullable TEXT)."""
-    is_sqlite = str(settings.DATABASE_URI).startswith("sqlite")
+    is_sqlite = conn.dialect.name == "sqlite"
     columns = ("catalog_json", "style_json")
     try:
         if is_sqlite:
@@ -973,6 +973,53 @@ async def _ensure_powerbi_extraction_table(conn) -> None:
         logger.warning(f"Could not ensure powerbi_extraction table: {e}")
 
 
+async def _ensure_powerbi_extraction_expressions_column(conn) -> None:
+    """Idempotently add `expressions` to powerbi_extraction.
+
+    Added after the table itself was already deployed on some environments —
+    create_all/checkfirst (`_ensure_powerbi_extraction_table`) only creates the
+    table when entirely absent, it never ALTERs an existing one. Without this,
+    the UC Metric View Generator's DB fallback (which SELECTs this column to
+    rebuild mquery_json/measures_json from Crew 1's already-computed result)
+    fails outright with `UndefinedColumnError` on any DB that had the table
+    before this column was added — exactly the gap that broke that fallback in
+    production. Safe to run on every startup.
+
+    Branches on the DIALECT OF THE CONNECTION PASSED IN (``conn.dialect.name``),
+    NOT ``settings.DATABASE_URI``. The Lakebase connect/migrate/expand flows
+    call this against a freshly-opened Postgres engine for the TARGET Lakebase
+    instance while the app's own primary DB is still SQLite (Lakebase hasn't
+    been swapped in as primary yet) — branching on the global setting there
+    took the SQLite `PRAGMA table_info` path against an actual Postgres
+    connection, which raises immediately and was silently swallowed by this
+    function's own except-block, so the column was never actually added
+    despite every caller reporting success.
+    """
+    is_sqlite = conn.dialect.name == "sqlite"
+    try:
+        if is_sqlite:
+            res = await conn.exec_driver_sql("PRAGMA table_info(powerbi_extraction)")
+            cols = {row[1] for row in res.fetchall()}
+            if not cols:
+                return  # table not created yet
+            if "expressions" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE powerbi_extraction ADD COLUMN expressions TEXT"
+                )
+                logger.info(
+                    "Added powerbi_extraction.expressions column (SQLite self-heal)"
+                )
+        else:
+            await conn.exec_driver_sql(
+                "ALTER TABLE powerbi_extraction ADD COLUMN IF NOT EXISTS expressions JSON"
+            )
+            logger.info("Ensured powerbi_extraction.expressions column")
+    except Exception as e:
+        logger.warning(
+            f"Could not ensure powerbi_extraction.expressions column: {e}"
+        )
+
+
 async def _ensure_databricks_config_columns(conn) -> None:
     """Idempotently add ai_gateway_enabled to databricksconfig.
 
@@ -981,8 +1028,15 @@ async def _ensure_databricks_config_columns(conn) -> None:
     we cannot migrate manually) are missing it — which breaks reading/writing
     the Databricks configuration. Safe to run on every startup; defaults to
     false (serving-endpoints routing) to preserve existing behavior.
+
+    Branches on ``conn.dialect.name``, not ``settings.DATABASE_URI`` — see
+    ``_ensure_powerbi_extraction_expressions_column`` for why: the global
+    setting reflects the app's own primary DB, not necessarily the dialect of
+    whatever connection was actually passed in (e.g. a Lakebase
+    connect/migrate flow's freshly-opened Postgres engine, while the app's
+    primary DB is still SQLite).
     """
-    is_sqlite = str(settings.DATABASE_URI).startswith("sqlite")
+    is_sqlite = conn.dialect.name == "sqlite"
     try:
         if is_sqlite:
             res = await conn.exec_driver_sql("PRAGMA table_info(databricksconfig)")
@@ -1007,7 +1061,7 @@ async def _ensure_databricks_config_columns(conn) -> None:
         )
 
 
-async def run_schema_self_heal(conn) -> None:
+async def run_schema_self_heal(engine) -> None:
     """Create missing tables and add missing columns on an existing DB.
 
     ``create_all`` fully creates a NEW table but never ALTERs an existing one, so
@@ -1020,18 +1074,55 @@ async def run_schema_self_heal(conn) -> None:
     the active Lakebase engine after the runtime hot-swap (``main.py`` lifespan) —
     the latter is the only path that heals a customer's PRE-EXISTING Lakebase,
     which ``init_db`` alone misses because it fires before Lakebase activation.
+
+    Takes an ``AsyncEngine`` (not a ``Connection``) and opens a FRESH
+    connection + transaction per step, rather than sharing one connection
+    across all steps. Two savepoint-based approaches (a plain
+    ``async with conn.begin_nested():`` per step, then an explicit
+    ``commit()``/``rollback()`` pair) were tried and both failed in
+    production. On Postgres, ONE failed statement aborts the entire
+    enclosing transaction — every later statement on that same connection is
+    rejected with "current transaction is aborted" until a real rollback
+    happens, even if the step that failed caught its own exception internally
+    (that only stops Python-level propagation; it does nothing for the
+    connection's transaction state). Every ``_ensure_*`` helper below already
+    catches its own internal errors (to log a warning per sub-step instead of
+    aborting the whole healer), so a savepoint wrapped around the call never
+    sees an exception to react to — it only discovers the problem when it
+    tries to commit, and by then a plain ``ROLLBACK TO SAVEPOINT`` did not
+    reliably leave the connection usable for the NEXT step's own
+    ``SAVEPOINT`` statement either (observed: every step after the first
+    failing one kept failing, each at its own ``SAVEPOINT``/``RELEASE
+    SAVEPOINT`` line, even though each got its own supposedly-isolated
+    savepoint). A fresh connection per step sidesteps all of that — there is
+    no shared transaction state left for one step's failure to poison.
     """
-    await _ensure_documentation_embeddings_columns(conn)
-    await _ensure_databricks_config_columns(conn)
-    await _ensure_chat_sessions_table(conn)
-    await _ensure_chat_sessions_columns(conn)
-    await _ensure_crew_feedback_table(conn)
-    await _ensure_powerbi_extraction_table(conn)
-    await _ensure_crew_columns(conn)
-    await _ensure_ui_config_columns(conn)
-    await _ensure_hot_polling_indexes(conn)
-    await _heal_personal_group_names(conn)
-    await _disable_bi_specialist_crew_memory(conn)
+    is_sqlite = engine.dialect.name == "sqlite"
+    healers = (
+        _ensure_documentation_embeddings_columns,
+        _ensure_databricks_config_columns,
+        _ensure_chat_sessions_table,
+        _ensure_chat_sessions_columns,
+        _ensure_crew_feedback_table,
+        _ensure_powerbi_extraction_table,
+        _ensure_powerbi_extraction_expressions_column,
+        _ensure_crew_columns,
+        _ensure_ui_config_columns,
+        _ensure_hot_polling_indexes,
+        _heal_personal_group_names,
+        _disable_bi_specialist_crew_memory,
+    )
+    for healer in healers:
+        try:
+            async with engine.begin() as conn:
+                if not is_sqlite:
+                    # search_path is per-connection, so it must be set on
+                    # THIS fresh connection — it is not inherited from
+                    # whatever connection the caller set it on earlier.
+                    await conn.execute(text("SET search_path TO kasal, public"))
+                await healer(conn)
+        except Exception as e:
+            logger.warning(f"Schema self-heal step '{healer.__name__}' failed (isolated to its own connection): {e}")
 
 
 async def init_db() -> None:
@@ -1221,8 +1312,7 @@ async def init_db() -> None:
                 str(settings.DATABASE_URI), future=True, echo=SQL_DEBUG
             )
             try:
-                async with ensure_engine.begin() as conn:
-                    await run_schema_self_heal(conn)
+                await run_schema_self_heal(ensure_engine)
             finally:
                 await ensure_engine.dispose()
         except Exception as ensure_err:

--- a/src/backend/src/engines/crewai/config/embedder_config_builder.py
+++ b/src/backend/src/engines/crewai/config/embedder_config_builder.py
@@ -18,6 +18,45 @@ from src.utils.databricks_url_utils import DatabricksURLUtils
 logger = LoggerManager.get_instance().crew
 
 
+def _embed_with_fail_open(embed_once, docs, dimension, max_attempts=3, sleep_fn=None):
+    """Call ``embed_once(docs)`` with bounded retry, then FAIL OPEN.
+
+    Crew memory is an enhancement, not part of producing the deliverable, so a
+    transient embedding failure (SSL/EOF, connection reset, 429/5xx) must never
+    propagate and fail the whole flow. Transport errors are always retried;
+    other errors are retried only if marked ``retryable`` (429/5xx). When all
+    attempts are exhausted we return zero vectors (one per doc) so CrewAI's
+    memory store/query degrades gracefully instead of raising.
+
+    ``sleep_fn`` is injectable for tests. Returns a list of embedding vectors.
+    """
+    import time
+    import requests
+
+    sleep_fn = sleep_fn or time.sleep
+    last_err = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return embed_once(docs)
+        except (requests.exceptions.SSLError,
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout) as e:
+            last_err = e  # transport-level → always transient
+        except Exception as e:  # noqa: BLE001
+            last_err = e
+            if not getattr(e, "retryable", False):
+                break  # non-transient (auth, malformed response) → stop retrying
+        if attempt < max_attempts:
+            sleep_fn(min(2 ** attempt, 8))
+
+    logger.warning(
+        "[Embedder] fail-open after %d attempt(s): %s — returning %d zero vector(s) "
+        "(dim=%d) so crew memory degrades instead of failing the flow",
+        max_attempts, last_err, len(docs), dimension,
+    )
+    return [[0.0] * dimension for _ in docs]
+
+
 class EmbedderConfigBuilder:
     """Handles embedder configuration for different providers"""
 
@@ -156,80 +195,97 @@ class EmbedderConfigBuilder:
 
             # Create custom embedding function
             class DatabricksEmbeddingFunction(EmbeddingFunction):
+                # gte-large-en produces 1024-dim vectors; used for the fail-open
+                # fallback so a transient embedding hiccup can't fail the flow.
+                _FALLBACK_DIM = 1024
+                _MAX_ATTEMPTS = 3
+
                 def __init__(self, api_key: str = None, api_base: str = None, model: str = None,
-                             auth_headers: dict = None, user_token: str = None):
+                             auth_headers: dict = None, user_token: str = None,
+                             embedding_dimension: int = 1024):
                     self.api_key = api_key
                     self.api_base = api_base
                     self.model = model
                     self.auth_headers = auth_headers
                     self.user_token = user_token
+                    self.embedding_dimension = embedding_dimension or self._FALLBACK_DIM
+
+                def _embed_once(self, docs: list) -> Embeddings:
+                    """One embedding HTTP round-trip. Raises on any failure."""
+                    import requests
+
+                    workspace_url = DatabricksURLUtils.extract_workspace_from_endpoint(self.api_base)
+                    # AI Gateway on  -> /ai-gateway/mlflow/v1/embeddings (model in body)
+                    # AI Gateway off -> /serving-endpoints/<model>/invocations (model in path)
+                    endpoint_url, body_model = DatabricksURLUtils.construct_embeddings_url(workspace_url, self.model)
+
+                    if not endpoint_url:
+                        raise Exception("Failed to construct valid endpoint URL")
+
+                    logger.debug(f"Databricks embedding endpoint URL: {endpoint_url}")
+                    payload: dict = {"input": docs}
+                    if body_model:
+                        payload["model"] = body_model
+
+                    # Prepare headers - prioritize user token for OBO auth
+                    if self.user_token:
+                        headers = {
+                            "Authorization": f"Bearer {self.user_token}",
+                            "Content-Type": "application/json"
+                        }
+                        logger.debug("Using OBO token for embeddings")
+                    elif self.auth_headers:
+                        headers = self.auth_headers.copy()
+                    elif self.api_key:
+                        headers = {
+                            "Authorization": f"Bearer {self.api_key}",
+                            "Content-Type": "application/json"
+                        }
+                    else:
+                        logger.error("No authentication method available for Databricks embeddings")
+                        raise Exception("No authentication method available")
+
+                    # Add User-Agent header for Databricks API attribution
+                    from src.utils.telemetry import get_user_agent_header, KasalProduct, send_logfood_telemetry_sync
+                    headers.update(get_user_agent_header(KasalProduct.EMBEDDING))
+
+                    response = requests.post(endpoint_url, headers=headers, json=payload, timeout=30)
+                    if response.status_code == 200:
+                        result = response.json()
+                        if 'data' in result and len(result['data']) > 0:
+                            embeddings = [item.get('embedding', item) for item in result['data']]
+                            usage = result.get('usage', {})
+                            if usage:
+                                auth_token = self.user_token or self.api_key
+                                send_logfood_telemetry_sync(
+                                    usage=usage,
+                                    model=self.model,
+                                    product_context=KasalProduct.EMBEDDING,
+                                    workspace_url=workspace_url,
+                                    token=auth_token
+                                )
+                            return cast(Embeddings, embeddings)
+                        raise Exception(f"Unexpected response format: {result}")
+                    # Non-200: mark retryable transient statuses distinctly.
+                    err = Exception(f"Embedding API error {response.status_code}: {response.text[:300]}")
+                    err.retryable = response.status_code in (429, 500, 502, 503, 504)  # type: ignore[attr-defined]
+                    raise err
 
                 def __call__(self, input: Documents) -> Embeddings:
-                    try:
-                        import requests
+                    """Embed with bounded retry + fail-open (see _embed_with_fail_open).
 
-                        workspace_url = DatabricksURLUtils.extract_workspace_from_endpoint(self.api_base)
-                        # AI Gateway on  -> /ai-gateway/mlflow/v1/embeddings (model in body)
-                        # AI Gateway off -> /serving-endpoints/<model>/invocations (model in path)
-                        endpoint_url, body_model = DatabricksURLUtils.construct_embeddings_url(workspace_url, self.model)
-
-                        if not endpoint_url:
-                            raise Exception("Failed to construct valid endpoint URL")
-
-                        logger.debug(f"Databricks embedding endpoint URL: {endpoint_url}")
-                        payload: dict = {"input": input if isinstance(input, list) else [input]}
-                        if body_model:
-                            payload["model"] = body_model
-
-                        # Prepare headers - prioritize user token for OBO auth
-                        if self.user_token:
-                            headers = {
-                                "Authorization": f"Bearer {self.user_token}",
-                                "Content-Type": "application/json"
-                            }
-                            logger.debug("Using OBO token for embeddings")
-                        elif self.auth_headers:
-                            headers = self.auth_headers.copy()
-                        elif self.api_key:
-                            headers = {
-                                "Authorization": f"Bearer {self.api_key}",
-                                "Content-Type": "application/json"
-                            }
-                        else:
-                            logger.error("No authentication method available for Databricks embeddings")
-                            raise Exception("No authentication method available")
-                        
-                        # Add User-Agent header for Databricks API attribution
-                        from src.utils.telemetry import get_user_agent_header, KasalProduct, send_logfood_telemetry_sync
-                        headers.update(get_user_agent_header(KasalProduct.EMBEDDING))
-
-                        response = requests.post(endpoint_url, headers=headers, json=payload, timeout=30)
-                        if response.status_code == 200:
-                            result = response.json()
-                            if 'data' in result and len(result['data']) > 0:
-                                embeddings = [item.get('embedding', item) for item in result['data']]
-                                
-                                # Send token usage to Databricks logfood
-                                usage = result.get('usage', {})
-                                if usage:
-                                    auth_token = self.user_token or self.api_key
-                                    send_logfood_telemetry_sync(
-                                        usage=usage,
-                                        model=self.model,
-                                        product_context=KasalProduct.EMBEDDING,
-                                        workspace_url=workspace_url,
-                                        token=auth_token
-                                    )
-
-                                return cast(Embeddings, embeddings)
-                            else:
-                                raise Exception(f"Unexpected response format: {result}")
-                        else:
-                            raise Exception(f"Embedding API error {response.status_code}: {response.text}")
-
-                    except Exception as e:
-                        logger.error(f"Error in Databricks embedding function: {e}")
-                        raise e
+                    Crew memory is an enhancement, not part of producing the metric
+                    view — so a transient embedding failure (SSL/EOF, connection
+                    reset, 429/5xx) must NEVER fail a flow whose generation already
+                    succeeded. (Observed: an SSLEOFError to the embedding endpoint
+                    flipped a completed UCMV run to FAILED.)
+                    """
+                    docs = list(input) if isinstance(input, list) else [input]
+                    return cast(Embeddings, _embed_with_fail_open(
+                        self._embed_once, docs,
+                        self.embedding_dimension or self._FALLBACK_DIM,
+                        self._MAX_ATTEMPTS,
+                    ))
 
             # Construct URLs (encodes the workspace; the embedding function re-derives
             # the workspace and picks serving-endpoints vs AI Gateway per the toggle)

--- a/src/backend/src/engines/crewai/infra/logging_config.py
+++ b/src/backend/src/engines/crewai/infra/logging_config.py
@@ -579,6 +579,14 @@ def configure_subprocess_logging(execution_id: str, process_type: str = "crew"):
         'src.engines.crewai.tools.custom.powerbi_metadata_reducer_tool',  # Metadata Reducer tool logs
         'src.engines.crewai.tools.custom.powerbi_semantic_model_fetcher_tool',  # Fetcher tool logs
         'src.engines.crewai.tools.custom.databricks_jobs_tool',  # Add Databricks jobs tool logger
+        'src.engines.crewai.tools.custom.uc_metric_view_generator_tool',  # UCMV Generator tool logs
+        'src.engines.crewai.tools.custom.pipeline_config_generator_tool',  # Pipeline Config Generator tool logs
+        'src.engines.crewai.tools.custom.metric_view_utils',  # UCMV pipeline submodules (pipeline, table_processor,
+                                                                # dax_llm_fallback, mquery_llm_fallback, ...) — a
+                                                                # parent-package entry since none of them set their
+                                                                # own level/handlers, so they propagate up to this one
+        'src.engines.crewai.tools.custom.metric_view_validation_utils',  # per-table DAX-vs-SQL validation pass run
+                                                                # from inside UCMetricViewGeneratorTool._run()
         'src.engines.crewai.paths.crew.task_adapter',  # Task tool resolution logs
         'src.engines.crewai.paths.crew.agent_adapter',  # Agent tool resolution logs
         'src.engines.crewai.security.tool_capability_manifest',  # Trifecta detection warnings

--- a/src/backend/src/engines/crewai/paths/flow/crewai_flow_service.py
+++ b/src/backend/src/engines/crewai/paths/flow/crewai_flow_service.py
@@ -130,12 +130,21 @@ class CrewAIFlowService:
                             }
 
                 if agents_yaml or tasks_yaml:
-                    name_service = ExecutionNameService.create(self.session)
+                    # Build the service with session=None, NOT self.session. Name
+                    # generation interleaves DB reads (template, model config) with a
+                    # seconds-long LLM call. self.session is the REQUEST-scoped
+                    # session, which the request's own work may still be using — two
+                    # coroutines on one AsyncSession raises "This session is
+                    # provisioning a new connection; concurrent operations are not
+                    # permitted". session=None makes each read open its own
+                    # standalone session (see ExecutionNameService.create), so the
+                    # naming step can never contend with the request transaction.
                     request = ExecutionNameGenerationRequest(
                         agents_yaml=agents_yaml,
                         tasks_yaml=tasks_yaml,
                         model=config.get('model')
                     )
+                    name_service = ExecutionNameService.create(None)
                     response = await name_service.generate_execution_name(request)
                     run_name = response.name
                     logger.info(f"Generated run_name for flow: {run_name}")

--- a/src/backend/src/engines/crewai/paths/flow/flow_execution_runner.py
+++ b/src/backend/src/engines/crewai/paths/flow/flow_execution_runner.py
@@ -25,6 +25,41 @@ CICD_ARTIFACT_QUERY = (
     "ORDER BY created_at ASC"
 )
 
+# Recover a UCMV generator result already persisted to the trace, so a run that
+# FAILED *after* generation (e.g. a downstream crew/memory hiccup) still surfaces
+# the drafts instead of losing them with the run. Newest first.
+UCMV_OUTPUT_QUERY = (
+    "SELECT output FROM execution_trace "
+    "WHERE job_id = :jid AND CAST(output AS TEXT) LIKE '%views_generated%' "
+    "ORDER BY created_at DESC"
+)
+
+
+async def _recover_ucmv_output(execution_id: str) -> Optional[str]:
+    """Return the most recent persisted UCMV generator output for a job, or None.
+
+    Used to salvage a completed generation when the flow later fails, so the UI
+    still shows the metric-view drafts. Best-effort: any error yields None.
+    """
+    import json as _json
+    from src.db.session import async_session_factory
+    from sqlalchemy import text as _text
+
+    async with async_session_factory() as _session:
+        _rows = await _session.execute(_text(UCMV_OUTPUT_QUERY), {'jid': execution_id})
+        _row = _rows.first()
+    if not _row or _row[0] is None:
+        return None
+    output = _row[0]
+    parsed = _json.loads(output) if isinstance(output, str) else output
+    # execution_trace wraps tool output as {"content": "<json_string>"}.
+    if isinstance(parsed, dict) and 'content' in parsed:
+        inner = parsed['content']
+        parsed = _json.loads(inner) if isinstance(inner, str) else inner
+    if isinstance(parsed, dict) and ('views_generated' in parsed or 'yaml' in parsed):
+        return _json.dumps(parsed)
+    return None
+
 
 async def update_execution_status_with_retry(
     execution_id: str,
@@ -243,6 +278,24 @@ async def run_flow_in_process(
                 final_status = ExecutionStatus.FAILED.value
                 final_message = result.get('error', 'Process execution failed')
                 logger.error(f"Flow execution failed for {execution_id}: {final_message}")
+
+                # Salvage: if the UCMV generation already succeeded and the flow
+                # only failed downstream (e.g. a crew-memory embedding hiccup),
+                # recover the produced drafts from the trace and surface them so
+                # they're not lost with the FAILED run. Status stays FAILED (the
+                # failure was real), but the user still gets the deliverable.
+                if final_result is None:
+                    try:
+                        recovered = await _recover_ucmv_output(execution_id)
+                        if recovered is not None:
+                            final_result = recovered
+                            final_message = (
+                                f"{final_message} — the metric-view generation had already "
+                                "succeeded; its output was recovered and is shown below.")
+                            logger.info(
+                                f"[recovery] Attached recovered UCMV output to FAILED run {execution_id}")
+                    except Exception as _rec_err:  # noqa: BLE001 - best-effort salvage
+                        logger.warning(f"[recovery] Could not recover UCMV output: {_rec_err}")
 
     except asyncio.CancelledError:
         # Execution was cancelled

--- a/src/backend/src/engines/crewai/paths/flow/modules/flow_methods.py
+++ b/src/backend/src/engines/crewai/paths/flow/modules/flow_methods.py
@@ -18,9 +18,15 @@ logger = LoggerManager.get_instance().flow
 
 # Per-crew kickoff timeout for flow execution. Large Power BI models (hundreds of
 # measures, dozens of fact tables + opt-in LLM DAX translation) can legitimately
-# take longer than the original 10 min. Bumped to 20 min as headroom; the DAX LLM
-# fallback is also now bounded-concurrent so it finishes far faster than before.
-CREW_KICKOFF_TIMEOUT_SECONDS = 1200.0
+# take longer than the original 10 min, then the 20 min this was bumped to next.
+# Confirmed in production: a 55-fact-table report (DCC) timed out at 20 min —
+# MetricViewPipeline processes fact tables SEQUENTIALLY (pipeline.py), and each
+# table's own LLM DAX-fallback batch (table_processor.py -> dax_llm_fallback.py,
+# itself bounded-concurrent within a table) blocks before the next table starts.
+# Bumped to 55 min, leaving a 5 min margin under process_flow_executor's outer
+# 3600s (1 hour) subprocess watchdog (flow_execution_runner.py) — that outer
+# timeout would need raising too if this one ever needs to grow further.
+CREW_KICKOFF_TIMEOUT_SECONDS = 3300.0
 
 
 def extract_final_answer(results) -> str:

--- a/src/backend/src/engines/crewai/tools/custom/generate_config.py
+++ b/src/backend/src/engines/crewai/tools/custom/generate_config.py
@@ -218,6 +218,49 @@ def parse_tmdl_to_admin_tables(
     return tables
 
 
+def parse_tmdl_expressions(tmdl_parts: list[dict] | None) -> dict[str, str]:
+    """Fabric TMDL equivalent of ``parse_admin_expressions`` — best-effort.
+
+    TMDL groups a model's shared/named expressions into a single
+    ``definition/expressions.tmdl`` (multiple ``expression <Name> = ...``
+    blocks), unlike tables, which each get their own
+    ``definition/tables/<name>.tmdl``. Not live-verified against a real
+    Fabric-enabled workspace: every run observed while building this reached
+    the model via the Admin Scanner (``parse_admin_expressions``), with TMDL
+    only ever attempted as its fallback and returning no data. Kept
+    defensive/best-effort rather than blocking on that verification — same
+    posture as ``fetch_tmdl_parts``/``parse_tmdl_to_admin_tables`` already
+    take with tables.
+    """
+    import base64
+
+    expressions: dict[str, str] = {}
+    for part in tmdl_parts or []:
+        path = part.get("path", "")
+        if not (path == "definition/expressions.tmdl"
+                or path.startswith("definition/expressions/")):
+            continue
+        try:
+            content = base64.b64decode(part.get("payload", "")).decode("utf-8")
+        except Exception:
+            continue
+        epattern = re.compile(
+            r"^expression\s+(?:'([^']+)'|(\w+))\s*=\s*([\s\S]*?)"
+            r"(?=\n\s*expression\s|\Z)",
+            re.MULTILINE,
+        )
+        for m in epattern.finditer(content):
+            name = m.group(1) or m.group(2)
+            expr = m.group(3).strip()
+            clean = []
+            for line in expr.split("\n"):
+                if line.strip().startswith(("lineageTag:", "annotation", "queryGroup:")):
+                    break
+                clean.append(line)
+            expressions[name] = "\n".join(clean).strip()
+    return expressions
+
+
 def _headers(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
@@ -1158,6 +1201,42 @@ def parse_admin_tables(
                     "measures": tbl.get("measures", []),
                 }
     return tables
+
+
+def parse_admin_expressions(
+    scan_result: dict,
+    dataset_id: str | None = None,
+) -> dict[str, str]:
+    """Parse the model's named/shared expressions out of an admin scan result.
+
+    A dataset's schema splits into ``tables`` (what ``parse_admin_tables``
+    reads — loaded tables only) and ``expressions``: named queries NOT loaded
+    as a table. Two things live only here, neither visible in ``tables`` at
+    all: (1) "staging" queries disabled from load that a real table's M does
+    nothing but reference (``let Source = #"Some Staging Query" in Source``)
+    — the query's actual Databricks/SQL source is only in ``expressions``;
+    (2) model **parameters** (an expression tagged ``IsParameterQuery=true``
+    holding the parameter's current literal value) — some tables build their
+    physical source from these at model-open time via string concatenation
+    rather than a literal, and the table name/schema doesn't exist anywhere
+    until that substitution happens.
+
+    Returns ``{name: raw_M_expression}``. Feed to
+    ``metric_view_utils.mquery_parser.resolve_mquery_with_context`` (which
+    both follows references and evaluates parameter-driven sources) alongside
+    a table's own ``mquery_expression`` — without this, both patterns are
+    unresolvable no matter how good the per-table M parsing is.
+    """
+    expressions: dict[str, str] = {}
+    for ws in scan_result.get("workspaces", []):
+        for dataset in ws.get("datasets", []):
+            if dataset_id and dataset.get("id", "").lower() != dataset_id.lower():
+                continue
+            for expr in dataset.get("expressions", []):
+                name = expr.get("name", "")
+                if name:
+                    expressions[name] = expr.get("expression", "")
+    return expressions
 
 
 def derive_column_metadata(admin_tables: dict[str, dict]) -> dict[str, dict]:

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/capability_version.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/capability_version.py
@@ -1,0 +1,139 @@
+"""Capability fingerprint for the DAX→UC-Metric-View transpiler.
+
+WHY: Kasal's transpilation capability keeps improving — new patterns in
+``dax_translator.py``, a better LLM-first path in ``dax_llm_fallback.py``, and an
+evolving skill corpus under ``skills/``. To know whether it is worth re-trying the
+measures that failed on an OLD run, we need a cheap answer to "has the transpiler
+changed since then?".
+
+Why a fingerprint and not a skill-file diff: most capability gains land in CODE
+(pattern registry, LLM-first path, emitters), not in the ``.md`` skill files, so
+diffing skills alone would miss them. And mapping "this skill paragraph changed" to
+"measure X now works" is guesswork. Hashing the whole capability surface gives a
+reliable "something changed" signal; the actual gain is then measured by RE-RUNNING
+the transpiler (ground truth) rather than inferred.
+
+Note: ``ConversionHistory.converter_version`` exists as a column but is never
+written anywhere in the codebase, so it cannot serve as the gate today. This
+fingerprint replaces it.
+
+Fail-open by design: any error yields the ``_UNKNOWN`` sentinel, which callers treat
+as "changed" (re-evaluate) rather than crashing a scheduled sweep.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+_UNKNOWN = "unknown"
+
+# The capability surface: source files whose content materially changes what the
+# transpiler can translate. Kept explicit (not a directory walk) so unrelated
+# helper edits don't churn the fingerprint.
+_SOURCE_FILES = ("dax_translator.py", "dax_llm_fallback.py")
+
+_SKILLS_DIRNAME = "skills"
+
+
+def _here() -> str:
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def _read(path: str) -> bytes:
+    try:
+        with open(path, "rb") as fh:
+            return fh.read()
+    except OSError:
+        return b""
+
+
+def skill_files() -> list[str]:
+    """Every skill-corpus file, as paths relative to the skills/ dir, sorted.
+
+    Sorted so the fingerprint is stable regardless of filesystem walk order.
+    """
+    root = os.path.join(_here(), _SKILLS_DIRNAME)
+    found: list[str] = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            if name.startswith("."):
+                continue
+            full = os.path.join(dirpath, name)
+            found.append(os.path.relpath(full, root))
+    return sorted(found)
+
+
+def pattern_names() -> list[str]:
+    """Registered translator pattern names — the deterministic capability surface.
+
+    Imported lazily: this module is used by a scheduled sweep that should not pay
+    the translator import cost unless it actually needs the fingerprint.
+    """
+    try:
+        from .dax_translator import DaxTranslator
+
+        translator = DaxTranslator({})
+        return [name for name, _m, _t in getattr(translator, "_patterns", [])]
+    except Exception as exc:  # fail-open — never block on introspection
+        logger.debug("[capability] could not read pattern names: %s", exc)
+        return []
+
+
+@lru_cache(maxsize=1)
+def capability_fingerprint() -> str:
+    """Short stable hash over the transpiler's capability surface.
+
+    Covers: every skill-corpus file's content, the source of the translator and the
+    LLM-first fallback, and the registered pattern names. Cached per process (the
+    files cannot change under a running interpreter without a reload).
+    """
+    try:
+        digest = hashlib.sha256()
+
+        root = os.path.join(_here(), _SKILLS_DIRNAME)
+        for rel in skill_files():
+            digest.update(rel.encode("utf-8"))
+            digest.update(_read(os.path.join(root, rel)))
+
+        for name in _SOURCE_FILES:
+            digest.update(name.encode("utf-8"))
+            digest.update(_read(os.path.join(_here(), name)))
+
+        for name in pattern_names():
+            digest.update(name.encode("utf-8"))
+
+        return digest.hexdigest()[:16]
+    except Exception as exc:  # fail-open
+        logger.warning("[capability] fingerprint failed (%s) — treating as unknown", exc)
+        return _UNKNOWN
+
+
+def capability_summary() -> dict:
+    """Human/report-friendly view of the current capability level."""
+    names = pattern_names()
+    files = skill_files()
+    return {
+        "fingerprint": capability_fingerprint(),
+        "pattern_count": len(names),
+        "skill_file_count": len(files),
+        "skill_files": files,
+    }
+
+
+def has_capability_changed(stored_fingerprint: str | None) -> bool:
+    """True when it is worth re-evaluating a run recorded under ``stored_fingerprint``.
+
+    Unknown/missing stored fingerprint → True (old runs predate fingerprinting, so we
+    cannot rule out a gain). Current fingerprint unknown → True (fail-open: prefer a
+    wasted re-check over silently never proposing anything).
+    """
+    if not stored_fingerprint or stored_fingerprint == _UNKNOWN:
+        return True
+    current = capability_fingerprint()
+    if current == _UNKNOWN:
+        return True
+    return current != stored_fingerprint

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/constants.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/constants.py
@@ -9,9 +9,12 @@ RE_AGG_COL = re.compile(
     re.IGNORECASE,
 )
 
-# Regex: extract FROM clause
+# Regex: extract FROM clause. Each dotted segment may be a bare word or a
+# backtick-quoted identifier (needed for a catalog/schema/column containing a
+# space, e.g. a PBI-connector catalog literally named `Databricks Data
+# Catalog` — mquery_parser.resolve_mquery_to_sql backtick-quotes those).
 RE_FROM_CLAUSE = re.compile(
-    r'FROM\s+([\w.]+)(?:\s+(?:as\s+)?(\w+))?',
+    r'FROM\s+((?:`[^`]+`|[\w]+)(?:\.(?:`[^`]+`|[\w]+))*)(?:\s+(?:as\s+)?(\w+))?',
     re.IGNORECASE,
 )
 

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/data_classes.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/data_classes.py
@@ -22,6 +22,10 @@ class TranslationResult:
     # Distinct from `category`, which drives yaml_emitter output routing — never
     # overload category with this. Reporting/telemetry only.
     dax_class: str | None = None
+    # The LLM's one-line justification for the translation (or the decline
+    # reason). Surfaced as a provenance comment on the emitted measure so a
+    # reviewer sees HOW/WHY each best-effort measure was produced. Reporting only.
+    explanation: str | None = None
     # How many OTHER measures reference this one (DAX dependency in-degree).
     # Surfaced on TODOs + the UCMV overview so reviewers prioritize high-impact
     # gaps. Populated from config['measure_usage']; measure→measure refs only

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/dax_llm_fallback.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/dax_llm_fallback.py
@@ -15,6 +15,7 @@ from collections import OrderedDict
 from typing import Any
 
 from .data_classes import TranslationResult
+from .function_ref_retriever import render_function_refs
 from .utils import to_snake_case
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ _RUN_CACHE_MAX = 128
 _SKILLS_DIR = os.path.join(os.path.dirname(__file__), "skills")
 _SKILL_FILES = (
     ("dax", "SKILL.md"), ("dax", "PATTERNS.md"),
+    ("dax", "FUNCTION_REFERENCE.md"),
     ("dax", "UNSUPPORTED.md"), ("dax", "EDGE_CASES.md"),
     ("uc-metric-views", "SYNTAX.md"), ("uc-metric-views", "WINDOW.md"),
     ("uc-metric-views", "LOD.md"), ("uc-metric-views", "JOINS.md"),
@@ -268,11 +270,15 @@ def _build_batch_user_prompt(
     for i, m in enumerate(measures, start=1):
         lines.append(f"{i}. name: {m.original_name}\n   DAX: {m.dax_expression}")
     measures_block = "\n".join(lines)
+    # Retrieval: inject deep UCMV-legal references for the long-tail DAX functions
+    # this batch uses (skips functions already taught deeply in the cached prefix).
+    # Goes in the VARIABLE user message so the corpus prefix stays cacheable.
+    func_refs = render_function_refs(m.dax_expression for m in measures)
     return f"""Translate the following {len(measures)} DAX measures to Spark SQL for a UC Metric View, using the shared fact-table context below.
 {ctx_block}
 ## Available MEASURE() references (already translated)
 {available_measures}
-
+{func_refs}
 ## Measures to translate
 {measures_block}
 
@@ -340,6 +346,7 @@ def _apply_parsed(measure: TranslationResult, parsed: dict, usage: dict | None =
         measure.category = 'llm_translated'
         # dax_class = translation provenance/quality (7-cat); NOT emission routing.
         measure.dax_class = parsed.get('dax_class')
+        measure.explanation = parsed.get('explanation')
         measure.skip_reason = ''
         usage = usage or {}
         tokens = usage.get('total_tokens', 0)
@@ -352,6 +359,7 @@ def _apply_parsed(measure: TranslationResult, parsed: dict, usage: dict | None =
     else:
         # Even on non-success, record the classification for reporting/telemetry.
         measure.dax_class = parsed.get('dax_class') or measure.dax_class
+        measure.explanation = parsed.get('explanation') or measure.explanation
         reason = parsed.get('error', parsed.get('explanation', 'LLM could not translate'))
         measure.skip_reason = _llm_declined_reason(measure.dax_class, reason)
         logger.info(f"[DAX_LLM] Could not translate {measure.original_name} (dax_class={measure.dax_class}): {reason}")

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/dax_llm_fallback.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/dax_llm_fallback.py
@@ -127,6 +127,46 @@ else:
     _SYSTEM_PROMPT = _FALLBACK_INSTRUCTIONS + "\n" + _OUTPUT_CONTRACT
 
 
+# Batch output contract: the model is handed SEVERAL measures in one call (so the
+# ~14k-token skill corpus is sent ONCE and amortised across the whole batch,
+# instead of re-sent per measure — Databricks silently drops Anthropic prompt
+# caching, so per-measure calls pay the full corpus every time). It must return a
+# JSON ARRAY, one object per measure, echoing the measure name so results map back.
+_BATCH_OUTPUT_CONTRACT = """
+
+You are given SEVERAL DAX measures in one request. Respond with a SINGLE valid
+JSON ARRAY (no markdown code fences), containing exactly one object per measure
+you were given:
+[
+  {
+    "measure_name": "<echo the EXACT measure name you were given>",
+    "success": true or false,
+    "sql_expr": "the Spark SQL expression" or null,
+    "dax_class": "translatable_direct|composed|filtered|architecture_change|display_layer|unsupported|out_of_scope",
+    "confidence": "high" or "medium" or "low",
+    "explanation": "brief explanation of the translation",
+    "error": "reason if success=false" or null
+  }
+]
+Include EVERY measure exactly once. Do not merge, skip, or invent measures.
+Classify each into exactly one dax_class (same definitions as above)."""
+
+# Corpus-backed batch system prompt (corpus sent ONCE per batch call).
+if _SKILL_CORPUS:
+    _SYSTEM_PROMPT_BATCH = (
+        "You are an expert Power BI DAX → Databricks UC Metric View translator. "
+        "Use the following skill corpus (engineering's DAX-translation decision "
+        "framework + UC-metric-view target-language spec) as your authoritative "
+        "guide for WHAT to translate and HOW to write the target YAML/SQL.\n\n"
+        f"{_SKILL_CORPUS}\n\n"
+        "----\n"
+        "Translate EACH of the given DAX measures to a Spark SQL expression for a "
+        "UC Metric View, following the corpus above." + _BATCH_OUTPUT_CONTRACT
+    )
+else:
+    _SYSTEM_PROMPT_BATCH = _FALLBACK_INSTRUCTIONS + "\n" + _BATCH_OUTPUT_CONTRACT
+
+
 def _content_hash(text: str) -> str:
     """SHA-256 hash for cache key."""
     return hashlib.sha256(text.encode()).hexdigest()[:16]
@@ -182,6 +222,75 @@ def _parse_response(response_text: str) -> dict:
         return {'success': False, 'error': 'Failed to parse LLM response'}
 
 
+def _strip_code_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith('```json'):
+        return text.split('```json')[1].split('```')[0].strip()
+    if text.startswith('```'):
+        return text.split('```')[1].split('```')[0].strip()
+    return text
+
+
+def _build_batch_user_prompt(
+    measures: list[TranslationResult],
+    base_names: set[str],
+    table_context: str = "",
+) -> str:
+    """Build ONE user prompt covering all measures in a batch.
+
+    The fact-table context (source table, columns, joins, filters) is included
+    ONCE for the whole batch — every measure in a ``translate_batch_with_llm``
+    call belongs to the same table_key, so they share it. This is what makes
+    batching cheap: the big shared context and the corpus system prefix are sent
+    once, not once per measure.
+    """
+    available_measures = ', '.join(sorted(base_names)[:50])
+    ctx_block = f"\n## Fact table context\n{table_context}\n" if table_context else ""
+    lines = []
+    for i, m in enumerate(measures, start=1):
+        lines.append(f"{i}. name: {m.original_name}\n   DAX: {m.dax_expression}")
+    measures_block = "\n".join(lines)
+    return f"""Translate the following {len(measures)} DAX measures to Spark SQL for a UC Metric View, using the shared fact-table context below.
+{ctx_block}
+## Available MEASURE() references (already translated)
+{available_measures}
+
+## Measures to translate
+{measures_block}
+
+## Instructions
+- Use ONLY the source columns / join aliases listed in the fact table context above; do not invent column names.
+- If referencing another measure, use MEASURE(snake_case_name)
+- Column references: source.column_name (fact) or alias.column_name (joined dimension)
+- Return a JSON ARRAY with one object per measure, echoing "measure_name" exactly as given."""
+
+
+def _parse_batch_response(response_text: str) -> list[dict] | None:
+    """Parse a batch response into a list of per-measure result dicts.
+
+    Accepts a bare JSON array, a ``{"measures": [...]}`` wrapper, or an object
+    keyed by measure name. Returns ``None`` if nothing usable parses, which the
+    caller treats as a signal to fall back to per-measure translation.
+    """
+    try:
+        data = json.loads(_strip_code_fences(response_text))
+    except (json.JSONDecodeError, IndexError):
+        return None
+    if isinstance(data, list):
+        return [d for d in data if isinstance(d, dict)]
+    if isinstance(data, dict):
+        if isinstance(data.get('measures'), list):
+            return [d for d in data['measures'] if isinstance(d, dict)]
+        # Object keyed by measure name → normalise to a list.
+        out = []
+        for key, val in data.items():
+            if isinstance(val, dict):
+                val.setdefault('measure_name', key)
+                out.append(val)
+        return out or None
+    return None
+
+
 def _validate_sql(sql_expr: str) -> bool:
     """Check that the LLM output doesn't contain DAX-only constructs."""
     _DAX_ONLY = re.compile(
@@ -191,6 +300,43 @@ def _validate_sql(sql_expr: str) -> bool:
         re.IGNORECASE,
     )
     return not _DAX_ONLY.search(sql_expr)
+
+
+def _apply_parsed(measure: TranslationResult, parsed: dict, usage: dict | None = None) -> None:
+    """Apply a parsed LLM result dict to a measure in place (success or decline).
+
+    Shared by the single-measure and batch paths so both interpret the LLM's
+    JSON identically. On success the measure is marked translatable; on decline
+    (or SQL that still contains DAX-only constructs) the measure is left
+    untranslated (fail-open) with a terminal ``skip_reason``.
+    """
+    if parsed.get('success') and parsed.get('sql_expr'):
+        sql_expr = parsed['sql_expr']
+        # Validate: no DAX-only constructs leaked into the output.
+        if not _validate_sql(sql_expr):
+            logger.warning(f"[DAX_LLM] LLM output contains DAX constructs for {measure.original_name}")
+            return
+        measure.sql_expr = sql_expr
+        measure.is_translatable = True
+        measure.confidence = parsed.get('confidence', 'medium')
+        measure.category = 'llm_translated'
+        # dax_class = translation provenance/quality (7-cat); NOT emission routing.
+        measure.dax_class = parsed.get('dax_class')
+        measure.skip_reason = ''
+        usage = usage or {}
+        tokens = usage.get('total_tokens', 0)
+        cache_read = usage.get('cache_read_input_tokens', 0)
+        logger.info(
+            f"[DAX_LLM] Translated {measure.original_name} → {sql_expr[:80]}... "
+            f"(confidence={measure.confidence}, dax_class={measure.dax_class}, "
+            f"tokens={tokens}, cache_read={cache_read})"
+        )
+    else:
+        # Even on non-success, record the classification for reporting/telemetry.
+        measure.dax_class = parsed.get('dax_class') or measure.dax_class
+        reason = parsed.get('error', parsed.get('explanation', 'LLM could not translate'))
+        measure.skip_reason = _llm_declined_reason(measure.dax_class, reason)
+        logger.info(f"[DAX_LLM] Could not translate {measure.original_name} (dax_class={measure.dax_class}): {reason}")
 
 
 def _system_message(system_prompt: str) -> dict:
@@ -220,6 +366,7 @@ async def _call_llm(
     prompt: str,
     system_prompt: str,
     model: str,
+    max_tokens: int = 2000,
 ) -> dict:
     """Call the LLM, preferring the cache-aware usage-returning path.
 
@@ -227,6 +374,9 @@ async def _call_llm(
     can carry ``cache_control`` and the ``usage`` block is returned (cache hits
     observable). Falls back to plain ``completion()`` if the cached path errors,
     so a transport hiccup never blocks translation (fail-open).
+
+    ``max_tokens`` is raised by the batch path, which asks the model to translate
+    many measures in one response (see ``translate_batch_with_llm``).
     """
     from src.core.llm_manager import LLMManager
     from src.utils.telemetry import get_user_agent_header, KasalProduct
@@ -238,7 +388,7 @@ async def _call_llm(
             messages=messages,
             model=model,
             temperature=0.1,
-            max_tokens=2000,
+            max_tokens=max_tokens,
             extra_headers=headers,
         )
         return {"content": result.get("content"), "usage": result.get("usage", {})}
@@ -252,7 +402,7 @@ async def _call_llm(
                 ],
                 model=model,
                 temperature=0.1,
-                max_tokens=2000,
+                max_tokens=max_tokens,
                 extra_headers=headers,
             )
             return {"content": content, "usage": {}}
@@ -330,41 +480,11 @@ async def translate_with_llm(
         _cache.popitem(last=False)
     _cache[cache_key] = parsed
 
-    if parsed.get('success') and parsed.get('sql_expr'):
-        sql_expr = parsed['sql_expr']
-
-        # Validate: no DAX-only constructs in output
-        if not _validate_sql(sql_expr):
-            logger.warning(f"[DAX_LLM] LLM output contains DAX constructs for {measure.original_name}")
-            return measure
-
-        measure.sql_expr = sql_expr
-        measure.is_translatable = True
-        measure.confidence = parsed.get('confidence', 'medium')
-        measure.category = 'llm_translated'
-        # dax_class = translation provenance/quality (7-cat); NOT emission routing.
-        measure.dax_class = parsed.get('dax_class')
-        measure.skip_reason = ''
-
-        usage = response.get('usage', {}) or {}
-        tokens = usage.get('total_tokens', 0)
-        cache_read = usage.get('cache_read_input_tokens', 0)
-        logger.info(
-            f"[DAX_LLM] Translated {measure.original_name} → {sql_expr[:80]}... "
-            f"(confidence={measure.confidence}, dax_class={measure.dax_class}, "
-            f"tokens={tokens}, cache_read={cache_read})"
-        )
-    else:
-        # Even on non-success, record the classification for reporting/telemetry.
-        measure.dax_class = parsed.get('dax_class') or measure.dax_class
-        reason = parsed.get('error', parsed.get('explanation', 'LLM could not translate'))
-        # Overwrite the ROUTING skip_reason with the TERMINAL verdict. The fast path
-        # sets "routed to LLM (fast-path dropped a DAX component)" to mean "hand this
-        # to the LLM"; leaving that text in place once the LLM has ALSO declined
-        # reports an intermediate state as the final one, so the Not-transpiled panel
-        # and the re-evaluation sweep both claim the LLM never got a turn.
-        measure.skip_reason = _llm_declined_reason(measure.dax_class, reason)
-        logger.info(f"[DAX_LLM] Could not translate {measure.original_name} (dax_class={measure.dax_class}): {reason}")
+    # Apply the parsed result (success marks translatable; decline sets a terminal
+    # skip_reason — overwriting the fast-path's "routed to LLM" routing text so the
+    # Not-transpiled panel / re-evaluation sweep don't report an intermediate state
+    # as final).
+    _apply_parsed(measure, parsed, response.get('usage', {}) or {})
 
     return measure
 
@@ -397,6 +517,15 @@ def _llm_declined_reason(dax_class: str | None, detail: str) -> str:
 # resolves references to measures translated in an earlier chunk — preserving
 # most of the cross-measure reference benefit of the old sequential order.
 _DAX_LLM_CONCURRENCY = 6
+
+# Number of measures translated per LLM call. The skill-corpus system prefix
+# (~14k tokens) and the shared fact-table context are sent ONCE per call, so a
+# batch of N amortises them across N measures instead of paying them per measure
+# — the single biggest lever on the workspace tokens-per-minute rate limit, since
+# Databricks silently drops Anthropic prompt caching (every call is cache_read=0).
+# Tunable via env for field tuning without a redeploy. Keep modest so one call's
+# input+output stays well within context/output limits.
+_DAX_LLM_BATCH_SIZE = max(1, int(os.getenv("DAX_LLM_BATCH_SIZE", "12")))
 
 
 async def translate_batch_with_llm(
@@ -464,30 +593,92 @@ async def translate_batch_with_llm(
 
     logger.info(
         f"[DAX_LLM] Attempting LLM fallback for {len(candidates)} measures in "
-        f"{table_key} (concurrency={_DAX_LLM_CONCURRENCY})"
+        f"{table_key} (batch_size={_DAX_LLM_BATCH_SIZE})"
     )
 
-    # Run-scoped cache — prevents cross-tenant leakage between pipeline runs.
-    # Shared across chunks so identical DAX only hits the LLM once.
+    # Run-scoped cache — prevents cross-tenant leakage between pipeline runs and
+    # lets identical DAX (same table_context) reuse an earlier result in this run.
     run_cache: OrderedDict[str, dict] = OrderedDict()
 
+    def _ck(m: TranslationResult) -> str:
+        return _content_hash(m.dax_expression + "\x00" + table_context)
+
     translated_count = 0
-    for start in range(0, len(candidates), _DAX_LLM_CONCURRENCY):
-        chunk = candidates[start:start + _DAX_LLM_CONCURRENCY]
-        # Snapshot the reference context so all measures in this chunk see the
-        # same (already-translated) refs — matches deterministic behaviour and
-        # avoids mutating shared dicts concurrently.
+    # Process in BATCHES: one LLM call per batch translates all its measures, so
+    # the ~14k-token skill corpus + shared fact-table context are paid ONCE per
+    # batch instead of per measure (~batch_size× fewer input tokens — what was
+    # blowing the workspace tokens-per-minute limit). Batches run sequentially:
+    # dependencies are ordered into earlier batches (topo_priority) and each
+    # batch's successes merge into base_names before the next, so cross-measure
+    # MEASURE() references still resolve, and the per-minute token burst stays low.
+    for start in range(0, len(candidates), _DAX_LLM_BATCH_SIZE):
+        batch = candidates[start:start + _DAX_LLM_BATCH_SIZE]
         snap_names = set(base_names)
-        snap_map = dict(original_to_snake)
-        await asyncio.gather(*(
-            translate_with_llm(
-                m, table_key, snap_names, snap_map,
-                model=model, cache=run_cache, table_context=table_context,
+
+        # Apply run-cache hits first; only the rest need an LLM call.
+        need_llm: list[TranslationResult] = []
+        for m in batch:
+            cached = run_cache.get(_ck(m))
+            if cached is not None:
+                _apply_parsed(m, cached)
+            else:
+                need_llm.append(m)
+
+        if need_llm:
+            prompt = _build_batch_user_prompt(need_llm, snap_names, table_context)
+            # Budget output for the whole batch (each measure ~a few hundred tokens).
+            batch_max_tokens = min(len(need_llm) * 400 + 800, 16000)
+            response = await _call_llm(
+                prompt, _SYSTEM_PROMPT_BATCH, model, max_tokens=batch_max_tokens
             )
-            for m in chunk
-        ))
-        # Merge this chunk's successes into the shared context for later chunks.
-        for m in chunk:
+            parsed_list = _parse_batch_response(response.get('content') or '')
+
+            if parsed_list is None:
+                # Whole batch unparseable → per-measure fallback so one malformed
+                # response never loses a whole batch of measures.
+                logger.warning(
+                    f"[DAX_LLM] batch response unparseable for {table_key}; "
+                    f"falling back to per-measure for {len(need_llm)} measure(s)"
+                )
+                await asyncio.gather(*(
+                    translate_with_llm(
+                        m, table_key, snap_names, dict(original_to_snake),
+                        model=model, cache=run_cache, table_context=table_context,
+                    )
+                    for m in need_llm
+                ))
+            else:
+                by_name = {}
+                for item in parsed_list:
+                    nm = str(item.get('measure_name', '')).strip().lower()
+                    if nm:
+                        by_name[nm] = item
+                missing: list[TranslationResult] = []
+                for m in need_llm:
+                    item = by_name.get(m.original_name.strip().lower())
+                    if item is None:
+                        missing.append(m)
+                        continue
+                    if len(run_cache) >= _RUN_CACHE_MAX:
+                        run_cache.popitem(last=False)
+                    run_cache[_ck(m)] = item
+                    _apply_parsed(m, item, response.get('usage', {}) or {})
+                # Any measure the model dropped from the array → per-measure retry.
+                if missing:
+                    logger.warning(
+                        f"[DAX_LLM] {len(missing)} measure(s) missing from batch "
+                        f"response in {table_key}; per-measure fallback"
+                    )
+                    await asyncio.gather(*(
+                        translate_with_llm(
+                            m, table_key, snap_names, dict(original_to_snake),
+                            model=model, cache=run_cache, table_context=table_context,
+                        )
+                        for m in missing
+                    ))
+
+        # Merge this batch's successes into the shared context for later batches.
+        for m in batch:
             if m.is_translatable:
                 translated_count += 1
                 base_names.add(m.measure_name)

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/dax_llm_fallback.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/dax_llm_fallback.py
@@ -88,6 +88,24 @@ Rules:
 8. If the expression CANNOT be translated to UC Metric View SQL, return success=false.
 9. Use snake_case for measure names."""
 
+# High-signal SQL rules, appended to BOTH the single and batch output contracts
+# (the short tail of the system prompt, sent every call). The full rationale +
+# examples live in the skill corpus (dax/PATTERNS.md §0), but the corpus is large
+# and a rule there can get diluted — these two are the ones that were violated in
+# practice, so we restate them where the model is most likely to attend to them.
+_SQL_RULES = """
+
+CRITICAL SQL rules for every "sql_expr" (see skill corpus §0 for detail):
+1. Qualify EVERY source column as source.<col> — including inside FILTER (WHERE ...)
+   and CASE WHEN predicates. (Unqualified defaults to source, but always write the
+   explicit source. prefix.)
+2. SINGLE-SOURCE only: never SELECT FROM another table in a subquery — no
+   "... IN (SELECT ... FROM other_table)", no "... = (SELECT ... FROM other_table)".
+   Only source and declared join aliases are valid namespaces. If a measure needs a
+   table that is neither source nor a declared join, set success=false with
+   dax_class="architecture_change" and explain the source-view change needed — do
+   NOT fabricate a cross-table subquery."""
+
 # The JSON output contract (shared by corpus + fallback prompts). Adds the
 # 7-category `dax_class` provenance label alongside the existing fields.
 _OUTPUT_CONTRACT = """
@@ -108,7 +126,7 @@ ALWAYS respond with valid JSON (no markdown code blocks):
   "confidence": "high"/"medium"/"low",
   "explanation": "brief explanation of the translation",
   "error": "reason if success=false" or null
-}"""
+}""" + _SQL_RULES
 
 # Corpus-backed system prompt when skills are vendored; terse otherwise. The
 # corpus is the STABLE prefix that gets cache_control:ephemeral at call time.
@@ -149,7 +167,7 @@ you were given:
   }
 ]
 Include EVERY measure exactly once. Do not merge, skip, or invent measures.
-Classify each into exactly one dax_class (same definitions as above)."""
+Classify each into exactly one dax_class (same definitions as above).""" + _SQL_RULES
 
 # Corpus-backed batch system prompt (corpus sent ONCE per batch call).
 if _SKILL_CORPUS:

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/dax_llm_fallback.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/dax_llm_fallback.py
@@ -297,7 +297,13 @@ async def translate_with_llm(
             measure.dax_class = cached.get('dax_class')
             measure.skip_reason = ''
         elif cached.get('dax_class'):
+            # Same terminal-verdict rule as the live path below: a cached DECLINE must
+            # not leave the fast-path's "routed to LLM" routing text in skip_reason.
             measure.dax_class = cached.get('dax_class')
+            measure.skip_reason = _llm_declined_reason(
+                measure.dax_class,
+                cached.get('error') or cached.get('explanation') or 'LLM could not translate',
+            )
         return measure
 
     # Build prompt
@@ -352,9 +358,35 @@ async def translate_with_llm(
         # Even on non-success, record the classification for reporting/telemetry.
         measure.dax_class = parsed.get('dax_class') or measure.dax_class
         reason = parsed.get('error', parsed.get('explanation', 'LLM could not translate'))
+        # Overwrite the ROUTING skip_reason with the TERMINAL verdict. The fast path
+        # sets "routed to LLM (fast-path dropped a DAX component)" to mean "hand this
+        # to the LLM"; leaving that text in place once the LLM has ALSO declined
+        # reports an intermediate state as the final one, so the Not-transpiled panel
+        # and the re-evaluation sweep both claim the LLM never got a turn.
+        measure.skip_reason = _llm_declined_reason(measure.dax_class, reason)
         logger.info(f"[DAX_LLM] Could not translate {measure.original_name} (dax_class={measure.dax_class}): {reason}")
 
     return measure
+
+
+def _llm_declined_reason(dax_class: str | None, detail: str) -> str:
+    """Human-readable terminal skip_reason for a measure the LLM declined.
+
+    Names the LLM as the decider and why, so a reviewer can tell "the LLM judged this
+    unsupported" apart from "nobody has looked at it yet".
+    """
+    label = {
+        'unsupported': 'no UC metric-view equivalent',
+        'display_layer': 'display/formatting only — not a data measure',
+        'out_of_scope': 'out of scope for a metric view',
+        'architecture_change': 'needs a source-model change (not expressible as-is)',
+        'composed': 'depends on other measures that must be defined first',
+    }.get((dax_class or '').strip(), '')
+    detail = (detail or '').strip().rstrip('.')
+    parts = [p for p in (label, detail) if p]
+    suffix = f" — {'; '.join(parts)}" if parts else ''
+    cls = f" [{dax_class}]" if dax_class else ''
+    return f"LLM declined{cls}{suffix}"
 
 
 # Max concurrent LLM translations per chunk. Bounded so we get a large

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/function_ref_retriever.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/function_ref_retriever.py
@@ -1,0 +1,240 @@
+"""Per-batch DAX function-reference retrieval.
+
+The always-on skill corpus (skills/dax/*.md) teaches translation *judgment* plus
+deep worked examples for the ~40 high-frequency functions that carry ~99% of real
+measures. This module supplies the LONG TAIL on demand: it detects which DAX
+functions a batch of measures actually uses and injects a deep, UCMV-legal
+reference block for exactly those — and ONLY those the static prefix does not
+already cover deeply (so CALCULATE/SUM/DIVIDE are never re-taught).
+
+Ground truth = skills/dax/function_reference.json (386 entries parsed from the
+392-function DAX reference). Curated UCMV-legal overrides below pin the exact form
++ dax_class for the non-obvious tail (statistical aggregates, PRODUCT, PATH,
+financial closed-forms, text/date traps); everything else renders from the base
+entry with an explicit "adapt per §0" caveat.
+
+Deterministic, local, no network. Fail-open: any error → "" (no injection), never
+blocks a translation.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+_DIR = os.path.dirname(__file__)
+_DATA_PATH = os.path.join(_DIR, "skills", "dax", "function_reference.json")
+# Static corpus files whose fenced examples already teach a function deeply.
+_PREFIX_FILES = (
+    os.path.join(_DIR, "skills", "dax", "FUNCTION_REFERENCE.md"),
+    os.path.join(_DIR, "skills", "dax", "PATTERNS.md"),
+    os.path.join(_DIR, "skills", "dax", "UNSUPPORTED.md"),
+)
+
+# Function-call token: an UPPERCASE identifier (optionally dotted, e.g. NORM.DIST)
+# immediately followed by '('. Matches DAX function calls, not [column] refs.
+_TOKEN = re.compile(r"\b([A-Z][A-Z0-9]*(?:\.[A-Z0-9]+)*)\s*\(")
+
+_MAX_RENDER = 40  # cap injected entries per batch (defensive)
+
+
+def _load_base() -> dict[str, dict]:
+    try:
+        with open(_DATA_PATH, encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[FUNC_REF] base data unavailable (%s): %s", _DATA_PATH, e)
+        return {}
+
+
+def _load_prefix_deep(base_keys: Iterable[str]) -> set[str]:
+    """Names that already appear inside a fenced ``` example in the static prefix.
+
+    Those are taught deeply in the always-on corpus, so retrieval must not
+    re-inject them. Auto-syncs: promoting a function to a worked prefix example
+    drops it from retrieval with no code change here.
+    """
+    blocks = ""
+    for path in _PREFIX_FILES:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                blocks += "\n".join(re.findall(r"```.*?```", fh.read(), re.DOTALL))
+        except Exception:  # noqa: BLE001
+            continue
+    return {k for k in base_keys if re.search(r"\b" + re.escape(k) + r"\b", blocks)}
+
+
+_BASE = _load_base()
+_PREFIX_DEEP = _load_prefix_deep(_BASE.keys())
+
+# ── Curated UCMV-legal overrides (the tail traps) ────────────────────────────
+# Each: exact SQL form for a measure expr (source.-qualified, single-source),
+# the dax_class to return, and a one-line note. Keyed by the JSON lookup name.
+# Head functions already deep in the prefix are intentionally omitted here.
+_CURATED: dict[str, dict[str, str | None]] = {
+    # Aggregation (non-obvious)
+    "PRODUCT": {"sql": "EXP(SUM(LN(source.col)))  -- col > 0 only", "cls": "translatable_direct",
+                "note": "no native product aggregate; log-sum-exp identity, positive values only."},
+    "PRODUCTX": {"sql": "EXP(SUM(LN(source.factor)))  -- factor > 0", "cls": "translatable_direct",
+                 "note": "per-row expr collapses into the aggregate; positive values only."},
+    "COUNTBLANK": {"sql": "COUNT(1) - COUNT(source.col)", "cls": "translatable_direct",
+                   "note": "count of NULLs."},
+    "APPROXIMATEDISTINCTCOUNT": {"sql": "approx_count_distinct(source.col)", "cls": "translatable_direct", "note": ""},
+    # Statistical aggregates (these DO appear in measures)
+    "MEDIAN": {"sql": "median(source.col)", "cls": "translatable_direct", "note": "or approx_percentile(source.col, 0.5) on large data."},
+    "MEDIANX": {"sql": "median(source.col)", "cls": "translatable_direct", "note": "iterator collapses to the aggregate."},
+    "PERCENTILE.INC": {"sql": "percentile(source.col, 0.75)", "cls": "translatable_direct", "note": "inclusive."},
+    "PERCENTILEX.INC": {"sql": "percentile(source.col, 0.75)", "cls": "translatable_direct", "note": ""},
+    "PERCENTILE.EXC": {"sql": "percentile_disc(0.75) WITHIN GROUP (ORDER BY source.col)", "cls": "translatable_direct", "note": "exclusive."},
+    "PERCENTILEX.EXC": {"sql": "percentile_disc(0.75) WITHIN GROUP (ORDER BY source.col)", "cls": "translatable_direct", "note": ""},
+    "STDEV.S": {"sql": "stddev_samp(source.col)", "cls": "translatable_direct", "note": ""},
+    "STDEV.P": {"sql": "stddev_pop(source.col)", "cls": "translatable_direct", "note": ""},
+    "STDEVX.S": {"sql": "stddev_samp(source.col)", "cls": "translatable_direct", "note": ""},
+    "STDEVX.P": {"sql": "stddev_pop(source.col)", "cls": "translatable_direct", "note": ""},
+    "VAR.S": {"sql": "var_samp(source.col)", "cls": "translatable_direct", "note": ""},
+    "VAR.P": {"sql": "var_pop(source.col)", "cls": "translatable_direct", "note": ""},
+    "VARX.S": {"sql": "var_samp(source.col)", "cls": "translatable_direct", "note": ""},
+    "VARX.P": {"sql": "var_pop(source.col)", "cls": "translatable_direct", "note": ""},
+    "GEOMEAN": {"sql": "EXP(AVG(LN(source.col)))  -- col > 0", "cls": "translatable_direct", "note": ""},
+    "GEOMEANX": {"sql": "EXP(AVG(LN(source.col)))  -- col > 0", "cls": "translatable_direct", "note": ""},
+    "RANKX": {"sql": None, "cls": "architecture_change",
+              "note": "measures aggregate, they don't rank inline. Rank in the dashboard, or precompute RANK() OVER (ORDER BY <agg> DESC) as a source dimension."},
+    "RANK.EQ": {"sql": None, "cls": "architecture_change",
+                "note": "same as RANKX — dashboard rank or source-view ROW_NUMBER/RANK precompute."},
+    # Math traps
+    "QUOTIENT": {"sql": "DIV(source.a, source.b)", "cls": "translatable_direct", "note": "integer division."},
+    "LOG": {"sql": "LOG(base, source.n)", "cls": "translatable_direct", "note": "ARG ORDER FLIPS vs DAX LOG(n, base)."},
+    "INT": {"sql": "FLOOR(source.x)", "cls": "translatable_direct", "note": ""},
+    "ROUNDDOWN": {"sql": "FLOOR(source.x)", "cls": "translatable_direct", "note": "or TRUNC for toward-zero."},
+    "ROUNDUP": {"sql": "CEIL(source.x)", "cls": "translatable_direct", "note": ""},
+    "CEILING": {"sql": "CEIL(source.x / sig) * sig", "cls": "translatable_direct", "note": "DAX takes a significance arg."},
+    "FLOOR": {"sql": "FLOOR(source.x / sig) * sig", "cls": "translatable_direct", "note": "DAX takes a significance arg."},
+    "ACOT": {"sql": "ATAN(1.0 / source.x)", "cls": "translatable_direct", "note": "no native cot family."},
+    "COT": {"sql": "1.0 / TAN(source.x)", "cls": "translatable_direct", "note": ""},
+    "FACT": {"sql": "FACTORIAL(source.n)", "cls": "translatable_direct", "note": ""},
+    "SQRTPI": {"sql": "SQRT(source.x * PI())", "cls": "translatable_direct", "note": ""},
+    "CURRENCY": {"sql": "CAST(source.x AS DECIMAL(19,4))", "cls": "translatable_direct", "note": ""},
+    "MROUND": {"sql": "ROUND(source.x / m) * m", "cls": "translatable_direct", "note": "round to nearest multiple m."},
+    "EVEN": {"sql": None, "cls": "architecture_change", "note": "round up to even integer — arithmetic UDF or source precompute."},
+    "ODD": {"sql": None, "cls": "architecture_change", "note": "round up to odd integer — arithmetic UDF or source precompute."},
+    "GCD": {"sql": None, "cls": "architecture_change", "note": "no native GCD — UDF."},
+    "LCM": {"sql": None, "cls": "architecture_change", "note": "no native LCM — UDF."},
+    "RANDBETWEEN": {"sql": "FLOOR(RAND() * (hi - lo + 1)) + lo", "cls": "translatable_direct", "note": ""},
+    # Text traps
+    "FIND": {"sql": "INSTR(source.hay, 'needle')", "cls": "translatable_direct", "note": "ARG ORDER SWAPS (DAX needle-first); FIND is case-sensitive."},
+    "SEARCH": {"sql": "INSTR(LOWER(source.hay), LOWER('needle'))", "cls": "translatable_direct", "note": "ARG ORDER SWAPS; SEARCH is case-insensitive → LOWER both sides."},
+    "REPLACE": {"sql": "OVERLAY(source.text PLACING 'new' FROM start FOR len)", "cls": "translatable_direct", "note": "positional REPLACE; NOT value-based (that's SUBSTITUTE → REPLACE())."},
+    "SUBSTITUTE": {"sql": "REPLACE(source.text, 'old', 'new')", "cls": "translatable_direct", "note": "value-based replace."},
+    "FIXED": {"sql": "format_number(source.x, d)", "cls": "display_layer", "note": "returns a STRING; if a rounded number is intended use ROUND(source.x, d) and flag."},
+    "COMBINEVALUES": {"sql": "CONCAT_WS('delim', source.a, source.b)", "cls": "translatable_direct", "note": ""},
+    "VALUE": {"sql": "TRY_CAST(source.s AS DOUBLE)", "cls": "translatable_direct", "note": "text → number."},
+    "CONCATENATEX": {"sql": None, "cls": "display_layer", "note": "string aggregation for a label, not a metric. If a real delimited value: array_join(collect_list(source.col), 'd')."},
+    "UNICHAR": {"sql": "CHR(source.n)", "cls": "translatable_direct", "note": ""},
+    "UNICODE": {"sql": "ASCII(source.s)", "cls": "translatable_direct", "note": ""},
+    # Date traps
+    "DATEDIFF": {"sql": "DATEDIFF(source.b, source.a)  -- DAY; months_between(source.b, source.a) for MONTH/QTR/YEAR", "cls": "translatable_direct", "note": "ARG ORDER SWAPS vs DAX; unit-dependent function."},
+    "EDATE": {"sql": "add_months(source.d, n)", "cls": "translatable_direct", "note": ""},
+    "EOMONTH": {"sql": "last_day(add_months(source.d, n))", "cls": "translatable_direct", "note": ""},
+    "YEARFRAC": {"sql": "datediff(source.b, source.a) / 365.25", "cls": "translatable_direct", "note": "approximation; day-count basis ignored — flag if basis matters."},
+    "NETWORKDAYS": {"sql": None, "cls": "architecture_change", "note": "business-day count — source-view calendar precompute or UDF."},
+    "WEEKDAY": {"sql": "DAYOFWEEK(source.d)", "cls": "translatable_direct", "note": ""},
+    "WEEKNUM": {"sql": "WEEKOFYEAR(source.d)", "cls": "translatable_direct", "note": ""},
+    # Parent-child (recursive → source view)
+    "PATH": {"sql": None, "cls": "architecture_change", "note": "recursive CTE in the source view exposing a `path` column: WITH RECURSIVE anc AS (... UNION ALL ...)."},
+    "PATHITEM": {"sql": "element_at(split(source.path, '|'), n)", "cls": "translatable_direct", "note": "requires `path` precomputed (see PATH)."},
+    "PATHITEMREVERSE": {"sql": "element_at(split(source.path, '|'), -n)", "cls": "translatable_direct", "note": "requires `path`."},
+    "PATHLENGTH": {"sql": "size(split(source.path, '|'))", "cls": "translatable_direct", "note": "requires `path`."},
+    "PATHCONTAINS": {"sql": "array_contains(split(source.path, '|'), 'x')", "cls": "translatable_direct", "note": "requires `path`."},
+    # Relationship
+    "RELATEDTABLE": {"sql": None, "cls": "architecture_change", "note": "aggregate over a declared join; if it needs a grain change, precompute in source. Never a cross-table subquery."},
+    # Table manipulation (tail)
+    "TOPN": {"sql": None, "cls": "architecture_change", "note": "row-selection; source-view ROW_NUMBER() OVER (ORDER BY … DESC) filtered =1 (or QUALIFY). Never a bare MAX."},
+    "GENERATE": {"sql": None, "cls": "architecture_change", "note": "lateral join belongs in the source view."},
+    "GENERATEALL": {"sql": None, "cls": "architecture_change", "note": "outer lateral join in the source view."},
+    "CROSSJOIN": {"sql": None, "cls": "architecture_change", "note": "set/join op belongs in the source view, not a measure."},
+    "UNION": {"sql": None, "cls": "architecture_change", "note": "UNION ALL belongs in the source view."},
+    "INTERSECT": {"sql": None, "cls": "architecture_change", "note": "set op in the source view."},
+    "EXCEPT": {"sql": None, "cls": "architecture_change", "note": "set op in the source view."},
+    # Financial closed-forms (inline arithmetic); iterative ones decline
+    "SLN": {"sql": "(source.cost - source.salvage) / source.life", "cls": "translatable_direct", "note": "straight-line depreciation."},
+    "EFFECT": {"sql": "POWER(1 + source.rate / source.n, source.n) - 1", "cls": "translatable_direct", "note": ""},
+    "NOMINAL": {"sql": "source.n * (POWER(1 + source.eff, 1.0/source.n) - 1)", "cls": "translatable_direct", "note": ""},
+    "RRI": {"sql": "POWER(source.fv / source.pv, 1.0/source.n) - 1", "cls": "translatable_direct", "note": ""},
+    "PDURATION": {"sql": "LOG(1 + source.rate, source.fv / source.pv)", "cls": "translatable_direct", "note": ""},
+    "XIRR": {"sql": None, "cls": "architecture_change", "note": "iterative solve — existing UC UDF or source precompute. Never invent a UDF name."},
+    "RATE": {"sql": None, "cls": "architecture_change", "note": "iterative — UDF."},
+    "XNPV": {"sql": None, "cls": "architecture_change", "note": "cash-flow sum over dates — source-view aggregate or UDF."},
+    # Information context tests → decline
+    "HASONEVALUE": {"sql": None, "cls": "unsupported", "note": "filter-context test; no metric-view meaning."},
+    "ISFILTERED": {"sql": None, "cls": "unsupported", "note": "visual filter-context test — skip guard."},
+    "ISCROSSFILTERED": {"sql": None, "cls": "unsupported", "note": "filter-context test — skip."},
+    "NAMEOF": {"sql": None, "cls": "unsupported", "note": "metadata name reference — not a metric."},
+}
+
+
+def detect_functions(dax_expressions: Iterable[str]) -> list[str]:
+    """Return the sorted set of known DAX function names used across the expressions."""
+    found: set[str] = set()
+    for expr in dax_expressions:
+        if not expr:
+            continue
+        for tok in _TOKEN.findall(expr):
+            if tok in _BASE:
+                found.add(tok)
+    return sorted(found)
+
+
+def _render_entry(name: str) -> str:
+    base = _BASE.get(name, {})
+    cat = base.get("category", "")
+    feas = base.get("feasibility", "")
+    dax_ex = base.get("dax_example", "")
+    cur = _CURATED.get(name)
+    if cur:
+        cls = cur["cls"]
+        head = f"### {name} — {cat} · {feas} → {cls}"
+        sql = cur["sql"]
+        sql_line = f"  SQL:  {sql}" if sql else "  SQL:  (not a measure expr — see note)"
+        note = f"\n  note: {cur['note']}" if cur.get("note") else ""
+        return f"{head}\n  DAX:  {dax_ex}\n{sql_line}{note}"
+    # base (uncurated) — carry the generic SQL with an explicit adaptation caveat
+    cls = base.get("default_dax_class", "")
+    raw = base.get("sql_reference_raw", "")
+    head = f"### {name} — {cat} · {feas} → {cls} (default)"
+    return (f"{head}\n  DAX:  {dax_ex}\n"
+            f"  SQL (generic — adapt per §0: source.-qualify args, single-source only): {raw}")
+
+
+def render_function_refs(dax_expressions: Iterable[str], max_render: int = _MAX_RENDER) -> str:
+    """Build a markdown reference block for the tail functions used in this batch.
+
+    Skips functions already taught deeply in the always-on prefix. Returns '' when
+    nothing tail-relevant is used (the common case for simple batches). Fail-open.
+    """
+    try:
+        if not _BASE:
+            return ""
+        names = [n for n in detect_functions(dax_expressions) if n not in _PREFIX_DEEP]
+        if not names:
+            return ""
+        names = names[:max_render]
+        curated = [n for n in names if n in _CURATED]
+        logger.info(
+            "[FUNC_REF] injected %d tail function ref(s): %s (curated: %s)",
+            len(names), names, curated,
+        )
+        body = "\n\n".join(_render_entry(n) for n in names)
+        return (
+            "\n## DAX function reference (functions in these measures not already "
+            "covered above)\n"
+            "Authoritative UCMV-legal forms — follow these; obey §0 (source.-qualify, "
+            "single-source). Entries marked (default) are generic references to adapt.\n\n"
+            f"{body}\n"
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[FUNC_REF] render failed (fail-open): %s", e)
+        return ""

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/generated_table_emitter.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/generated_table_emitter.py
@@ -1,0 +1,143 @@
+"""Generated-table SQL emitter (KASAL_FIXES Gap 3, materialization step).
+
+Some Power Query tables are computed entirely in M with no physical source — the
+classic case is a **calendar** built with ``List.Dates`` + ``Table.AddColumn``
+steps. A UC metric view can't reference a table that doesn't exist, so this module
+turns that M into a runnable ``CREATE OR REPLACE VIEW`` (Databricks SQL) that
+reproduces the same rows/columns. `physical_name_resolver` detects these tables;
+this emits the SQL to materialize them.
+
+Scope: the ``List.Dates`` calendar pattern (covers virtually every PBI date dim).
+For AddColumn expressions it can't translate it emits the column as a
+``/* TODO */`` placeholder rather than dropping it, so the view is never silently
+wrong — the reviewer sees exactly what needs a hand.
+"""
+
+from __future__ import annotations
+
+import re
+
+_LIST_DATES = re.compile(r"\bList\.Dates\b")
+# #date(Y, M, D)
+_DATE_LIT = re.compile(r"#date\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)")
+_ADDCOL_START = re.compile(r"Table\.AddColumn\(")
+_TRAILING_TYPE = re.compile(r",\s*(?:Int64\.Type|type\s+\w+|[A-Za-z0-9_.]+\.Type)\s*$")
+
+
+def _find_addcols(m_expr: str) -> list[tuple[str, str]]:
+    """Extract (column_name, M expression body) for each Table.AddColumn(...),
+    using a balanced-paren scan so nested calls (Text.From(Date.X([Date]))) and
+    quoted prev-step names (#"Renamed Columns") are handled correctly."""
+    out: list[tuple[str, str]] = []
+    for start in _ADDCOL_START.finditer(m_expr):
+        i = start.end() - 1  # index of the opening '('
+        depth, j = 0, i
+        while j < len(m_expr):
+            c = m_expr[j]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        args = m_expr[i + 1 : j]
+        em = re.search(r"\beach\b", args)
+        if not em:
+            continue
+        names = re.findall(
+            r'"([^"]+)"', args[: em.start()]
+        )  # last quoted before `each`
+        if not names:
+            continue
+        body = _TRAILING_TYPE.sub("", args[em.end() :].strip()).strip()
+        out.append((names[-1], body))
+    return out
+
+
+# M Date.ToText format token → Spark date_format token (mostly identical; the day
+# name differs: M 'dddd'/'ddd' → Spark 'EEEE'/'EEE').
+def _map_fmt(fmt: str) -> str:
+    fmt = fmt.replace("dddd", "EEEE").replace("ddd", "EEE")
+    return fmt
+
+
+def _m_scalar_to_sql(expr: str) -> str | None:
+    """Translate one M column expression (body of ``each …``) to Spark SQL over the
+    date column ``d``. Returns None if it contains constructs we don't handle."""
+    s = expr.strip()
+    s = s.replace("[Date]", "d")
+
+    # Date.ToText(d, "fmt")  → date_format(d, 'fmt')
+    s = re.sub(
+        r'Date\.ToText\(\s*d\s*,\s*"([^"]*)"\s*\)',
+        lambda m: f"date_format(d, '{_map_fmt(m.group(1))}')",
+        s,
+    )
+    # Date.Year / Month / Day / QuarterOfYear / WeekOfYear
+    s = re.sub(r"Date\.Year\(\s*d\s*\)", "year(d)", s)
+    s = re.sub(r"Date\.Month\(\s*d\s*\)", "month(d)", s)
+    s = re.sub(r"Date\.Day\(\s*d\s*\)", "day(d)", s)
+    s = re.sub(r"Date\.QuarterOfYear\(\s*d\s*\)", "quarter(d)", s)
+    s = re.sub(r"Date\.WeekOfYear\(\s*d\s*\)", "weekofyear(d)", s)
+    # Date.DayOfWeek(d, Day.Monday)  → weekday(d)  (Spark weekday: Mon=0, matches M Day.Monday base)
+    s = re.sub(r"Date\.DayOfWeek\(\s*d\s*,\s*Day\.\w+\s*\)", "weekday(d)", s)
+    # Text.From(x) → the inner expression (Spark concat/|| coerce implicitly; wrap in string())
+    s = re.sub(r"Text\.From\(\s*(.*?)\s*\)", r"string(\1)", s)
+    # M string concat '&' → SQL '||'
+    s = s.replace("&", "||")
+    # Text.PadStart(x, n, "c") → lpad(x, n, 'c')
+    s = re.sub(
+        r'Text\.PadStart\(\s*(.*?)\s*,\s*(\d+)\s*,\s*"([^"]*)"\s*\)',
+        r"lpad(\1, \2, '\3')",
+        s,
+    )
+    # bare double-quoted string literals → single-quoted
+    s = re.sub(r'"([^"]*)"', r"'\1'", s)
+
+    # If anything M-specific survived, we can't safely translate it.
+    if re.search(r"\b(Date|Time|Text|Number|List|Table)\.", s) or "#" in s:
+        return None
+    return s
+
+
+def emit_view_sql(m_expr: str, fqn: str) -> str | None:
+    """Emit a CREATE OR REPLACE VIEW that reproduces a generated calendar table.
+
+    Args:
+        m_expr: the table's Power Query M.
+        fqn: fully-qualified view name to create (e.g. `cat`.`sch`.`date`).
+
+    Returns the SQL string, or None if it isn't a List.Dates calendar we can emit.
+    """
+    if not m_expr or not _LIST_DATES.search(m_expr):
+        return None
+    lits = _DATE_LIT.findall(m_expr)
+    if len(lits) < 2:
+        return None  # need a start and an end #date literal
+    (sy, sm, sd), (ey, em, ed) = lits[0], lits[1]
+    start = f"{int(sy):04d}-{int(sm):02d}-{int(sd):02d}"
+    end = f"{int(ey):04d}-{int(em):02d}-{int(ed):02d}"
+
+    cols = ["d AS `date`"]
+    todo = 0
+    for name, body in _find_addcols(m_expr):
+        sql = _m_scalar_to_sql(body)
+        col = f"`{name}`"
+        if sql is None:
+            cols.append(f"/* TODO translate M: {body.strip()[:80]} */ NULL AS {col}")
+            todo += 1
+        else:
+            cols.append(f"{sql} AS {col}")
+
+    select = ",\n    ".join(cols)
+    header = (
+        f"-- Auto-generated from a Power Query List.Dates calendar (no physical source).\n"
+        f"-- Reproduces the M-computed date dimension so metric views can join it.\n"
+    )
+    if todo:
+        header += f"-- NOTE: {todo} column(s) need manual translation (see /* TODO */ below).\n"
+    return (
+        f"{header}CREATE OR REPLACE VIEW {fqn} AS\nSELECT\n    {select}\n"
+        f"FROM (SELECT explode(sequence(DATE'{start}', DATE'{end}', INTERVAL 1 DAY)) AS d);"
+    )

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/mquery_let_evaluator.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/mquery_let_evaluator.py
@@ -1,0 +1,332 @@
+"""M ``let`` block evaluator — resolves a narrow, common subset of Power Query M
+(string-literal concatenation of PBI parameters and local variables) to a
+literal string, without a general M interpreter.
+
+Why this exists: some PBI models build a table's physical source (or its whole
+native-query text) at model-open time from parameters rather than a literal —
+e.g.::
+
+    Object = "hub_product_" & Table_Version,
+    FromClause = Catalog_Name & "." & Database & "." & Object,
+    VersionFilter = if Table_Version = "v2" then " AND version = '" & Version_Type & "'" else "",
+    NativeQuery = Value.NativeQuery(Data_Mesh, "select ... from "& FromClause &" WHERE ..." & VersionFilter, ...)
+
+The physical table only exists after substituting each parameter's *current*
+value (itself a separate named expression in the model — see
+``extract_parameter_defaults``). Admin Scanner / Fabric TMDL both expose those
+current values, so this is fully resolvable without an LLM — but only when
+every step is one of the handful of shapes below. Anything else (a function
+call we don't recognise, a condition we can't evaluate, a reference to an
+unresolved name) makes the whole table return ``None`` — this never guesses; a
+wrong physical table silently wires a bad source.
+"""
+
+from __future__ import annotations
+
+import re
+
+# A PBI parameter query: a literal string tagged as its own value, e.g.
+#   "dc_datalake_prod_001" meta [IsParameterQuery = true, Type = "Text"]
+_PARAMETER_RE = re.compile(
+    r'^\s*"((?:[^"]|"")*)"\s*meta\s*\[[^\]]*IsParameterQuery\s*=\s*true',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def extract_parameter_defaults(expressions: dict[str, str]) -> dict[str, str]:
+    """Pull ``{name: current_value}`` for every M parameter query in ``expressions``.
+
+    ``expressions`` is the ``{name: raw_M}`` map of a model's named/shared
+    expressions (``generate_config.parse_admin_expressions`` /
+    ``parse_tmdl_expressions``) — parameters are simply expressions tagged
+    ``IsParameterQuery = true``, indistinguishable from ordinary shared
+    queries except by that tag.
+    """
+    params: dict[str, str] = {}
+    for name, expr in (expressions or {}).items():
+        if not name or not isinstance(expr, str):
+            continue
+        m = _PARAMETER_RE.match(expr.strip())
+        if m:
+            params[name] = m.group(1).replace('""', '"')
+    return params
+
+
+def _skip_string(text: str, i: int) -> int:
+    """Given ``text[i] == '"'``, return the index just past the closing quote
+    (M doubles an embedded quote as ``""``, so ``"a""b"`` is one string)."""
+    j = i + 1
+    n = len(text)
+    while j < n:
+        if text[j] == '"':
+            if j + 1 < n and text[j + 1] == '"':
+                j += 2
+                continue
+            return j + 1
+        j += 1
+    return n  # unterminated — caller's depth tracking will simply run out
+
+
+def _split_top_level(text: str, sep_chars: str) -> list[str]:
+    """Split ``text`` on any of ``sep_chars`` that sit at depth 0, outside a
+    quoted string. Depth tracks ``()``, ``{}``, ``[]`` — all M's grouping forms."""
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            i = _skip_string(text, i)
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif depth == 0 and ch in sep_chars:
+            parts.append(text[start:i])
+            start = i + 1
+        i += 1
+    parts.append(text[start:])
+    return parts
+
+
+def _find_top_level_word(text: str, word: str) -> int:
+    """Index of the first top-level, whole-word occurrence of ``word`` in
+    ``text`` (depth 0, outside a string), or -1."""
+    depth = 0
+    i = 0
+    n = len(text)
+    wl = len(word)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            i = _skip_string(text, i)
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif depth == 0 and text[i : i + wl] == word:
+            before_ok = i == 0 or not (text[i - 1].isalnum() or text[i - 1] == "_")
+            after_idx = i + wl
+            after_ok = after_idx >= n or not (
+                text[after_idx].isalnum() or text[after_idx] == "_"
+            )
+            if before_ok and after_ok:
+                return i
+        i += 1
+    return -1
+
+
+def _extract_let_block(mquery: str) -> tuple[list[str], str] | None:
+    """Split a *single, non-nested* ``let <bindings> in <expr>`` into its raw
+    binding strings and the final expression. Returns ``None`` for anything
+    else (no let block, or a nested let — deliberately not supported: two
+    top-level ``let``s would make the naive first-``in``-wins split wrong)."""
+    s = mquery.strip()
+    if not re.match(r"^let\b", s, re.IGNORECASE):
+        return None
+    body = s[3:]  # past "let"
+    # A second top-level "let" means nesting — bail rather than mis-split.
+    if _find_top_level_word(body, "let") != -1:
+        return None
+    in_idx = _find_top_level_word(body, "in")
+    if in_idx == -1:
+        return None
+    bindings_text = body[:in_idx]
+    final_expr = body[in_idx + 2 :].strip()
+    bindings = [b.strip() for b in _split_top_level(bindings_text, ",") if b.strip()]
+    return bindings, final_expr
+
+
+def _parse_binding(binding: str) -> tuple[str, str] | None:
+    """Split ``Name = Expression`` on the first top-level bare ``=`` (not
+    ``==``, ``<=``, ``>=``, ``<>``)."""
+    depth = 0
+    i = 0
+    n = len(binding)
+    while i < n:
+        ch = binding[i]
+        if ch == '"':
+            i = _skip_string(binding, i)
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif depth == 0 and ch == "=":
+            prev_ch = binding[i - 1] if i > 0 else ""
+            next_ch = binding[i + 1] if i + 1 < n else ""
+            if next_ch != "=" and prev_ch not in ("=", "<", ">", "!"):
+                name = binding[:i].strip()
+                if re.fullmatch(r'#?"?[\w ]+"?', name):
+                    return name.strip('#"'), binding[i + 1 :].strip()
+                return None
+        i += 1
+    return None
+
+
+def _eval_string_literal(expr: str) -> str | None:
+    if len(expr) >= 2 and expr[0] == '"' and _skip_string(expr, 0) == len(expr):
+        return expr[1:-1].replace('""', '"')
+    return None
+
+
+def _eval_expr(expr: str, env: dict[str, str | None]) -> str | None:
+    """Evaluate the narrow expression grammar this module supports. ``None``
+    on anything unrecognised or referencing an unresolved name — never guess."""
+    e = expr.strip()
+    if not e:
+        return None
+
+    lit = _eval_string_literal(e)
+    if lit is not None:
+        return lit
+
+    # if <cond> then <A> else <B> — cond limited to `<expr> = <expr>` so it
+    # can be evaluated with the same machinery (see _eval_condition).
+    if_idx = _find_top_level_word(e, "if")
+    if if_idx == 0:
+        then_idx = _find_top_level_word(e, "then")
+        else_idx = _find_top_level_word(e, "else")
+        if then_idx != -1 and else_idx != -1 and then_idx < else_idx:
+            cond = e[2:then_idx].strip()
+            branch_a = e[then_idx + 4 : else_idx].strip()
+            branch_b = e[else_idx + 4 :].strip()
+            verdict = _eval_condition(cond, env)
+            if verdict is None:
+                return None
+            return _eval_expr(branch_a if verdict else branch_b, env)
+        return None
+
+    # Text.From(<expr>) — our params/locals are already text; unwrap.
+    tf_match = re.match(r"^Text\.From\s*\((.*)\)$", e, re.DOTALL)
+    if tf_match:
+        return _eval_expr(tf_match.group(1), env)
+
+    # A & B & C ... — string concatenation, only if every operand resolves.
+    amp_parts = _split_top_level(e, "&")
+    if len(amp_parts) > 1:
+        out = []
+        for part in amp_parts:
+            v = _eval_expr(part, env)
+            if v is None:
+                return None
+            out.append(v)
+        return "".join(out)
+
+    # Bare identifier — look up in the environment (parameters + earlier
+    # bindings). Unresolved / unknown → fail rather than guess.
+    if re.fullmatch(r"[A-Za-z_]\w*", e):
+        return env.get(e)
+
+    return None
+
+
+def _eval_condition(cond: str, env: dict[str, str | None]) -> bool | None:
+    """Evaluate ``<expr> = <expr>`` (the only condition shape supported)."""
+    eq_idx = _find_top_level_word(cond, "=")
+    # '=' isn't a "word" by _find_top_level_word's alnum boundary rule, so
+    # locate it directly instead, guarding against '==' / '<=' / '>=' / '!='.
+    depth = 0
+    i = 0
+    n = len(cond)
+    eq_idx = -1
+    while i < n:
+        ch = cond[i]
+        if ch == '"':
+            i = _skip_string(cond, i)
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif depth == 0 and ch == "=":
+            prev_ch = cond[i - 1] if i > 0 else ""
+            next_ch = cond[i + 1] if i + 1 < n else ""
+            if next_ch != "=" and prev_ch not in ("=", "<", ">", "!"):
+                eq_idx = i
+                break
+        i += 1
+    if eq_idx == -1:
+        return None
+    left = _eval_expr(cond[:eq_idx], env)
+    right = _eval_expr(cond[eq_idx + 1 :], env)
+    if left is None or right is None:
+        return None
+    return left == right
+
+
+def _extract_call_args(text: str, call_prefix_end: int) -> list[str] | None:
+    """Given ``text`` and the index just past a call's opening ``(``, return
+    the top-level comma-separated argument strings (the call's own closing
+    paren excluded), or ``None`` if the parens never balance."""
+    depth = 1
+    i = call_prefix_end
+    n = len(text)
+    start = i
+    args: list[str] = []
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            i = _skip_string(text, i)
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+            if depth == 0:
+                args.append(text[start:i])
+                return args
+        elif depth == 1 and ch == ",":
+            args.append(text[start:i])
+            start = i + 1
+        i += 1
+    return None  # unbalanced
+
+
+def resolve_via_let_evaluation(mquery: str, known_params: dict[str, str]) -> str | None:
+    """Resolve a parameter-driven ``Value.NativeQuery`` M source to literal SQL.
+
+    Evaluates every ``let`` binding in order (seeding the environment with
+    ``known_params``), then evaluates the SQL-text argument of whichever
+    binding calls ``Value.NativeQuery`` — itself just another expression in
+    the same grammar, so the same evaluator resolves it once every parameter
+    and local variable it references has resolved. Returns ``None`` if no
+    ``Value.NativeQuery`` call is found, or if anything along the way can't be
+    confidently evaluated.
+    """
+    if not mquery or not isinstance(mquery, str) or not known_params:
+        return None
+    parsed = _extract_let_block(mquery)
+    if not parsed:
+        return None
+    bindings, _final_expr = parsed
+
+    env: dict[str, str | None] = dict(known_params)
+    native_query_sql_arg: str | None = None
+
+    for raw in bindings:
+        pb = _parse_binding(raw)
+        if not pb:
+            continue
+        name, raw_expr = pb
+
+        nq_idx = _find_top_level_word(raw_expr, "Value.NativeQuery")
+        if nq_idx != -1:
+            paren_idx = raw_expr.find("(", nq_idx + len("Value.NativeQuery"))
+            if paren_idx != -1:
+                args = _extract_call_args(raw_expr, paren_idx + 1)
+                if args and len(args) >= 2:
+                    native_query_sql_arg = args[1]
+            # A binding invoking Value.NativeQuery doesn't itself need to
+            # resolve to a plain string — skip normal evaluation for it.
+            continue
+
+        env[name] = _eval_expr(raw_expr, env)
+
+    if native_query_sql_arg is None:
+        return None
+    return _eval_expr(native_query_sql_arg, env)

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/mquery_parser.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/mquery_parser.py
@@ -18,6 +18,18 @@ from .data_classes import TableInfo
 
 logger = logging.getLogger(__name__)
 
+# Connector functions for "Get Data → browse catalog/schema/table" navigation
+# UIs. Not Databricks-specific: Snowflake/Postgres/MySQL/Oracle/Redshift/
+# BigQuery's catalog-browse connectors emit the identical [Name=,Kind=]
+# navigation-chain shape (a shared Power Query SDK convention), so the same
+# regex walk in extract_source_table/resolve_mquery_to_sql applies to all of
+# them — only the connector-function gate below differs per family.
+_CATALOG_NAV_CONNECTORS = re.compile(
+    r'\b(Databricks\.\w+|Snowflake\.Databases|PostgreSQL\.Database|'
+    r'MySQL\.Database|Oracle\.Database|AmazonRedshift\.Database|'
+    r'GoogleBigQuery\.Database)\b'
+)
+
 
 def looks_like_raw_mquery(sql: str) -> bool:
     """Heuristic: does this string look like raw Power Query M rather than SQL?
@@ -46,12 +58,17 @@ def classify_mquery_source(mquery: str) -> tuple[str, str]:
     """Classify a raw Power Query M source expression that produced no SQL.
 
     Returns ``(category, human_reason)``. Categories:
-      * ``inline_const``  — hardcoded table (`Table.FromRows(Json.Document(
-        Binary.Decompress(Binary.FromText("…Base64"))))`): a slicer/selector
-        helper. No warehouse source — correctly skipped.
+      * ``inline_const``  — hardcoded table: either `Table.FromRows(Json.
+        Document(Binary.Decompress(Binary.FromText("…Base64"))))` (a slicer/
+        selector helper) or `Table.FromRows({...literal rows...})` written
+        out in plain M with no base64 wrapper. No warehouse source —
+        correctly skipped.
       * ``dax_calc``      — DAX-defined calculated table (`GENERATESERIES`,
-        `SUMMARIZECOLUMNS`, `VALUES(...)`, `Row(...)`, parameter query): computed
-        in-model, no source SQL exists — correctly skipped.
+        `SUMMARIZE`/`SUMMARIZECOLUMNS`, `CALCULATETABLE`, `VALUES(...)`,
+        `Row(...)`, a bare `{ (...), (...) }` tuple-literal table
+        constructor, parameter query): computed in-model from other
+        already-loaded tables, no independent source SQL exists — correctly
+        skipped.
       * ``external``      — non-warehouse connector (`Access.Database`,
         `Excel.Workbook`, `PowerBI.Dataflows`, `AnalysisServices`): source lives
         outside the lakehouse; needs a customer-supplied mapping.
@@ -72,8 +89,22 @@ def classify_mquery_source(mquery: str) -> tuple[str, str]:
         return ('inline_const',
                 'inline constant table (slicer/selector helper, base64-embedded) — '
                 'no warehouse source; correctly skipped')
-    if re.search(r'\b(GENERATESERIES|SUMMARIZECOLUMNS|ADDCOLUMNS|SELECTCOLUMNS|VALUES|CALENDAR|CALENDARAUTO)\s*\(', mu) \
+    if re.search(r'Table\.FromRows\s*\(\s*\{', m):
+        return ('inline_const',
+                'inline constant table (hardcoded literal rows) — '
+                'no warehouse source; correctly skipped')
+    # (?<!\.) excludes M's dotted standard-library calls (Table.SelectColumns,
+    # Table.AddColumns, ...) — DAX never namespaces a function with a leading
+    # dot, so a bare match preceded by "." is always M, not the DAX function of
+    # the same name. Without this, a Databricks.Catalogs (or any other
+    # catalog-nav) source with an ordinary Table.SelectColumns step downstream
+    # got mis-classified as 'dax_calc' and short-circuited before ever reaching
+    # the 'extractable' branch — an M source with a real physical table lost
+    # to a DAX-function-name collision purely because it also selected columns.
+    if re.search(r'(?<!\.)\b(GENERATESERIES|SUMMARIZECOLUMNS|SUMMARIZE|CALCULATETABLE|'
+                 r'ADDCOLUMNS|SELECTCOLUMNS|VALUES|CALENDAR|CALENDARAUTO)\s*\(', mu) \
             or re.match(r'^\s*ROW\s*\(', mu) \
+            or re.match(r'^\s*\{\s*\(', m) \
             or re.search(r'IsParameterQuery\s*=\s*true', m, re.IGNORECASE):
         return ('dax_calc',
                 'DAX calculated table / parameter query — computed in-model, '
@@ -83,10 +114,12 @@ def classify_mquery_source(mquery: str) -> tuple[str, str]:
         return ('external',
                 'non-warehouse external source (dataflow / file / AAS) — needs a '
                 'customer-supplied source-table mapping')
-    if re.search(r'\b(Value\.NativeQuery|Sql\.Databases?|Databricks\.\w+|Spark\.)\b', m):
+    if (re.search(r'\b(Value\.NativeQuery|Sql\.Databases?|Spark\.)\b', m)
+            or _CATALOG_NAV_CONNECTORS.search(m)):
         return ('extractable',
-                'looks extractable (native query / Databricks connector) but no '
-                'source table was resolved — extraction gap, investigate')
+                'looks extractable (native query / catalog-browsing warehouse '
+                'connector) but no source table was resolved — extraction gap, '
+                'investigate')
     return ('unknown', 'unrecognized M source shape')
 
 
@@ -120,14 +153,23 @@ def extract_source_table(mquery: str) -> str | None:
 
     # 1. Databricks.Catalogs(...){[Name="cat"]}[Data]{[Name="sch"]}[Data]{[Name="tbl"]}[Data]
     #    — walk the ordered [Name="…"] navigation chain (catalog, schema, table).
-    if re.search(r'\bDatabricks\.\w+', m):
-        names = re.findall(r'\[\s*Name\s*=\s*"([^"]+)"', m)
+    #    Not Databricks-specific: Snowflake/Postgres/MySQL/Oracle/Redshift/BigQuery
+    #    "Get Data" catalog-browse connectors emit the identical [Name=,Kind=] chain
+    #    shape (a shared Power Query SDK convention), so the same walk applies.
+    if re.search(_CATALOG_NAV_CONNECTORS, m):
+        # M quotes an identifier as #"like this" whenever it isn't a valid bare
+        # identifier (contains spaces, etc) — e.g. [Name=#"Databricks Data Catalog"].
+        # The leading `#` sat between `=` and `"` and was never matched, so a
+        # catalog name needing quoting silently dropped out of `names` and the
+        # chain fell one short of 3 — always resolving to None even though the
+        # M was fully resolvable. `#?` makes the `#` optional either way.
+        names = re.findall(r'\[\s*Name\s*=\s*#?"([^"]+)"', m)
         if len(names) >= 3:
             return f'{names[0]}.{names[1]}.{names[2]}'
         # Some connectors expose a Catalog/Schema/Table keyed nav instead.
-        cat = re.search(r'\[\s*Catalog\s*=\s*"([^"]+)"', m)
-        sch = re.search(r'\[\s*(?:Schema|Database)\s*=\s*"([^"]+)"', m)
-        tbl = re.search(r'\[\s*(?:Item|Table)\s*=\s*"([^"]+)"', m)
+        cat = re.search(r'\[\s*Catalog\s*=\s*#?"([^"]+)"', m)
+        sch = re.search(r'\[\s*(?:Schema|Database)\s*=\s*#?"([^"]+)"', m)
+        tbl = re.search(r'\[\s*(?:Item|Table)\s*=\s*#?"([^"]+)"', m)
         if cat and sch and tbl:
             return f'{cat.group(1)}.{sch.group(1)}.{tbl.group(1)}'
 
@@ -156,6 +198,230 @@ def extract_source_table(mquery: str) -> str | None:
         return '.'.join(_unquote(p) for p in bare.groups())
 
     return None
+
+
+def _quote_sql_ident(name: str) -> str:
+    """Backtick-quote a SQL identifier unless it's already a plain token.
+
+    ``extract_source_table`` returns the FQN un-quoted (existing callers use it
+    as a plain dotted config value, e.g. ``join_key_map[dim].source_table``),
+    but a catalog/schema/column name containing a space or other special
+    character (M's connector nav routinely surfaces these, e.g. a catalog
+    literally named ``Databricks Data Catalog``) is not valid unquoted SQL —
+    ``resolve_mquery_to_sql`` must quote it before it lands in a FROM/SELECT.
+    """
+    if re.fullmatch(r'[A-Za-z_]\w*', name):
+        return name
+    return '`' + name.replace('`', '``') + '`'
+
+
+def resolve_mquery_to_sql(mquery: str) -> str | None:
+    """Deterministically compile an *extractable* M source into a compact SQL
+    string — ``SELECT col, col2 AS alias, ... FROM catalog.schema.table`` —
+    that the downstream ``MQueryParser`` (SQL-only) can read directly.
+
+    This is what closes the gap for "click-together" M authored via a
+    catalog-browse connector (``Databricks.Catalogs`` et al): those sources
+    have no embedded SQL text for the parser to find, and previously the only
+    way to recover them was routing the FULL raw M through an LLM. Query
+    folding for this shape is trivial and fully structural — a source
+    navigation chain plus, at most, a column projection/rename — so it needs
+    no LLM: same physical-table resolution as ``extract_source_table``, plus a
+    best-effort read of a following ``Table.SelectColumns``/``RenameColumns``
+    step pair for the projected column list.
+
+    Returns ``None`` when the source table itself can't be resolved (caller
+    then falls back to the LLM path or skips the table, per the same policy
+    for a bare ``extract_source_table`` miss). Never invents a JOIN or a
+    filter — those M shapes are more varied and are left to the LLM fallback.
+    """
+    fqn = extract_source_table(mquery)
+    if not fqn:
+        return None
+    m = mquery
+
+    # Table.SelectColumns(<prevStep>, {"a","b","c"}) — projected column list,
+    # order preserved. Absent → keep every source column (SELECT *).
+    select_cols: list[str] = []
+    sel_match = re.search(r'Table\.SelectColumns\s*\([^,]+,\s*\{([^}]*)\}', m)
+    if sel_match:
+        select_cols = re.findall(r'"([^"]+)"', sel_match.group(1))
+
+    # Table.RenameColumns(<prevStep>, {{"old","new"}, {"old2","new2"}, ...})
+    # — old→new alias map, applied over the projected list (if any).
+    renames: dict[str, str] = {}
+    ren_match = re.search(r'Table\.RenameColumns\s*\([^,]+,\s*\{(.*?)\}\s*\)', m, re.DOTALL)
+    if ren_match:
+        for pair in re.finditer(r'\{\s*"([^"]+)"\s*,\s*"([^"]+)"\s*\}', ren_match.group(1)):
+            renames[pair.group(1)] = pair.group(2)
+
+    if select_cols:
+        projected = [
+            (f'{_quote_sql_ident(c)} AS {_quote_sql_ident(renames[c])}'
+             if renames.get(c) and renames[c] != c else _quote_sql_ident(c))
+            for c in select_cols
+        ]
+        select_clause = ', '.join(projected)
+    else:
+        select_clause = '*'
+
+    fqn_quoted = '.'.join(_quote_sql_ident(p) for p in fqn.split('.'))
+    return f'SELECT {select_clause} FROM {fqn_quoted}'
+
+
+# A table whose M is nothing but a passthrough to another named expression —
+# a disabled "staging query" referenced by the tables that actually load. Two
+# shapes seen in practice: `let Source = #"Other Name" in Source` (or a bare
+# unquoted reference), and — for some Admin-Scanner-reported tables — just the
+# referenced name on its own with no `let` wrapper at all.
+_BARE_LET_REF_RE = re.compile(
+    r'^\s*let\s+(?:\w+|#"[^"]+")\s*=\s*(?:#"([^"]+)"|([A-Za-z_]\w*))\s*'
+    r'(?:,\s*)?in\s+(?:\w+|#"[^"]+")\s*$',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _as_reference_name(expr: str) -> str | None:
+    """If ``expr`` (already isolated — e.g. one `let` binding's RHS) is
+    nothing but a reference to another name — ``#"Quoted Name"``, a bare
+    identifier, or a plain quoted string — return that name. ``None`` for
+    anything with actual logic (a function call, an operator, ...)."""
+    e = (expr or '').strip()
+    m = re.fullmatch(r'#"([^"]+)"', e)
+    if m:
+        return m.group(1)
+    if re.fullmatch(r'"(?:[^"]|"")+"', e):
+        return e[1:-1].replace('""', '"')
+    if re.fullmatch(r'[A-Za-z_]\w*', e):
+        return e
+    return None
+
+
+def _extract_bare_reference(mquery: str) -> str | None:
+    """If ``mquery`` does nothing but reference another named expression (no
+    transformation of its own), return that expression's name. ``None`` for
+    anything with real logic."""
+    s = (mquery or '').strip()
+    if not s:
+        return None
+    direct = _as_reference_name(s)
+    if direct:
+        return direct
+    m = _BARE_LET_REF_RE.match(s)
+    if m:
+        return m.group(1) or m.group(2)
+    return None
+
+
+# Any of these combine MULTIPLE sources into one table (union/join/merge) —
+# when present, "the M's first binding is a reference" is no longer a safe
+# signal of the WHOLE table's physical source (it might be only one side of a
+# union), so _extract_first_binding_reference refuses to guess.
+_COMBINING_FUNCTIONS_RE = re.compile(
+    r'\b(Table\.Combine|Table\.Append|Table\.NestedJoin|Table\.Join|'
+    r'Table\.FuzzyNestedJoin|Table\.Merge)\b',
+    re.IGNORECASE,
+)
+
+
+def _extract_first_binding_reference(mquery: str) -> str | None:
+    """If ``mquery``'s FIRST ``let`` binding is a bare reference to another
+    named expression, return that name — even when later bindings do more
+    than pass the result straight through (``Table.TransformColumnTypes``,
+    ``Table.RenameColumns``, ``Table.SelectColumns``, ...). Those reshape
+    columns; they don't change which physical table is being read, so a
+    reference in the first binding is still the real source — UNLESS
+    anything in the M combines multiple sources (see
+    ``_COMBINING_FUNCTIONS_RE``), in which case trusting "the first binding"
+    could silently pick only one side of a union. Bails to ``None`` there
+    rather than guess.
+    """
+    if not mquery or _COMBINING_FUNCTIONS_RE.search(mquery):
+        return None
+    from .mquery_let_evaluator import _extract_let_block, _parse_binding
+    parsed = _extract_let_block(mquery)
+    if not parsed:
+        return None
+    bindings, _final_expr = parsed
+    if not bindings:
+        return None
+    pb = _parse_binding(bindings[0])
+    if not pb:
+        return None
+    _, first_raw_expr = pb
+    return _as_reference_name(first_raw_expr)
+
+
+def resolve_mquery_with_context(
+    mquery: str, expressions: dict[str, str] | None = None,
+) -> str | None:
+    """``resolve_mquery_to_sql``, extended with model-level context for the
+    shapes a table's own M can't resolve on its own:
+
+    1. **Reference-following** — the table's M is only a passthrough to a
+       separate named/shared expression (a "staging query" disabled from
+       load, referenced by the tables that actually load) — recurse into
+       that expression's own M via the direct resolver. Covers both a pure
+       passthrough (``let Source = #"Other Name" in Source``) and a
+       reference followed by column-level cleanup that doesn't change the
+       physical source (``Table.TransformColumnTypes``/``RenameColumns``/
+       ``SelectColumns`` after it) — see ``_extract_first_binding_reference``.
+    2. **Parameter-driven sources** — the physical table (or the whole native
+       query) is built from string concatenation of model parameters at
+       model-open time — resolved via ``mquery_let_evaluator`` using each
+       parameter's current default value, both pulled from the SAME
+       ``expressions`` map (Admin Scanner / Fabric TMDL report parameters as
+       ordinary named expressions tagged ``IsParameterQuery = true``).
+
+    ``expressions`` is the model's ``{name: raw_M}`` map of named/shared
+    expressions — absent (or empty) callers just get the direct resolver's
+    result. Never guesses: ``None`` if nothing resolves confidently.
+    """
+    direct = resolve_mquery_to_sql(mquery)
+    if direct:
+        return direct
+    if not expressions:
+        return None
+
+    for ref_name in (_extract_bare_reference(mquery), _extract_first_binding_reference(mquery)):
+        if ref_name and ref_name in expressions and expressions[ref_name] != mquery:
+            resolved = resolve_mquery_to_sql(expressions[ref_name])
+            if resolved:
+                return resolved
+
+    from .mquery_let_evaluator import extract_parameter_defaults, resolve_via_let_evaluation
+    params = extract_parameter_defaults(expressions)
+    if params:
+        return resolve_via_let_evaluation(mquery, params)
+    return None
+
+
+def extract_source_table_with_context(
+    mquery: str, expressions: dict[str, str] | None = None,
+) -> str | None:
+    """``extract_source_table``, extended with the same model-level context as
+    ``resolve_mquery_with_context`` (reference-following + parameter-driven
+    sources) — returns just the physical ``catalog.schema.table``, not a full
+    SQL string. Used for ``join_key_map[dim].source_table``, a plain config
+    value rather than something ever executed directly.
+    """
+    direct = extract_source_table(mquery)
+    if direct:
+        return direct
+    if not expressions:
+        return None
+
+    for ref_name in (_extract_bare_reference(mquery), _extract_first_binding_reference(mquery)):
+        if ref_name and ref_name in expressions and expressions[ref_name] != mquery:
+            resolved = extract_source_table(expressions[ref_name])
+            if resolved:
+                return resolved
+
+    sql = resolve_mquery_with_context(mquery, expressions)
+    if not sql:
+        return None
+    fm = RE_FROM_CLAUSE.search(sql)
+    return fm.group(1) if fm else None
 
 
 class MQueryParser:

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/physical_name_resolver.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/physical_name_resolver.py
@@ -1,0 +1,240 @@
+"""Physical-name resolution pass (KASAL_FIXES Gaps 1–3).
+
+Power BI friendly table names and model (display) column names usually differ
+from the real physical table/column names in the warehouse — the mapping lives
+only in each table's Power Query M (``Item=``/``FROM`` for the table,
+``Table.RenameColumns`` for the columns). The rest of the pipeline emits
+identifiers from the *model*, so a generated UC metric view can reference tables
+and columns that do not exist.
+
+This module rewrites a built ``MetricViewSpec`` so every ``source``/join table and
+every column reference uses the real physical name recovered from the M. It runs
+just before YAML emission and is **fail-open**: any table/column it cannot resolve
+from the M is left exactly as-is, so it can never break an already-correct spec.
+
+Gap 1  physical TABLE names   — ``Item=`` (navigation) / ``FROM`` (NativeQuery)
+Gap 2  physical COLUMN names  — inverse of ``Table.RenameColumns`` (+ verbatim for
+                                un-renamed columns; matched case/underscore-insensitively
+                                so camelCase physicals like ``KeyQuestion`` resolve)
+Gap 3  GENERATED tables       — ``List.Dates``/``#table``/… have no physical source;
+                                detected and reported so they can be materialised.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+_GENERATED = re.compile(
+    r"\b(List\.Dates|List\.Numbers|List\.Generate|Table\.FromList)\b|#table\b"
+)
+_RENAME_PAIR = re.compile(r'\{"([^"]+)",\s*"([^"]+)"\}')
+_NAV_ITEM = re.compile(r'Item\s*=\s*"([^"]+)"')
+
+
+def _norm(s: str) -> str:
+    """Match key: lowercase, drop every non-alphanumeric (so ``Key Question``,
+    ``KeyQuestion`` and ``key_question`` all collapse to ``keyquestion``)."""
+    return re.sub(r"[^0-9a-z]", "", s.lower())
+
+
+def _norm_table(name: str) -> str:
+    """Table match key — like ``_norm`` but also strips a leading ``dim``/``cdim``
+    so a join alias (``dim_supervisor``) matches its friendly table."""
+    n = _norm(name)
+    for p in ("cdim", "dim"):
+        if n.startswith(p) and len(n) > len(p):
+            return n[len(p) :]
+    return n
+
+
+def physical_table(m_expr: str) -> str | None:
+    """Real physical table name from an M expression, or None (generated / unknown)."""
+    if not m_expr or _GENERATED.search(m_expr):
+        return None
+    nav = _NAV_ITEM.search(m_expr)
+    if nav:
+        return nav.group(1)
+    if re.search(r"\bValue\.NativeQuery\b", m_expr):
+        mm = re.search(r'FROM\b[^\n]*?\.([A-Za-z0-9_]+)\s*"', m_expr) or re.search(
+            r'FROM\s+[`"]?[\w-]+[`"]?\.[`"]?\w+[`"]?\.([A-Za-z0-9_]+)', m_expr
+        )
+        if mm:
+            return mm.group(1)
+    return None
+
+
+def is_generated(m_expr: str) -> bool:
+    """True if the table is computed entirely in M (no physical source)."""
+    return bool(m_expr and _GENERATED.search(m_expr))
+
+
+def column_map(m_expr: str, display_columns: list[str]) -> dict[str, str]:
+    """Map ``_norm(token) -> physical column`` for a table.
+
+    Physical name = the *raw* (pre-rename) side of ``Table.RenameColumns``; for a
+    column that was never renamed, the model (display) name IS the physical name.
+    Indexed by the normalized display name AND the normalized physical name, so a
+    token that is already physical still resolves (to itself)."""
+    inv = {disp: raw for raw, disp in _RENAME_PAIR.findall(m_expr or "")}
+    cmap: dict[str, str] = {}
+    for disp in display_columns:
+        raw = inv.get(disp, disp)
+        cmap.setdefault(_norm(disp), raw)
+        cmap.setdefault(_norm(raw), raw)
+    return cmap
+
+
+def _qcol(raw: str) -> str:
+    return raw if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", raw or "") else f"`{raw}`"
+
+
+def _rewrite_columns(text: str, prefix_maps: dict[str, dict[str, str]]) -> str:
+    """Rewrite ``<prefix>.<col>`` tokens using the per-prefix column map. Only
+    changes a token when a physical name is found AND it differs; unknown columns
+    are left untouched (fail-open)."""
+    if not text:
+        return text
+    prefixes = "|".join(re.escape(p) for p in prefix_maps)
+    pat = re.compile(rf"\b({prefixes})\.([A-Za-z_][A-Za-z0-9_]*)")
+
+    def _sub(mm: re.Match) -> str:
+        pre, col = mm.group(1), mm.group(2)
+        raw = prefix_maps.get(pre, {}).get(_norm(col))
+        if raw and raw != col:
+            return f"{pre}.{_qcol(raw)}"
+        return mm.group(0)
+
+    return pat.sub(_sub, text)
+
+
+def _replace_leaf(source: str, physical: str) -> str:
+    """Replace the table leaf of a dotted ``cat.sch.table`` source with ``physical``.
+    Leaves inline-SQL sources (containing whitespace/SELECT) untouched."""
+    if not source or re.search(r"\s", source) or physical is None:
+        return source
+    parts = source.rsplit(".", 1)
+    return f"{parts[0]}.{physical}" if len(parts) == 2 else physical
+
+
+def resolve_physical_names(specs, mquery_tables, mquery_expressions) -> dict:
+    """Rewrite every spec's table/column identifiers to physical names from the M.
+
+    Args:
+        specs: dict[table_key -> MetricViewSpec] (mutated in place).
+        mquery_tables: dict[table_key -> TableInfo] (for the display-column lists).
+        mquery_expressions: dict[table_key -> raw Power Query M string].
+
+    Returns a report dict: {'generated_tables': [...], 'tables_resolved': n,
+    'columns_rewritten': n} for logging / limitations.
+    """
+    logger.info(
+        "[physical_name_resolver] invoked: %d spec(s), %d M expression(s)",
+        len(specs or {}), len(mquery_expressions or {}))
+    if not mquery_expressions:
+        logger.info(
+            "[physical_name_resolver] skipped: no Power Query M available "
+            "(pass scan_data_json / mquery_expressions) — identifiers left as model names")
+        return {"generated_tables": [], "tables_resolved": 0, "columns_rewritten": 0}
+
+    # Per friendly table: physical name, column map, generated flag — indexed by
+    # several normalized keys so facts, dims and join aliases all resolve.
+    by_norm: dict[str, dict] = {}
+    generated: set[str] = set()
+    for tkey, m in mquery_expressions.items():
+        tinfo = mquery_tables.get(tkey)
+        cols = []
+        if tinfo is not None:
+            cols = [
+                c.get("source_col") or c.get("name")
+                for c in (getattr(tinfo, "aggregate_columns", None) or [])
+            ]
+            cols += list(getattr(tinfo, "group_by_columns", None) or [])
+            cols += [
+                c.get("name")
+                for c in (getattr(tinfo, "calculated_columns", None) or [])
+            ]
+        cols = [c for c in cols if c]
+        phys = physical_table(m)
+        entry = {
+            "physical": phys,
+            "colmap": column_map(m, cols),
+            "generated": is_generated(m),
+        }
+        if entry["generated"]:
+            generated.add(tkey)
+        for k in {_norm_table(tkey), _norm(tkey)}:
+            by_norm.setdefault(k, entry)
+        if phys:
+            by_norm.setdefault(_norm_table(phys), entry)
+
+    def lookup(*names) -> dict | None:
+        for n in names:
+            if not n:
+                continue
+            for k in {_norm_table(n), _norm(n)}:
+                if k in by_norm:
+                    return by_norm[k]
+        return None
+
+    report = {
+        "generated_tables": sorted(generated),
+        "tables_resolved": 0,
+        "columns_rewritten": 0,
+    }
+
+    for spec in specs.values():
+        fact = lookup(
+            getattr(spec, "fact_table_key", None),
+            getattr(spec, "source_table", "").rsplit(".", 1)[-1],
+        )
+        fact_map = fact["colmap"] if fact else {}
+        if fact and fact.get("physical"):
+            spec.source_table = _replace_leaf(spec.source_table, fact["physical"])
+            report["tables_resolved"] += 1
+
+        # per-join: resolve the dim table + build the alias->colmap for column rewrites
+        prefix_maps: dict[str, dict[str, str]] = {"source": fact_map}
+        for j in getattr(spec, "joins", None) or []:
+            alias = j.get("name")
+            leaf = (j.get("source") or "").rsplit(".", 1)[-1]
+            dim = lookup(alias, leaf)
+            if dim:
+                if dim.get("physical"):
+                    j["source"] = _replace_leaf(j.get("source", ""), dim["physical"])
+                    report["tables_resolved"] += 1
+                if alias:
+                    prefix_maps[alias] = dim["colmap"]
+
+        # rewrite join ON clauses, dimension exprs, measure SQL
+        for j in getattr(spec, "joins", None) or []:
+            key = (
+                "join_on"
+                if j.get("join_on") is not None
+                else ("on" if j.get("on") is not None else None)
+            )
+            if key:
+                j[key] = _rewrite_columns(j[key], prefix_maps)
+        for d in getattr(spec, "dimensions", None) or []:
+            if d.get("expr"):
+                d["expr"] = _rewrite_columns(d["expr"], prefix_maps)
+        for m in getattr(spec, "measures", None) or []:
+            if getattr(m, "sql_expr", None):
+                m.sql_expr = _rewrite_columns(m.sql_expr, prefix_maps)
+
+    if report["tables_resolved"] or generated:
+        logger.info(
+            "[physical_name_resolver] resolved %d table ref(s) to physical names; "
+            "%d generated table(s) need materialisation: %s",
+            report["tables_resolved"],
+            len(generated),
+            ", ".join(sorted(generated)) or "(none)",
+        )
+    else:
+        logger.info(
+            "[physical_name_resolver] no-op: %d M expression(s) but nothing matched "
+            "%d spec(s) (check that fact/dim keys align with the M table names)",
+            len(mquery_expressions), len(specs or {}))
+    return report

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
@@ -91,6 +91,12 @@ class MetricViewPipeline:
                       if isinstance(_si, dict) else getattr(_si, 'raw_m_expression', None))
                 if _m:
                     self._mquery_expressions[_k] = _m
+        # Fallback: config-gen ships the raw M per table in the config (no scan_data
+        # needed). Enables physical-name resolution + generated-view SQL in the flow.
+        if not self._mquery_expressions:
+            _cfg_m = self.config.get('table_mquery_expressions')
+            if isinstance(_cfg_m, dict):
+                self._mquery_expressions = {k: v for k, v in _cfg_m.items() if v}
         self.unflatten_tables = unflatten_tables
         self.llm_config = llm_config or {}
         self._inactive_rels: list[dict] = inactive_relationships or []
@@ -785,6 +791,7 @@ class MetricViewPipeline:
     def get_results(self) -> dict:
         """Return pipeline results as a serializable dict."""
         from .recovery_recommender import recommend as _recovery_recipe
+        from .recovery_recommender import draft_source_view as _draft_source_view
         # Tables reachable only via a skipped many:many/bidirectional relationship
         # — used to recommend an EXISTS-precompute recovery (Gap 4) instead of a
         # generic decline.
@@ -851,6 +858,12 @@ class MetricViewPipeline:
                                 m2n_tables=_m2n_tables,
                                 join_tables={j.get('name') for j in (spec.joins or [])}),
                             m.skip_reason),
+                        # Best-effort, UNVERIFIED source-view SQL scaffold for cross-fact /
+                        # multi-stage measures — a proposal starting point, never an emitted
+                        # measure. Clearly labeled DRAFT; complete + verify against PBI.
+                        'source_view_sql_draft': _draft_source_view(
+                            m.dax_expression, measure_name=m.measure_name,
+                            fact_table=spec.fact_table_key),
                     }
                     for m in spec.untranslatable
                 ],

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
@@ -762,8 +762,16 @@ class MetricViewPipeline:
                 'untranslatable': [
                     {
                         'name': m.original_name,
+                        'original_name': m.original_name,
                         'skip_reason': m.skip_reason,
                         'category': m.category,
+                        # Rich fields for the validation-UI "Not transpiled" review
+                        # panel: the full original DAX, the LLM translation-class
+                        # label, and how many other measures depend on this one (so
+                        # reviewers can triage high-impact gaps first).
+                        'dax_expression': m.dax_expression,
+                        'dax_class': m.dax_class,
+                        'referenced_by': getattr(m, 'referenced_by', 0),
                     }
                     for m in spec.untranslatable
                 ],

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
@@ -369,6 +369,21 @@ class MetricViewPipeline:
                 self.all_specs, self.mquery_tables, self._mquery_expressions)
             if _res.get('generated_tables'):
                 self._limitations['generated_tables'] = _res['generated_tables']
+                # Gap 3 materialization: emit CREATE VIEW SQL for generated calendars
+                # (List.Dates etc.) so the reviewer can create the missing source.
+                from .generated_table_emitter import emit_view_sql
+                _gen_sql = {}
+                for _t in _res['generated_tables']:
+                    _sql = emit_view_sql(
+                        self._mquery_expressions.get(_t, ''),
+                        f"{{catalog}}.{{schema}}.{to_snake_case(_t)}")
+                    if _sql:
+                        _gen_sql[_t] = _sql
+                if _gen_sql:
+                    self._limitations['generated_view_sql'] = _gen_sql
+                    logger.info(
+                        "[MetricViewPipeline] emitted CREATE VIEW SQL for %d generated "
+                        "table(s): %s", len(_gen_sql), ', '.join(sorted(_gen_sql)))
 
         # Phase 2c: Rebuild YAML comment blocks to reflect updated skip_reasons
         for spec in self.all_specs.values():

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
@@ -207,6 +207,22 @@ class MetricViewPipeline:
                 'original_mquery': raw[:2000],
             }
 
+        # Table processing is sequential and each table's LLM DAX-fallback batch
+        # (table_processor.py) blocks on its own network round-trips — on a
+        # report with many fact tables this can add up past the flow's crew
+        # timeout with NO visible progress in between (those per-measure LLM
+        # calls aren't OTel-traced), which is exactly what made a stalled run
+        # indistinguishable from a slow one. Log wall-clock per table so a
+        # future stall/slowdown is diagnosable directly from these logs.
+        import time as _time
+        _fact_table_count = sum(
+            1 for _, ti in self.mquery_tables.items() if ti.is_fact and ti.source_table
+        )
+        logger.info(
+            "[MetricViewPipeline] Phase 1: processing %d fact table(s) sequentially "
+            "(llm_fallback=%s)", _fact_table_count, bool(self.llm_config.get('use_llm_fallback'))
+        )
+        _table_num = 0
         for table_key, table_info in self.mquery_tables.items():
             if not table_info.is_fact:
                 # Non-fact / raw-M tables: record a classified skip (not a silent
@@ -218,9 +234,15 @@ class MetricViewPipeline:
                 self.stats[table_key] = _skip_stat(table_info)
                 continue
 
+            _table_num += 1
+            _t0 = _time.time()
             dax_measures = measure_groups.get(table_key, [])
             spec = self._process_table(table_key, table_info, dax_measures)
             self.all_specs[table_key] = spec
+            logger.info(
+                "[MetricViewPipeline] (%d/%d) processed table '%s' in %.1fs",
+                _table_num, _fact_table_count, table_key, _time.time() - _t0
+            )
 
         # Handle mapping-only tables (measures in PBI mapping but no MQuery SQL)
         mapping_only_cfg = self.config.get('mapping_only_tables', {})

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
@@ -28,7 +28,7 @@ from .relationships_loader import RelationshipsLoader
 from .utils import to_snake_case, col_to_readable
 from .yaml_emitter import emit_yaml
 from .sql_emitter import emit_deploy_sql
-from .report_emitter import emit_migration_report
+from .report_emitter import build_proposal, emit_migration_report
 from .table_processor import (
     process_table,
     expand_calculation_groups,
@@ -794,6 +794,12 @@ class MetricViewPipeline:
                         'dax_expression': m.dax_expression,
                         'dax_class': m.dax_class,
                         'referenced_by': getattr(m, 'referenced_by', 0),
+                        # The LLM's concrete recipe (when it gave one) and a single
+                        # actionable next-step so the "Not transpiled" panel proposes
+                        # HOW to handle each measure, not just why it was skipped.
+                        'explanation': getattr(m, 'explanation', None),
+                        'proposal': build_proposal(
+                            m.dax_class, getattr(m, 'explanation', None), m.skip_reason),
                     }
                     for m in spec.untranslatable
                 ],

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/pipeline.py
@@ -75,12 +75,22 @@ class MetricViewPipeline:
         refresh_policy_tables: list[dict] | None = None,
         no_summarize_columns: list[dict] | None = None,
         rls_tables: set[str] | None = None,
+        mquery_expressions: dict | None = None,
     ):
         self.mapping = mapping
         self.mquery_tables = mquery_tables
         self.config = config or {}
         self.inner_dim_joins = inner_dim_joins
         self.scan_data = scan_data or {}
+        # Raw Power Query M per table, for physical-name resolution (Gaps 1–3).
+        # Prefer the explicit map; otherwise recover it from scan_data if present.
+        self._mquery_expressions: dict[str, str] = dict(mquery_expressions or {})
+        if not self._mquery_expressions and self.scan_data:
+            for _k, _si in self.scan_data.items():
+                _m = (_si.get('raw_m_expression') or _si.get('m_expression')
+                      if isinstance(_si, dict) else getattr(_si, 'raw_m_expression', None))
+                if _m:
+                    self._mquery_expressions[_k] = _m
         self.unflatten_tables = unflatten_tables
         self.llm_config = llm_config or {}
         self._inactive_rels: list[dict] = inactive_relationships or []
@@ -350,6 +360,15 @@ class MetricViewPipeline:
                 if primary_table and primary_table != spec.fact_table_key:
                     if m.original_name in global_covered or to_snake_case(m.original_name) in global_covered:
                         m.skip_reason = 'Covered on primary table (secondary allocation)'
+
+        # Phase 2b-fix: resolve physical table/column names from the Power Query M
+        # (KASAL_FIXES Gaps 1–3). Fail-open — unresolved identifiers are left as-is.
+        if self._mquery_expressions:
+            from .physical_name_resolver import resolve_physical_names
+            _res = resolve_physical_names(
+                self.all_specs, self.mquery_tables, self._mquery_expressions)
+            if _res.get('generated_tables'):
+                self._limitations['generated_tables'] = _res['generated_tables']
 
         # Phase 2c: Rebuild YAML comment blocks to reflect updated skip_reasons
         for spec in self.all_specs.values():
@@ -750,6 +769,15 @@ class MetricViewPipeline:
 
     def get_results(self) -> dict:
         """Return pipeline results as a serializable dict."""
+        from .recovery_recommender import recommend as _recovery_recipe
+        # Tables reachable only via a skipped many:many/bidirectional relationship
+        # — used to recommend an EXISTS-precompute recovery (Gap 4) instead of a
+        # generic decline.
+        _m2n_tables: set[str] = set()
+        for _r in self._limitations.get('m2n_relationships', []) or []:
+            _m2n_tables.add(_r.get('from_table', ''))
+            _m2n_tables.add(_r.get('to_table', ''))
+        _m2n_tables.discard('')
         results = {
             'specs': {},
             'stats': self.stats,
@@ -798,8 +826,16 @@ class MetricViewPipeline:
                         # actionable next-step so the "Not transpiled" panel proposes
                         # HOW to handle each measure, not just why it was skipped.
                         'explanation': getattr(m, 'explanation', None),
+                        # Prefer the LLM's own recipe; else a concrete Gap 4/5 recovery
+                        # recipe (EXISTS precompute / separate-grain view) when the DAX
+                        # shape matches; else the class-based default.
                         'proposal': build_proposal(
-                            m.dax_class, getattr(m, 'explanation', None), m.skip_reason),
+                            m.dax_class,
+                            getattr(m, 'explanation', None) or _recovery_recipe(
+                                m.dax_expression, fact_table=spec.fact_table_key,
+                                m2n_tables=_m2n_tables,
+                                join_tables={j.get('name') for j in (spec.joins or [])}),
+                            m.skip_reason),
                     }
                     for m in spec.untranslatable
                 ],

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/recovery_recommender.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/recovery_recommender.py
@@ -1,0 +1,104 @@
+"""Recovery recommender (KASAL_FIXES Gaps 4 & 5).
+
+Some DAX measures can't be a single single-source metric-view measure, but the
+recovery is mechanical — a source-view precompute plus (for Gap 5) a separate
+metric view at a coarser grain. Rather than decline with a generic message, this
+module detects the two shapes and returns a **concrete recipe** (with the resolved
+table/key when known) that the report + "Not transpiled" proposal surface.
+
+It deliberately does NOT auto-emit the SQL: reproducing these correctly needs
+warehouse validation (they hinge on filter literals, grain, and weekly/daily-style
+encodings), so the pipeline hands the reviewer an exact recipe instead of a
+best-effort-but-unverified view.
+
+Gap 4  filter through a many-side / bidirectional relationship → EXISTS-flag precompute.
+Gap 5  multi-stage aggregation (grouped virtual table + outer iterator) → precompute
+        view at the coarser grain + a SEPARATE metric view (co-locating biases the aggregate).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Grouped-virtual-table builders + an outer iterator over them = multi-stage aggregation.
+_GROUPERS = re.compile(
+    r"\b(SUMMARIZE|SUMMARIZECOLUMNS|GROUPBY|ADDCOLUMNS|CURRENTGROUP)\b", re.I
+)
+_ITERATORS = re.compile(
+    r"\b(AVERAGEX|SUMX|COUNTX|MINX|MAXX|GEOMEANX|PRODUCTX|MEDIANX)\b", re.I
+)
+# NOT-EXISTS / zero-match shape: a correlated count compared to zero.
+_COUNT_FN = re.compile(r"\b(COUNTROWS|COUNTX|DISTINCTCOUNT|COUNT)\b", re.I)
+_CMP_ZERO = re.compile(r"=\s*0(?!\d)")
+
+
+def _is_zero_match(dax: str) -> bool:
+    return bool(_COUNT_FN.search(dax) and _CMP_ZERO.search(dax))
+
+
+def _dax_filter_tables(dax: str) -> set[str]:
+    """Table names referenced by a DAX filter: 'Table Name'[col] and Bare[col]."""
+    quoted = set(re.findall(r"'([^']+)'\s*\[", dax or ""))
+    bare = set(re.findall(r"(?:^|[^'\w\]])([A-Z][A-Za-z0-9 ]*?)\s*\[", dax or ""))
+    return {t.strip() for t in (quoted | bare) if t.strip()}
+
+
+def recommend(
+    dax: str,
+    *,
+    fact_table: str | None = None,
+    m2n_tables: set[str] | None = None,
+    join_tables: set[str] | None = None,
+) -> str | None:
+    """Return a concrete recovery recipe for a declined measure, or None.
+
+    Args:
+        dax: the original DAX expression.
+        fact_table: the measure's home fact (for the recipe text).
+        m2n_tables: tables related to the fact by a skipped many:many/bidirectional
+            relationship (from RelationshipsLoader.get_skipped_m2n()).
+        join_tables: tables already available as declared joins (to avoid recommending
+            a precompute when a plain join would do).
+    """
+    dax = dax or ""
+    du = dax.upper()
+
+    # Gap 5 — multi-stage aggregation: grouped virtual table + an outer iterator.
+    if _GROUPERS.search(dax) and _ITERATORS.search(dax):
+        return (
+            "Multi-stage aggregation (grouped virtual table + outer iterator, e.g. "
+            "SUMMARIZE/GROUPBY then AVERAGEX). A single metric-view measure can't nest "
+            "aggregations. Precompute the inner GROUP BY at its grain in a source view, "
+            "then AVG/SUM it in a SEPARATE metric view at that grain (co-locating it on the "
+            "fact grain gives a row-weighted-average bug)."
+        )
+
+    # Gap 4 — filter through a many-side / bidirectional relationship.
+    m2n = {t.lower() for t in (m2n_tables or set())}
+    joins = {t.lower() for t in (join_tables or set())}
+    filt = {t for t in _dax_filter_tables(dax) if t.lower() not in joins}
+    hit = sorted(t for t in filt if t.lower() in m2n)
+    if hit:
+        tgt = hit[0]
+        # zero-match variant → NOT EXISTS
+        neg = " (zero-match: use NOT EXISTS)" if _is_zero_match(dax) else ""
+        return (
+            f"Filter references '{tgt}', related to {fact_table or 'the fact'} via a "
+            f"many-side/bidirectional relationship (no safe 1:1 join — a plain join would "
+            f"fan out). Precompute an EXISTS flag on the source view "
+            f"(EXISTS/NOT EXISTS against '{tgt}' on the shared key){neg}, then "
+            f"FILTER the measure on that flag. The inline `source:` SELECT accepts this "
+            f"with no extra object."
+        )
+
+    # generic NOT-EXISTS / zero-match even without a known m2n table
+    if _is_zero_match(dax) and (
+        "DISTINCTCOUNT" in du or "VALUES" in du or "FILTER" in du
+    ):
+        return (
+            "Zero-match / NOT-EXISTS pattern (counts entities with no matching rows). "
+            "Precompute a per-entity has_<x> flag in the source view (window or self-join), "
+            "then COUNT(DISTINCT id) FILTER (WHERE has_<x> = 0)."
+        )
+
+    return None

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/recovery_recommender.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/recovery_recommender.py
@@ -102,3 +102,68 @@ def recommend(
         )
 
     return None
+
+
+_FACT_REF = re.compile(r"'([^']*[Ff]act[^']*)'\s*\[|\b(\w*[Ff]act\w*)\b\s*\[")
+
+
+def _facts_in(dax: str) -> set[str]:
+    out = set()
+    for a, b in _FACT_REF.findall(dax or ""):
+        t = (a or b).strip()
+        if t:
+            out.add(t)
+    return out
+
+
+def draft_source_view(
+    dax: str, *, measure_name: str = "measure", fact_table: str | None = None
+) -> str | None:
+    """Best-effort, UNVERIFIED `CREATE VIEW` scaffold for the cases that need a
+    source-view reshape (cross-fact UNION, multi-stage precompute), or None.
+
+    This is a *proposal artifact* — a labeled starting point a human completes and
+    verifies against PBI. It is NEVER an emitted/active measure, so a wrong draft
+    can't ship bad data; worst case the draft needs editing. Deterministic (no LLM):
+    it scaffolds the structure + embeds the original DAX to translate by hand.
+    """
+    dax = dax or ""
+    label = (
+        "-- DRAFT · UNVERIFIED · verify against PBI before use\n"
+        "-- Auto-scaffolded from the declined DAX — complete the <…> parts, then\n"
+        "-- point a UC metric view's `source:` at this view.\n"
+    )
+    dax_c = "\n".join("--   " + ln for ln in dax.strip().splitlines()[:40])
+    base = fact_table or "fact"
+
+    facts = _facts_in(dax)
+    if len(facts) > 1:  # cross-fact → UNION source view
+        arms = "\n  UNION ALL\n".join(
+            f"  SELECT /* aligned shared keys */ *, '{f}' AS _src FROM {f}"
+            for f in sorted(facts)
+        )
+        return (
+            f"{label}-- Cross-fact: spans {', '.join(sorted(facts))}. UC metric views are single-source,\n"
+            f"-- so UNION the facts here (align columns, tag _src), then express the measure as\n"
+            f"-- filtered SUMs over the tagged rows in a UCMV on this view.\n"
+            f"-- Original DAX:\n{dax_c}\n"
+            f"CREATE OR REPLACE VIEW <catalog>.<schema>.{base}__unioned AS\n{arms}\n;"
+        )
+
+    if _GROUPERS.search(dax) and _ITERATORS.search(
+        dax
+    ):  # multi-stage → precompute view
+        return (
+            f"{label}-- Multi-stage: precompute the inner GROUP BY at its grain here, then build a\n"
+            f"-- SEPARATE UCMV on this view that AVG/SUMs across the outer level\n"
+            f"-- (co-locating on the fact grain gives a row-weighted-average bug).\n"
+            f"-- Original DAX:\n{dax_c}\n"
+            f"CREATE OR REPLACE VIEW <catalog>.<schema>.{base}__by_<grain> AS\n"
+            f"  SELECT <grain_cols>,\n"
+            f"         /* inner aggregate per <grain>, e.g. */ SUM(<value>) AS {measure_name}_inner\n"
+            f"  FROM {base}\n"
+            f"  /* JOIN <dims> …  WHERE <filters> */\n"
+            f"  GROUP BY <grain_cols>\n;"
+        )
+
+    return None

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/reevaluate.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/reevaluate.py
@@ -57,6 +57,17 @@ RETRYABLE_CATEGORIES = frozenset({
 # Review statuses that mean "a human settled this — stop proposing it".
 _SUPPRESSING_STATUSES = frozenset({'wont_fix', 'hand_written'})
 
+# dax_class verdicts the LLM-first translator assigns when IT has already examined a
+# measure and declined. Retrying these at the SAME capability level just re-derives
+# the same "no" (and costs tokens when use_llm=true), so they are skipped unless the
+# caller opts in. They are NOT the same as "nobody looked at it yet".
+LLM_DECLINED_CLASSES = frozenset({
+    'unsupported',
+    'display_layer',
+    'out_of_scope',
+    'architecture_change',
+})
+
 
 def review_key(item: dict) -> str:
     """Stable key matching the frontend's ``untranslatableKey`` (table::measure)."""
@@ -114,6 +125,14 @@ def is_retryable(
     if is_suppressed(item, review):
         return False, 'dismissed by reviewer'
     if not include_impossible:
+        # The LLM's own verdict is the strongest signal: if the LLM-first translator
+        # already examined this measure and classified it as untranslatable, retrying
+        # at the SAME capability level re-derives the same "no". Checked FIRST because
+        # it is more reliable than pattern-matching on free-text reasons.
+        dax_class = (item.get('dax_class') or '').strip()
+        if dax_class in LLM_DECLINED_CLASSES:
+            return False, f'LLM already declined at this capability level ({dax_class})'
+
         text = _classification_text(item)
         # Exact-category match (kept for the curated buckets) …
         category = (item.get('category') or '').strip()

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/reevaluate.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/reevaluate.py
@@ -1,0 +1,258 @@
+"""Re-evaluate previously-untranslatable measures against today's transpiler.
+
+WHY: capability improvements (new translator patterns, a better LLM-first path, an
+evolving skill corpus) only ever helped NEW conversions. A model converted last month
+still shows the measures that failed back then, even though several are translatable
+now. This module re-tries ONLY the previously-failed measures and reports which ones
+are recoverable, so a human can choose to re-transpile them.
+
+Hard rules:
+  * Never touch a measure that already succeeded — re-transpiling a validated measure
+    risks silently changing it.
+  * Propose only. This module returns a report; applying it goes through the normal
+    UCMV route, human-triggered.
+
+Cost / noise controls:
+  * CATEGORY GATE — some skip reasons are permanent (a display artifact or a
+    slicer-driven scalar will never become an aggregatable measure). Retrying those
+    forever is wasted compute, so they are skipped unless ``include_impossible``.
+  * DETERMINISTIC-FIRST — ``trivial_only=True`` by default: only the regex fast-path
+    runs, so a sweep over many datasets burns no LLM tokens. ``use_llm=True`` opts
+    into the full (LLM-capable) path.
+  * SUPPRESSION — measures a human already dismissed in the review panel
+    (``untranslatable_review`` status ``wont_fix`` / ``hand_written``) are skipped, so
+    the sweep stops re-proposing settled items.
+  * IMPACT ORDER — results are sorted by ``referenced_by`` desc so the measures other
+    measures depend on surface first.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Categories emitted by yaml_emitter._categorize_untranslatable that represent a
+# PERMANENT limitation — not a transpiler gap. No amount of capability improvement
+# turns a colour string into a metric, so these are not retried by default.
+IMPOSSIBLE_CATEGORIES = frozenset({
+    'display artifact',
+    'slicer/scalar helper',
+    'dynamic KPI selector',
+    'disconnected-slicer dispatch (TREATAS)',
+    'parameter/label lookup (LOOKUPVALUE)',
+    'prior-year time-intelligence',
+})
+
+# Categories that are hard but EXPRESSIBLE — each has a documented unlock, so a
+# capability improvement can genuinely recover them. These are the retry targets.
+RETRYABLE_CATEGORIES = frozenset({
+    'top-N row selection (TOPN)',
+    'fixed-LOD (ALLEXCEPT)',
+    'group-then-aggregate (SUMMARIZE/CALCULATETABLE)',
+    'distinct-count pattern',
+    'complex DAX — needs manual translation',
+})
+
+# Review statuses that mean "a human settled this — stop proposing it".
+_SUPPRESSING_STATUSES = frozenset({'wont_fix', 'hand_written'})
+
+
+def review_key(item: dict) -> str:
+    """Stable key matching the frontend's ``untranslatableKey`` (table::measure)."""
+    table = item.get('table_key') or item.get('view_name') or ''
+    name = item.get('original_name') or item.get('name') or ''
+    return f"{table}::{name}"
+
+
+def is_suppressed(item: dict, review: Optional[dict]) -> bool:
+    """True when a reviewer already marked this measure as settled."""
+    if not review:
+        return False
+    ann = review.get(review_key(item)) or {}
+    return (ann.get('status') or '') in _SUPPRESSING_STATUSES
+
+
+# Substrings that mark a PERMANENT limitation. Real stored rows carry the
+# allocation bucket in `category` ('unassigned', 'single_table', …) and the
+# human-readable classification in `skip_reason` / `previous_category`, so the gate
+# must match on TEXT across both fields rather than only on an exact category name.
+_IMPOSSIBLE_MARKERS = (
+    'display artifact',
+    'slicer/scalar helper',
+    'dynamic kpi selector',
+    'disconnected-slicer dispatch',
+    'parameter/label lookup',
+    'selectedvalue',          # slicer-driven scalar: no static metric equivalent
+    'isfiltered',             # PBI-specific filter-state introspection
+    'blank() placeholder',
+    'display-only',
+    'covered on primary table',   # already emitted elsewhere — not a gap
+)
+
+
+def _classification_text(item: dict) -> str:
+    """All the fields that may carry the human-readable failure classification."""
+    return ' '.join(str(item.get(k) or '') for k in
+                    ('category', 'skip_reason', 'previous_category',
+                     'previous_skip_reason', 'dax_class')).lower()
+
+
+def is_retryable(
+    item: dict,
+    *,
+    include_impossible: bool = False,
+    review: Optional[dict] = None,
+) -> tuple[bool, str]:
+    """Decide whether a previously-failed measure is worth re-trying.
+
+    Returns ``(retryable, reason_when_not)`` so the caller can report WHY something
+    was skipped instead of silently dropping it.
+    """
+    if not (item.get('dax_expression') or '').strip():
+        return False, 'no DAX stored to re-translate'
+    if is_suppressed(item, review):
+        return False, 'dismissed by reviewer'
+    if not include_impossible:
+        text = _classification_text(item)
+        # Exact-category match (kept for the curated buckets) …
+        category = (item.get('category') or '').strip()
+        if category in IMPOSSIBLE_CATEGORIES:
+            return False, f'permanent limitation ({category})'
+        # … plus substring markers, which is what real stored rows actually carry.
+        for marker in _IMPOSSIBLE_MARKERS:
+            if marker in text:
+                return False, f'permanent limitation ({marker})'
+    return True, ''
+
+
+def _measure_payload(item: dict) -> dict:
+    """Shape a stored untranslatable row into the dict DaxTranslator.translate wants."""
+    name = item.get('original_name') or item.get('name') or ''
+    return {
+        'measure_name': name,
+        'original_name': name,
+        'dax_expression': item.get('dax_expression') or '',
+        'table_refs': item.get('table_refs') or [],
+    }
+
+
+def reevaluate_measures(
+    untranslatable_items: Iterable[dict],
+    config: Optional[dict] = None,
+    *,
+    review: Optional[dict] = None,
+    include_impossible: bool = False,
+    use_llm: bool = False,
+    limit: Optional[int] = None,
+) -> dict:
+    """Re-run the transpiler over previously-failed measures only.
+
+    Args:
+        untranslatable_items: stored ``untranslatable_items`` rows from a prior run.
+        config: the stored ``proposed_config`` (filter_sets, column_overrides,
+            fact_join_map, …) so the retry sees the same context as the original run.
+        review: persisted ``untranslatable_review`` map — dismissed measures are skipped.
+        include_impossible: also retry the permanent-limitation categories.
+        use_llm: allow the LLM-first path (costs tokens). Default False = regex
+            fast-path only, so a scheduled sweep is free.
+        limit: cap how many measures are retried (cost guard).
+
+    Returns:
+        ``{newly_translatable, still_failing, skipped, counts}``. Each recovered row
+        carries ``new_sql`` plus the ``previous_skip_reason`` for context.
+    """
+    items = [i for i in (untranslatable_items or []) if isinstance(i, dict)]
+    newly_translatable: list[dict] = []
+    still_failing: list[dict] = []
+    skipped: list[dict] = []
+
+    candidates: list[dict] = []
+    for item in items:
+        ok, why = is_retryable(item, include_impossible=include_impossible, review=review)
+        if ok:
+            candidates.append(item)
+        else:
+            skipped.append({
+                'original_name': item.get('original_name') or item.get('name'),
+                'table_key': item.get('table_key'),
+                'category': item.get('category'),
+                'skipped_because': why,
+            })
+
+    # Highest-impact first, and apply the cost cap AFTER ordering so a limited run
+    # still retries the measures that matter most.
+    candidates.sort(key=lambda i: i.get('referenced_by') or 0, reverse=True)
+    if limit is not None and limit >= 0:
+        candidates = candidates[:limit]
+
+    if candidates:
+        try:
+            from .dax_translator import DaxTranslator
+        except Exception as exc:  # fail-open: report nothing rather than crash a sweep
+            logger.warning("[reevaluate] translator unavailable: %s", exc)
+            return {
+                'newly_translatable': [], 'still_failing': [], 'skipped': skipped,
+                'counts': {
+                    'considered': len(items), 'retried': 0, 'recovered': 0,
+                    'still_failing': 0, 'skipped': len(skipped),
+                },
+                'error': f'translator unavailable: {exc}',
+            }
+
+        translator = DaxTranslator(config or {})
+        for item in candidates:
+            name = item.get('original_name') or item.get('name') or ''
+            table_key = item.get('table_key') or item.get('view_name') or ''
+            try:
+                result = translator.translate(
+                    _measure_payload(item), table_key, trivial_only=not use_llm
+                )
+            except Exception as exc:  # one bad measure must not kill the sweep
+                logger.debug("[reevaluate] %s raised: %s", name, exc)
+                still_failing.append({
+                    'original_name': name, 'table_key': table_key,
+                    'category': item.get('category'),
+                    'skip_reason': f'retry raised: {exc}',
+                    'referenced_by': item.get('referenced_by') or 0,
+                })
+                continue
+
+            sql = (getattr(result, 'sql_expr', None) or '').strip()
+            if sql and getattr(result, 'is_translatable', False):
+                newly_translatable.append({
+                    'original_name': name,
+                    'table_key': table_key,
+                    'view_name': item.get('view_name'),
+                    'dax_expression': item.get('dax_expression') or '',
+                    'previous_skip_reason': item.get('skip_reason') or '',
+                    'previous_category': item.get('category') or '',
+                    'new_sql': sql,
+                    'confidence': getattr(result, 'confidence', '') or '',
+                    'dax_class': getattr(result, 'dax_class', None),
+                    'referenced_by': item.get('referenced_by') or 0,
+                })
+            else:
+                still_failing.append({
+                    'original_name': name,
+                    'table_key': table_key,
+                    'category': item.get('category'),
+                    'skip_reason': getattr(result, 'skip_reason', '') or item.get('skip_reason') or '',
+                    'referenced_by': item.get('referenced_by') or 0,
+                })
+
+    newly_translatable.sort(key=lambda r: r.get('referenced_by') or 0, reverse=True)
+    still_failing.sort(key=lambda r: r.get('referenced_by') or 0, reverse=True)
+
+    return {
+        'newly_translatable': newly_translatable,
+        'still_failing': still_failing,
+        'skipped': skipped,
+        'counts': {
+            'considered': len(items),
+            'retried': len(candidates),
+            'recovered': len(newly_translatable),
+            'still_failing': len(still_failing),
+            'skipped': len(skipped),
+        },
+    }

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/report_emitter.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/report_emitter.py
@@ -6,6 +6,35 @@ from datetime import datetime
 
 from .data_classes import MetricViewSpec
 
+# Class-based fallback proposals, used only when the LLM gave no actionable
+# explanation (deterministic declines / uncategorized). When present, the LLM's
+# own explanation is preferred — it is usually the concrete recipe already.
+_CLASS_PROPOSAL = {
+    'display_layer': 'Not a metric — rebuild in the AI/BI dashboard layer (slicer parameter, label, or conditional format).',
+    'architecture_change': 'Needs a source-view change (declare a join, UNION the facts, or precompute a column) before it can be a single-source measure.',
+    'unsupported': 'No UC metric-view equivalent — handle in the dashboard layer or omit.',
+    'composed': 'Translate the referenced base measure(s) first, then compose this one via MEASURE().',
+    'out_of_scope': 'References a table/measure outside this fact — allocate it to its owning fact, or handle as multi-fact.',
+    'filtered': 'Expressible as SUM(...) FILTER (WHERE ...) once the referenced column/join is in scope.',
+}
+
+
+def build_proposal(dax_class: str | None, explanation: str | None,
+                   skip_reason: str | None = None) -> str:
+    """A single actionable next-step for a not-emitted measure.
+
+    Prefers the LLM's own explanation — it is usually the concrete recipe
+    ("precompute the scorecard KPI as a column", "add the calendar date_py
+    join") — and falls back to a class-based recommendation so EVERY declined
+    measure carries a proposal, not just a terse reason.
+    """
+    exp = (explanation or '').strip()
+    if exp:
+        return exp
+    return _CLASS_PROPOSAL.get(
+        (dax_class or '').strip(),
+        'Manual translation required — map the DAX to a source-view expression or a dashboard element.')
+
 
 def emit_migration_report(
     all_specs: dict[str, MetricViewSpec],
@@ -171,13 +200,17 @@ def emit_migration_report(
 
     lines.append('## Untranslatable Measures')
     lines.append('')
-    lines.append('| Table | Measure | Reason |')
-    lines.append('|-------|---------|--------|')
+    lines.append('| Table | Measure | Class | Reason | Proposed approach |')
+    lines.append('|-------|---------|-------|--------|-------------------|')
     for table_key, spec in sorted(all_specs.items()):
         for m in spec.untranslatable:
-            reason = m.skip_reason[:80] if m.skip_reason else 'Unknown'
+            reason = (m.skip_reason or 'Unknown')[:80]
+            proposal = build_proposal(
+                getattr(m, 'dax_class', None), getattr(m, 'explanation', None), m.skip_reason
+            ).replace('|', '\\|')[:200]
             lines.append(
-                f'| {table_key} | {m.original_name} | {reason} |')
+                f'| {table_key} | {m.original_name} | {getattr(m, "dax_class", "") or ""} '
+                f'| {reason} | {proposal} |')
     lines.append('')
 
     # ── M:N Relationships ─────────────────────────────────────────────────

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/FUNCTION_REFERENCE.md
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/FUNCTION_REFERENCE.md
@@ -1,0 +1,361 @@
+# DAX Function Reference → UC Metric View SQL
+
+Function-by-function map of the Microsoft DAX function reference to a **UC-metric-view-legal**
+Spark SQL expression. This is the *vocabulary* layer — `PATTERNS.md` teaches the common measure
+*shapes* (CALCULATE/DIVIDE/ALL/SWITCH/time-intel); this file tells you what any individual DAX
+function becomes inside a measure `expr`, and — just as important — **which functions are NOT a
+measure at all** and must be declined with the right `dax_class`.
+
+> **These SQL forms are already rewritten for this pipeline.** The generic "DAX→SQL" tables you may
+> have seen elsewhere emit unqualified columns and cross-table subqueries (e.g. `LOOKUPVALUE` →
+> `(SELECT … FROM other_table)`). Those **do not deploy here.** Every form below obeys §0.
+
+## 0. The four rules that override any per-function mapping
+
+1. **`source.`-qualify every fact column**, including inside `FILTER (WHERE …)` and `CASE WHEN`
+   predicates. Joined-dimension columns use the join alias (`dim.col`). (See `PATTERNS.md §0.1`.)
+2. **Single-source only.** A measure `expr` may reference `source` and declared join aliases —
+   never `SELECT … FROM another_table`. If a function's only faithful form needs another table, a
+   recursive CTE, a self-join, or `ROW_NUMBER`-then-slice, it is **not expressible in a measure
+   expr**: return `success=false`, `dax_class="architecture_change"`, and name the source-view
+   precompute needed. (See `PATTERNS.md §0.2`.)
+3. **A measure aggregates; it does not rank, slice, or format.** Functions that pick rows
+   (`TOPN`, `FIRST`, `INDEX`), rank inline (`RANKX`), or build display text/labels
+   (`FORMAT`, `CONCATENATEX`, `NAMEOF`) are not aggregatable measures — decline them, do not
+   force an aggregate that changes the semantics.
+4. **You cannot create UDFs or tables here.** When a function's only equivalent is "a SQL/Python
+   UDF" (most `Financial`, statistical *distributions*), you may call one **only if it already
+   exists** in UC (`my_udf(source.col)`); otherwise return `architecture_change` naming the UDF, or
+   inline the closed-form arithmetic when one exists (below). Never invent a UDF name.
+
+**Feasibility → `dax_class` cheat sheet** (how the buckets map to the output contract):
+
+| Function feasibility | Typical `dax_class` | Meaning |
+|---|---|---|
+| Direct scalar / aggregate | `translatable_direct` | 1:1 or simple arithmetic on `source.` columns |
+| Ratio / references a measure | `composed` | uses `MEASURE(...)` |
+| Needs a `FILTER (WHERE …)` | `filtered` | CALCULATE/FILTER context |
+| Needs window / recursive CTE / self-join / source precompute | `architecture_change` | still emittable once the source view is reshaped |
+| FORMAT / label / color / slicer-dispatch | `display_layer` | not a metric |
+| Visual-calc / model-only, no equivalent | `unsupported` | flag, do not fabricate |
+
+---
+
+## 1. Aggregation
+
+Direct 1:1 — `expr: <SQL>(source.<col>)`:
+
+| DAX | SQL | `dax_class` |
+|---|---|---|
+| `SUM` / `AVERAGE` / `MIN` / `MAX` / `COUNT` | `SUM` / `AVG` / `MIN` / `MAX` / `COUNT` | `translatable_direct` |
+| `COUNTA(col)` / `COUNTROWS(t)` | `COUNT(source.col)` / `COUNT(1)` | `translatable_direct` |
+| `COUNTBLANK(col)` | `COUNT(1) - COUNT(source.col)` | `translatable_direct` |
+| `DISTINCTCOUNT` / `DISTINCTCOUNTNOBLANK` | `COUNT(DISTINCT source.col)` | `translatable_direct` |
+
+**X-iterators** (`SUMX`/`AVERAGEX`/`MINX`/`MAXX`/`COUNTX`): the inner expression is per-row, so it
+collapses into the aggregate — **no subquery**:
+
+```
+DAX:  SUMX(sales, sales[price] * sales[qty])
+SQL:  SUM(source.price * source.qty)
+```
+
+With a `FILTER`, the predicate becomes a `FILTER (WHERE …)` (this is the bread-and-butter shape,
+see `PATTERNS.md §2b`):
+
+```
+DAX:  AVERAGEX(FILTER(sales, sales[region]="US"), sales[margin])
+SQL:  AVG(source.margin) FILTER (WHERE source.region = 'US')
+```
+
+**`PRODUCT` / `PRODUCTX`** — no native product aggregate; use the log-sum-exp identity (valid only
+for strictly-positive values, else `architecture_change`):
+
+```
+DAX:  PRODUCTX(sales, sales[factor])
+SQL:  EXP(SUM(LN(source.factor)))          -- factor > 0 only
+```
+
+**`APPROXIMATEDISTINCTCOUNT`** → `approx_count_distinct(source.col)` (`translatable_direct`).
+
+---
+
+## 2. Statistical aggregates  (these DO appear in real measures — translate them)
+
+These are genuine aggregates and belong in a measure `expr` directly.
+
+| DAX | SQL (measure `expr`) | `dax_class` |
+|---|---|---|
+| `MEDIAN` / `MEDIANX` | `median(source.col)` | `translatable_direct` |
+| `PERCENTILE.INC` / `PERCENTILEX.INC` | `percentile(source.col, 0.75)` | `translatable_direct` |
+| `PERCENTILE.EXC` / `PERCENTILEX.EXC` | `percentile_disc(0.75) WITHIN GROUP (ORDER BY source.col)` | `translatable_direct` |
+| `STDEV.S` / `STDEVX.S` | `stddev_samp(source.col)` | `translatable_direct` |
+| `STDEV.P` / `STDEVX.P` | `stddev_pop(source.col)` | `translatable_direct` |
+| `VAR.S` / `VARX.S` | `var_samp(source.col)` | `translatable_direct` |
+| `VAR.P` / `VARX.P` | `var_pop(source.col)` | `translatable_direct` |
+| `GEOMEAN` / `GEOMEANX` | `EXP(AVG(LN(source.col)))` (col > 0) | `translatable_direct` |
+
+Large columns: `approx_percentile(source.col, 0.5)` is a cheaper `MEDIAN`.
+
+**`RANKX` / `RANK.EQ` — NOT a plain measure.** Ranking a measure across a dimension is a window
+op, and metric views aggregate rather than rank-and-slice inline. Route it:
+
+```
+DAX:  RANKX(ALL(Product[Name]), [Sales])
+→ dax_class="architecture_change"
+  explanation: "Ranking across a dimension. Either rank in the dashboard/visual layer, or
+   precompute in the source view: RANK() OVER (ORDER BY SUM(amount) DESC) at the product grain,
+   then expose the rank as a dimension."
+```
+
+**Distributions** (`NORM.DIST`, `BETA.INV`, `CHISQ.*`, `T.*`, `POISSON.DIST`, `CONFIDENCE.*`,
+`LINEST`, `PERMUT`, `COMBIN`): no native SQL. Call an existing UC UDF if one is registered
+(`normdist(source.x, …)`); otherwise `architecture_change` naming the UDF. These almost never
+appear as BI measures.
+
+---
+
+## 3. Math & trig
+
+Same-named, direct 1:1 → `translatable_direct` (write `source.` on any column arg):
+
+`ABS ACOS ACOSH ASIN ASINH ATAN ATANH COS COSH SIN SINH TAN TANH EXP LN LOG10 PI POWER SQRT SIGN
+DEGREES RADIANS RAND ROUND TRUNC FLOOR CEILING MOD` → identical names.
+
+Non-obvious mappings:
+
+| DAX | SQL | Note |
+|---|---|---|
+| `DIVIDE(a, b)` / `DIVIDE(a,b,alt)` | `a / NULLIF(b, 0)` / `CASE WHEN b=0 THEN alt ELSE a/b END` | never bare `/`; see `EDGE_CASES §2` |
+| `QUOTIENT(a, b)` | `DIV(source.a, source.b)` | integer division |
+| `LOG(n, base)` | `LOG(base, n)` | **argument order flips** |
+| `POWER(x, y)` / `x ^ y` | `POWER(source.x, source.y)` | |
+| `INT` / `ROUNDDOWN` | `FLOOR` | |
+| `ROUNDUP` | `CEIL` | |
+| `CEILING(x, sig)` / `FLOOR(x, sig)` | `CEIL(source.x/sig)*sig` / `FLOOR(source.x/sig)*sig` | DAX takes a significance arg |
+| `ACOT(x)` / `COT(x)` | `ATAN(1.0/source.x)` / `1.0/TAN(source.x)` | no native cot |
+| `FACT(n)` | `FACTORIAL(source.n)` | |
+| `CURRENCY(x)` | `CAST(source.x AS DECIMAL(19,4))` | |
+| `CONVERT(x, TYPE)` | `CAST(source.x AS <type>)` | |
+
+No native equivalent → arithmetic UDF or `architecture_change`: `GCD`, `LCM`, `MROUND`, `EVEN`,
+`ODD`, `SQRTPI` (`SQRT(source.x*PI())` works), `RANDBETWEEN` (`FLOOR(RAND()*(hi-lo+1))+lo`).
+
+---
+
+## 4. Text
+
+Direct 1:1 → `translatable_direct`:
+
+| DAX | SQL | | DAX | SQL |
+|---|---|---|---|---|
+| `LEN` | `LENGTH(source.col)` | | `UPPER`/`LOWER` | `UPPER`/`LOWER` |
+| `LEFT(c,n)` | `LEFT(source.c, n)` | | `RIGHT(c,n)` | `RIGHT(source.c, n)` |
+| `MID(c,s,n)` | `SUBSTR(source.c, s, n)` | | `TRIM` | `TRIM(source.col)` |
+| `SUBSTITUTE(c,o,n)` | `REPLACE(source.c,'o','n')` | | `REPT(s,n)` | `REPEAT('s', n)` |
+| `EXACT(a,b)` | `source.a = source.b` | | `CONCATENATE(a,b)` | `CONCAT(source.a, source.b)` |
+| `UNICHAR` / `UNICODE` | `CHR` / `ASCII` | | `VALUE(s)` | `TRY_CAST(source.s AS DOUBLE)` |
+| `COMBINEVALUES(d,a,b)` | `CONCAT_WS('d', source.a, source.b)` | | | |
+
+Traps (get these right):
+
+- **`FIND(needle, hay)` / `SEARCH(needle, hay)`** → `INSTR(source.hay, 'needle')` — note the
+  **argument order swaps** (DAX is needle-first, `INSTR` is haystack-first). `FIND` is
+  case-sensitive; `SEARCH` is case-insensitive → wrap both sides in `LOWER(...)`.
+- **`REPLACE(text, start, len, new)`** (positional) → `OVERLAY(source.text PLACING 'new' FROM start FOR len)`.
+  Do **not** confuse with DAX `SUBSTITUTE` (value-based) → SQL `REPLACE`.
+- **`FORMAT(x, "pattern")`** → this is display formatting, **not a measure**. Emit semantic
+  metadata, not a `FORMAT` call (see `PATTERNS.md §9`). `dax_class="display_layer"`.
+- **`FIXED(x, d)`** → `format_number(source.x, d)` returns a *string*; if the intent is a rounded
+  number use `ROUND(source.x, d)` and flag the ambiguity.
+
+**`CONCATENATEX(t, expr, delim)`** — string aggregation across rows. This builds a label, not a
+metric. `dax_class="display_layer"`, skip (see `UNSUPPORTED.md`). Only if a genuine delimited-list
+*value* is required: `array_join(collect_list(source.col), 'delim')` — but confirm it's a real
+metric first.
+
+---
+
+## 5. Logical & Information
+
+**Logical** — direct → `translatable_direct`:
+
+| DAX | SQL |
+|---|---|
+| `IF(c, t, f)` / `IF.EAGER` | `CASE WHEN c THEN t ELSE f END` |
+| `SWITCH(x, v1, r1, …, else)` | `CASE x WHEN v1 THEN r1 … ELSE else END` (value form) |
+| `AND`/`OR`/`NOT` | `AND`/`OR`/`NOT` |
+| `COALESCE` | `COALESCE` |
+| `TRUE`/`FALSE` | `true`/`false` |
+| `BITAND/BITOR/BITXOR` | `&` / `\|` / `^` |
+| `BITLSHIFT/BITRSHIFT` | `shiftleft` / `shiftright` |
+| `IFERROR(a, alt)` | `COALESCE(try(a), alt)` |
+
+> `SWITCH(TRUE(), …)` and `SWITCH` over a slicer selection are **display-layer dispatch**, not a
+> value form — see `PATTERNS.md §5/§6`. Only the value form (`SWITCH(col, …)`) maps to `CASE`.
+
+**Information** — value tests are direct; context tests are not:
+
+| DAX | SQL / action | `dax_class` |
+|---|---|---|
+| `ISBLANK(x)` | `source.x IS NULL` | `translatable_direct` |
+| `ISERROR(a)` | `try(a) IS NULL` | `translatable_direct` |
+| `ISEVEN/ISODD` | `source.n % 2 = 0` / `!= 0` | `translatable_direct` |
+| `ISNUMBER/ISTEXT/ISLOGICAL/…` (type tests) | `typeof(source.col) = 'int'` etc. | `translatable_direct` |
+| `CONTAINSSTRING(h, n)` | `source.h ILIKE '%n%'` | `translatable_direct` |
+| `CONTAINSSTRINGEXACT(h, n)` | `source.h LIKE '%n%'` | `translatable_direct` |
+| `USERNAME/USERPRINCIPALNAME` | `current_user()` | `translatable_direct` (RLS: prefer UC row policies) |
+| `HASONEVALUE/HASONEFILTER/ISFILTERED/ISINSCOPE/ISCROSSFILTER` | filter-context tests — no metric-view meaning | `unsupported` / skip guard |
+| `SELECTEDMEASURE*`, `ISSELECTEDMEASURE` | calculation-item context | `display_layer` |
+| `NAMEOF`, `USEROBJECTID`, `CUSTOMDATA` | metadata / session | `unsupported` |
+
+`CONTAINS`/`CONTAINSROW` (table membership tests) → an `EXISTS (SELECT … FROM other_table)` is
+**forbidden** (§0.2). If the target is `source`/a join it's a `FILTER (WHERE …)`; otherwise
+`architecture_change`.
+
+---
+
+## 6. Date & time
+
+Direct 1:1 → `translatable_direct`: `YEAR MONTH DAY HOUR MINUTE SECOND QUARTER` (same names on
+`source.col`), `NOW`/`UTCNOW` → `NOW()`, `TODAY` → `CURRENT_DATE()`, `WEEKDAY` → `DAYOFWEEK`,
+`WEEKNUM` → `WEEKOFYEAR`, `DATE(y,m,d)` → `MAKE_DATE`, `DATEVALUE` → `TO_DATE`.
+
+Non-obvious:
+
+| DAX | SQL | Note |
+|---|---|---|
+| `DATEDIFF(a, b, DAY)` | `DATEDIFF(source.b, source.a)` | **arg order swaps**; DAY unit |
+| `DATEDIFF(a, b, MONTH)` | `months_between(source.b, source.a)` | for MONTH/YEAR/QUARTER units |
+| `EDATE(d, n)` | `add_months(source.d, n)` | |
+| `EOMONTH(d, n)` | `last_day(add_months(source.d, n))` | |
+| `YEARFRAC(a, b)` | `datediff(source.b, source.a) / 365.25` | approximation; note basis ignored |
+| `NETWORKDAYS(a, b)` | business-day count | no native fn → `architecture_change` (source-view / UDF) |
+
+---
+
+## 7. Time intelligence
+
+**All of this is covered in depth by `PATTERNS.md` (share-of-total, offsets) and `UNSUPPORTED.md`
+(SAMEPERIODLASTYEAR, TOTALYTD, DATESINPERIOD, PARALLELPERIOD) plus `WINDOW.md` — read those.** The
+one-line routing:
+
+| DAX family | UCMV form | `dax_class` |
+|---|---|---|
+| `TOTALYTD/QTD/MTD`, `DATESYTD/QTD/MTD` | window `range: cumulative` + period `range: current` | `architecture_change` |
+| `SAMEPERIODLASTYEAR`, `PREVIOUSYEAR/MONTH`, `PARALLELPERIOD` | calendar `date_py` self-join **or** window `offset`/`trailing` | `architecture_change` |
+| `DATESINPERIOD`, `DATESBETWEEN` | window `trailing <N> <unit>` | `architecture_change` |
+| `OPENING/CLOSINGBALANCE*`, `FIRSTDATE/LASTDATE` | window `semiadditive: first/last` | `architecture_change` |
+| `STARTOF*`/`ENDOF*` | `date_trunc(...)` / `last_day(...)` on a date dimension | `translatable_direct` (as a dimension) |
+
+Never fabricate a fixed day-offset (e.g. `LAG(…, 365)`) when the period dimension is sparse — if
+no `date_py` column and non-dense periods, leave a documented TODO (`UNSUPPORTED.md`).
+
+---
+
+## 8. Filter / context functions  (mostly ⚪ — they are clauses, not scalars)
+
+These are **filter-context modifiers**, not functions that return a scalar. Their translation is a
+SQL *clause*, and the common shapes are already deep in `PATTERNS.md`:
+
+| DAX | Route | See |
+|---|---|---|
+| `CALCULATE(expr, pred)` | `expr FILTER (WHERE pred)` → `filtered` | `PATTERNS.md §3` |
+| `FILTER(t, pred)` inside an iterator | `FILTER (WHERE pred)` → `filtered` | `PATTERNS.md §2b` |
+| `ALL/ALLSELECTED/REMOVEFILTERS(dim)` | share-of-total window `range: all` → `architecture_change` | `PATTERNS.md §4` |
+| `ALLEXCEPT(t, keep)` | fixed-LOD window at `keep` grain → `architecture_change` | `PATTERNS.md §14` |
+| `KEEPFILTERS(pred)` | intersect predicates with `AND` in the `WHERE` | `PATTERNS.md §3` |
+| `SELECTEDVALUE(dim, alt)` | slicer read — usually `display_layer`; as a guard, skip it | `UNSUPPORTED.md` |
+
+**Visual-calculation functions — always `unsupported` (❌), never force an aggregate:**
+`FIRST`, `LAST`, `NEXT`, `PREVIOUS`, `INDEX`, `OFFSET` (visual), `RANK`, `ROWNUMBER`,
+`RUNNINGSUM`, `MOVINGAVERAGE`, `WINDOW`, `LOOKUP`. These operate on a visual's row order, which a
+metric view has no concept of. If a running/moving figure is genuinely wanted, that's a window
+measure (`WINDOW.md`) — but confirm intent; do not silently convert a visual calc.
+
+`EARLIER`/`EARLIEST` (row-context self-reference) → needs a self-join / precomputed column →
+`architecture_change` (see `EDGE_CASES §4`).
+
+---
+
+## 9. Relationship
+
+| DAX | Route | `dax_class` |
+|---|---|---|
+| `RELATED(dim[col])` | a declared `join` + `dim.col` reference | `filtered`/`composed` (see `PATTERNS.md §7`) |
+| `RELATEDTABLE(t)` inside `SUMX` | aggregate over the join, **not** a subquery | `architecture_change` if it needs a grain change |
+| `USERELATIONSHIP(a, b)` | inactive relationship — no UCMV equivalent | `unsupported` (`UNSUPPORTED.md`) |
+| `CROSSFILTER(...)` | bidirectional filter direction | `unsupported` |
+
+---
+
+## 10. Parent-child (hierarchies)
+
+`PATH`, `PATHITEM`, `PATHITEMREVERSE`, `PATHLENGTH`, `PATHCONTAINS` build/query an ancestor path
+from a self-referencing (`id`, `parent_id`) table. This is a **recursive CTE** — not expressible in
+a single measure expr (§0.2). Route to `architecture_change`:
+
+```
+DAX:  PATH(Emp[ID], Emp[ParentID])
+→ dax_class="architecture_change"
+  explanation: "Parent-child path. Precompute in the source view with a recursive CTE
+   (WITH RECURSIVE anc AS (... UNION ALL ...)) exposing a `path` column, then PATHITEM →
+   element_at(split(path,'|'), n), PATHCONTAINS → array_contains(split(path,'|'), x),
+   PATHLENGTH → size(split(path,'|'))."
+```
+
+Once `path` exists as a source column, the `PATHITEM`/`PATHCONTAINS`/`PATHLENGTH` readers become
+direct scalar expressions on `source.path`.
+
+---
+
+## 11. Financial
+
+No native SQL. Two routes, in order:
+
+1. **Closed-form → inline arithmetic on `source.` columns** (`translatable_direct`): `SLN` →
+   `(source.cost - source.salvage) / source.life`; `EFFECT` → `POWER(1 + source.rate/source.n, source.n) - 1`;
+   `NOMINAL`, `RRI` → `POWER(source.fv/source.pv, 1.0/source.n) - 1`; `PDURATION`, `DOLLARDE/FR`,
+   `TBILLYIELD/PRICE/EQ`, `INTRATE`, `RECEIVED`, `DISC`, `ACCRINTM`.
+2. **Iterative / no closed form → existing UC UDF or `architecture_change`**: `XIRR`, `RATE`,
+   `NPER`, `YIELD*`, `IRR`, `VDB`, `DURATION`, `MDURATION`, `ODDF*`, `COUP*`.
+
+Financial functions almost never appear as BI *measures*; if one does, prefer the closed form and
+flag for review. Never invent a UDF name.
+
+---
+
+## 12. Table manipulation
+
+| DAX | Route | `dax_class` |
+|---|---|---|
+| `SUMMARIZE(t, cols, "m", agg)` | `GROUP BY` — usually the metric-view grain itself | see `PATTERNS.md §13` |
+| `SUMX(SUMMARIZE(...))` | source-view `GROUP BY` precompute | `architecture_change` (`PATTERNS.md §13`) |
+| `ADDCOLUMNS/SELECTCOLUMNS/ROW` | projection — a dimension/measure expr, not a table | `translatable_direct` |
+| `VALUES/DISTINCT(col)` in `COUNTROWS` | `COUNT(DISTINCT source.col)` | `translatable_direct` (`PATTERNS.md §12`) |
+| `TREATAS(list, col)` | disconnected-slicer dispatch | `unsupported` (`UNSUPPORTED.md`) |
+| `TOPN(n, t, order)` | row-selection → source `ROW_NUMBER()`/`QUALIFY` precompute | `architecture_change` (`UNSUPPORTED.md`) |
+| `GENERATE/GENERATEALL` | lateral join → source view | `architecture_change` |
+| `CROSSJOIN/UNION/INTERSECT/EXCEPT` | set ops belong in the **source** view, not a measure | `architecture_change` |
+| `LOOKUPVALUE(res, key, val)` | label/param lookup — usually a join or display text | `display_layer` / a `join` (`UNSUPPORTED.md`) |
+
+---
+
+## 13. Quick decline list (⚪/❌ — return `success=false`)
+
+When the measure's top-level intent is one of these and no source-view reshape is in scope, decline
+cleanly with the class shown — **do not fabricate a translation**:
+
+- **`display_layer`**: `FORMAT`, `CONCATENATEX`, `SELECTEDVALUE`-guard, `SWITCH`-on-slicer,
+  `SELECTEDMEASURE*`, `LOOKUPVALUE`-as-label, `ISSELECTEDMEASURE`.
+- **`unsupported`**: `ALLSELECTED` (scope-aware), `USERELATIONSHIP`, `CROSSFILTER`, `TREATAS`,
+  `FIRST/LAST/INDEX/NEXT/PREVIOUS/RANK/ROWNUMBER/RUNNINGSUM/MOVINGAVERAGE/WINDOW` (visual calcs),
+  `NAMEOF`, `CUSTOMDATA`, `USEROBJECTID`, `EXTERNALMEASURE`, `ISFILTERED/ISCROSSFILTERED`.
+- **`architecture_change`** (emittable after a source-view reshape): `PATH*`, `TOPN`, `RANKX`,
+  time-intelligence, `ALL/ALLEXCEPT` share-of-total/LOD, `SUMX(SUMMARIZE)`, recursive/self-join
+  shapes, set operations, iterative financial.
+
+The honest talk-track: **every DAX function reduces to SQL** — but roughly half are direct
+metric-view expressions, some need the source view reshaped first (that's `architecture_change`,
+not failure), and a genuine minority are Power-BI-visual conveniences with no metric meaning. Your
+job is the *correct verdict*, not a forced translation.

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/PATTERNS.md
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/PATTERNS.md
@@ -411,3 +411,149 @@ Rules:
   `SUM(...) OVER (PARTITION BY keep_col1, keep_col2)` as an identity dimension, or
   flag UNSUPPORTED. Do NOT approximate with a single `range: all` window — it
   would collapse the wrong dimensions.
+
+---
+
+# Measure-shape recipes (daxpatterns.com)
+
+The sections above are the shapes seen most in the wild. The following are the
+standard analytical *patterns* from daxpatterns.com — each is a whole measure
+shape rather than a single function. Most reduce to a **source-view precompute**
+(a `GROUP BY` / `OVER (...)` in the `source:` SELECT, exposed as a dimension or a
+pre-aggregated column) that a plain measure then sums. That precompute is the
+`dax_class="architecture_change"` route: emittable, but it reshapes the source.
+For per-function mappings, see `FUNCTION_REFERENCE.md`.
+
+## 15. Static segmentation (fixed bands)
+
+Fixed price/age/size bands off a single row value → a `CASE` **dimension** (not a
+measure). The band is known without aggregating.
+
+```
+DAX:  Price Band := SWITCH(TRUE(), [Price]<10,"Low", [Price]<50,"Mid", "High")
+
+YAML: dimensions:
+        - name: price_band
+          expr: |
+            CASE WHEN source.price < 10 THEN 'Low'
+                 WHEN source.price < 50 THEN 'Mid'
+                 ELSE 'High' END
+```
+
+This is the ONE segmentation case that is a clean `translatable_direct` — it's a
+row-level bucket. Contrast with §16.
+
+## 16. Dynamic segmentation (band on an aggregated value)
+
+Count/measure entities whose **aggregated** value falls in a band (e.g. "customers
+whose total sales > 1000"). The band depends on an aggregate, so the row-level
+`CASE` of §15 is wrong — you must pre-aggregate to the entity grain first, then
+bucket. That is a source-view precompute.
+
+```
+DAX:  Big Customers :=
+        CALCULATE(DISTINCTCOUNT(Cust[Id]), FILTER(VALUES(Cust[Id]), [Sales] > 1000))
+
+YAML: version: '1.1'
+      source: |
+        SELECT cust_id, SUM(amount) AS cust_sales
+        FROM <catalog>.<schema>.sales
+        GROUP BY cust_id
+      dimensions:
+        - name: sales_band
+          expr: CASE WHEN source.cust_sales > 1000 THEN 'Big' ELSE 'Small' END
+      measures:
+        - name: customers
+          expr: COUNT(DISTINCT source.cust_id)          -- filter band at query time
+```
+
+Rule: the entity you count (`cust_id`) becomes the `GROUP BY` grain of the source
+precompute; the threshold measure (`[Sales]`) becomes the aggregate in that SELECT.
+Never approximate with a row-level `CASE` on the raw fact — it buckets rows, not
+entities.
+
+## 17. New & returning customers (first-purchase logic)
+
+"New in period" = entities whose FIRST-ever event falls in the period. `MIN() OVER`
+per entity in the source view exposes the first-event date; the measure then
+counts by comparing it to the row's period.
+
+```
+DAX:  New Customers :=
+        CALCULATE(DISTINCTCOUNT(Sales[Cust]),
+          FILTER(VALUES(Sales[Cust]), [First Order Date] IN <current period>))
+
+YAML: source: |
+        SELECT *, MIN(order_date) OVER (PARTITION BY cust_id) AS first_order_date
+        FROM <catalog>.<schema>.sales
+      measures:
+        - name: new_customers
+          expr: |
+            COUNT(DISTINCT source.cust_id)
+            FILTER (WHERE date_trunc('month', source.order_date)
+                      = date_trunc('month', source.first_order_date))
+        - name: returning_customers
+          expr: |
+            COUNT(DISTINCT source.cust_id)
+            FILTER (WHERE date_trunc('month', source.order_date)
+                      > date_trunc('month', source.first_order_date))
+```
+
+The `MIN(...) OVER (PARTITION BY entity)` first-event column is the reusable
+building block for new/returning/reactivated/churn variants.
+
+## 18. Events in progress (active-at-a-point-in-time)
+
+Count events open at each date: `start <= d AND (end >= d OR end IS NULL)`. This is
+a **range-join to a date spine**, not a fact aggregate — the fact has one row per
+event, but you count it once per active day. Requires a `dim_date` join.
+
+```
+DAX:  Open := CALCULATE(COUNTROWS(Ev),
+        FILTER(Ev, Ev[Start] <= MAX('Date'[Date]) && Ev[End] >= MIN('Date'[Date])))
+
+YAML: joins:
+        - name: cal
+          source: <catalog>.<schema>.dim_date
+          'on': source.start_date <= cal.d AND (source.end_date >= cal.d OR source.end_date IS NULL)
+      measures:
+        - name: events_in_progress
+          expr: COUNT(1)          # grouped by cal.d at query time
+```
+
+If the range-join is not acceptable (fan-out concerns), route to
+`architecture_change` and describe a source-view spine explode instead.
+
+## 19. Like-for-like / same-store
+
+Compare only entities present in **both** the current and prior period. The
+"present in both" set is an intersection — expressible as a `FILTER (WHERE …)` only
+if a "present-in-prior" flag is precomputed on the fact; otherwise it needs a
+source-view self-join.
+
+```
+DAX:  Same-Store Sales := CALCULATE([Sales],
+        FILTER(VALUES(Store[Id]), <store active in both periods>))
+
+YAML: source: |
+        SELECT s.*,
+          MAX(CASE WHEN period = :prev THEN 1 ELSE 0 END) OVER (PARTITION BY store_id) AS in_prev,
+          MAX(CASE WHEN period = :cur  THEN 1 ELSE 0 END) OVER (PARTITION BY store_id) AS in_cur
+        FROM <catalog>.<schema>.sales s
+      measures:
+        - name: like_for_like_sales
+          expr: SUM(source.amount) FILTER (WHERE source.in_prev = 1 AND source.in_cur = 1)
+```
+
+`dax_class="architecture_change"` — the `in_prev`/`in_cur` flags are the source
+reshape. Pair with the period-offset measure (§ time intelligence) for the
+comparison itself.
+
+## 20. Ranking / TOPN
+
+`RANKX` / `TOPN` rank-and-slice; metric views aggregate. See
+`FUNCTION_REFERENCE.md §2` (RANKX) and `UNSUPPORTED.md` (TOPN). Simple "rank by a
+measure" belongs in the **dashboard/visual** layer; a stored top-N needs a
+source-view `ROW_NUMBER() OVER (ORDER BY … DESC)` (or `QUALIFY`) exposed as a
+column. Do not emit a bare `MAX`/aggregate in place of a rank — it changes the
+semantics.

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/PATTERNS.md
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/PATTERNS.md
@@ -2,6 +2,43 @@
 
 Each entry shows the DAX pattern, its UC metric view equivalent, and migration notes.
 
+## 0. Output Conventions (MUST follow for EVERY `sql_expr`)
+
+These apply on top of the per-pattern notes below.
+
+### 0.1 Qualify source columns with `source.` — including inside FILTER
+
+Write source-table columns as `source.<col>` **everywhere they appear**, including
+inside `FILTER (WHERE ...)` clauses and `CASE WHEN` predicates. Unqualified names
+are technically valid (they default to `source`), but this pipeline standardises
+on the explicit `source.` prefix for consistency and review.
+
+```
+DAX:  CALCULATE(COUNTROWS(fact), fact[check_status] = 0)
+SQL:  COUNT(1) FILTER (WHERE source.check_status = 0)     -- ✅ source. in FILTER
+NOT:  COUNT(1) FILTER (WHERE check_status = 0)            -- ❌ unqualified
+```
+
+Columns from a **declared join** use that join's name (`<join_name>.<col>`, see
+§7). Backtick names with spaces/punctuation: `` source.`Check Status` ``.
+
+### 0.2 A metric view is SINGLE-SOURCE — never emit cross-table subqueries
+
+The only valid column namespaces are `source` and the **declared join names**.
+Do **not** emit a subquery that selects `FROM` another table, e.g.
+`... IN (SELECT key FROM tech_rules_exceptions)` or
+`... = (SELECT MAX(week_445_sequential) FROM param_calendar445)`. Such SQL
+references a table that is neither `source` nor a declared join and will not
+deploy.
+
+If a measure genuinely needs a table that is neither `source` nor a declared
+join — e.g. a separate calendar for a max-date / time-intelligence lookup, or an
+exceptions list for a `NOT IN` filter — it is **not expressible as-is**. Return
+`success=false` with `dax_class="architecture_change"` and say what the source
+view would need (e.g. "precompute max_available_date per week grain as a column",
+"materialise the exceptions flag on the fact"). Never fabricate a cross-table
+subquery to force a translation.
+
 ## 1. Direct Aggregations (Leaf Measures)
 
 ### SUM

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/SKILL.md
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/SKILL.md
@@ -21,6 +21,9 @@ For each DAX measure, classify it into one of these categories:
 6. **Not translatable**: `ALLSELECTED`, `USERELATIONSHIP`, certain time-intelligence -> flag for review.
 7. **Out of scope**: `EXTERNALMEASURE`, DirectQuery references -> flag.
 
-For the complete pattern catalog, read [PATTERNS.md](PATTERNS.md).
+For the complete pattern catalog (measure shapes), read [PATTERNS.md](PATTERNS.md).
+For the function-by-function map (what any individual DAX function becomes in a
+measure expr, and which functions are not a measure at all), read
+[FUNCTION_REFERENCE.md](FUNCTION_REFERENCE.md).
 For patterns that cannot be translated, read [UNSUPPORTED.md](UNSUPPORTED.md).
 For edge cases and gotchas, read [EDGE_CASES.md](EDGE_CASES.md).

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/function_reference.json
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/skills/dax/function_reference.json
@@ -1,0 +1,3476 @@
+{
+ "APPROXIMATEDISTINCTCOUNT": {
+  "name": "APPROXIMATEDISTINCTCOUNT",
+  "category": "Aggregation",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "APPROXIMATEDISTINCTCOUNT(sales[id])",
+  "sql_reference_raw": "Approximation varies by dialect; no standard SQL equivalent",
+  "curated": false
+ },
+ "AVERAGE": {
+  "name": "AVERAGE",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "AVERAGE(sales[amount])",
+  "sql_reference_raw": "`AVG(amount)`",
+  "curated": false
+ },
+ "AVERAGEA": {
+  "name": "AVERAGEA",
+  "category": "Aggregation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "AVERAGEA(table[text_or_num])",
+  "sql_reference_raw": "`AVG(CAST(col AS DOUBLE))` or UDF treating text as 0",
+  "curated": false
+ },
+ "AVERAGEX": {
+  "name": "AVERAGEX",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "AVERAGEX(sales, sales[price] * sales[qty])",
+  "sql_reference_raw": "`AVG(price * qty)`",
+  "curated": false
+ },
+ "COUNT": {
+  "name": "COUNT",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COUNT(sales[id])",
+  "sql_reference_raw": "`COUNT(id)`",
+  "curated": false
+ },
+ "COUNTA": {
+  "name": "COUNTA",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COUNTA(sales[id])",
+  "sql_reference_raw": "`COUNT(*)` or `COUNT(id)` (both count non-null)",
+  "curated": false
+ },
+ "COUNTAX": {
+  "name": "COUNTAX",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COUNTAX(sales, sales[qty])",
+  "sql_reference_raw": "`COUNT(qty)`",
+  "curated": false
+ },
+ "COUNTBLANK": {
+  "name": "COUNTBLANK",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COUNTBLANK(sales[notes])",
+  "sql_reference_raw": "`COUNT(*) - COUNT(notes)`",
+  "curated": false
+ },
+ "COUNTROWS": {
+  "name": "COUNTROWS",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COUNTROWS(FILTER(sales, sales[region]=\"US\"))",
+  "sql_reference_raw": "`COUNT(*)` or table rowcount",
+  "curated": false
+ },
+ "COUNTX": {
+  "name": "COUNTX",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COUNTX(sales, sales[price])",
+  "sql_reference_raw": "`COUNT(price)`",
+  "curated": false
+ },
+ "DISTINCTCOUNT": {
+  "name": "DISTINCTCOUNT",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DISTINCTCOUNT(sales[customer_id])",
+  "sql_reference_raw": "`COUNT(DISTINCT customer_id)`",
+  "curated": false
+ },
+ "DISTINCTCOUNTNOBLANK": {
+  "name": "DISTINCTCOUNTNOBLANK",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DISTINCTCOUNTNOBLANK(sales[id])",
+  "sql_reference_raw": "`COUNT(DISTINCT id)` (excludes NULL by default)",
+  "curated": false
+ },
+ "MAX": {
+  "name": "MAX",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MAX(sales[amount])",
+  "sql_reference_raw": "`MAX(amount)`",
+  "curated": false
+ },
+ "MAXA": {
+  "name": "MAXA",
+  "category": "Aggregation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "MAXA(table[values])",
+  "sql_reference_raw": "`MAX(CAST(col AS DOUBLE))` or UDF for text handling",
+  "curated": false
+ },
+ "MAXX": {
+  "name": "MAXX",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MAXX(sales, sales[price] * sales[qty])",
+  "sql_reference_raw": "`MAX(price * qty)`",
+  "curated": false
+ },
+ "MIN": {
+  "name": "MIN",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MIN(sales[amount])",
+  "sql_reference_raw": "`MIN(amount)`",
+  "curated": false
+ },
+ "MINA": {
+  "name": "MINA",
+  "category": "Aggregation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "MINA(table[values])",
+  "sql_reference_raw": "`MIN(CAST(col AS DOUBLE))` or UDF for text handling",
+  "curated": false
+ },
+ "MINX": {
+  "name": "MINX",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MINX(sales, sales[price] * sales[qty])",
+  "sql_reference_raw": "`MIN(price * qty)`",
+  "curated": false
+ },
+ "PRODUCT": {
+  "name": "PRODUCT",
+  "category": "Aggregation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PRODUCT(sales[multiplier])",
+  "sql_reference_raw": "`EXP(SUM(LN(multiplier)))` or UDF",
+  "curated": false
+ },
+ "PRODUCTX": {
+  "name": "PRODUCTX",
+  "category": "Aggregation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PRODUCTX(sales, sales[factor])",
+  "sql_reference_raw": "`EXP(SUM(LN(factor)))` or UDF",
+  "curated": false
+ },
+ "SUM": {
+  "name": "SUM",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SUM(sales[amount])",
+  "sql_reference_raw": "`SUM(amount)`",
+  "curated": false
+ },
+ "SUMX": {
+  "name": "SUMX",
+  "category": "Aggregation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SUMX(sales, sales[price] * sales[qty])",
+  "sql_reference_raw": "`SUM(price * qty)`",
+  "curated": false
+ },
+ "CALENDAR": {
+  "name": "CALENDAR",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALENDAR(DATE(2024,1,1), DATE(2024,12,31))",
+  "sql_reference_raw": "`SELECT EXPLODE(SEQUENCE(DATE '2024-01-01', DATE '2024-12-31')) AS Date`",
+  "curated": false
+ },
+ "CALENDARAUTO": {
+  "name": "CALENDARAUTO",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALENDARAUTO()",
+  "sql_reference_raw": "`SELECT EXPLODE(SEQUENCE(MIN(date_col), MAX(date_col))) FROM table`",
+  "curated": false
+ },
+ "DATE": {
+  "name": "DATE",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DATE(2024, 3, 15)",
+  "sql_reference_raw": "`MAKE_DATE(2024, 3, 15)`",
+  "curated": false
+ },
+ "DATEDIFF": {
+  "name": "DATEDIFF",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DATEDIFF([EndDate], [StartDate], DAY)",
+  "sql_reference_raw": "`DATEDIFF(end_date, start_date)`",
+  "curated": false
+ },
+ "DATEVALUE": {
+  "name": "DATEVALUE",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DATEVALUE(\"2024-03-15\")",
+  "sql_reference_raw": "`TO_DATE('2024-03-15', 'yyyy-MM-dd')`",
+  "curated": false
+ },
+ "DAY": {
+  "name": "DAY",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DAY([OrderDate])",
+  "sql_reference_raw": "`DAY(order_date)`",
+  "curated": false
+ },
+ "EDATE": {
+  "name": "EDATE",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "EDATE([StartDate], 6)",
+  "sql_reference_raw": "`ADD_MONTHS(start_date, 6)`",
+  "curated": false
+ },
+ "EOMONTH": {
+  "name": "EOMONTH",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "EOMONTH([Date], -1)",
+  "sql_reference_raw": "`LAST_DAY(ADD_MONTHS(date_col, -1))`",
+  "curated": false
+ },
+ "HOUR": {
+  "name": "HOUR",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "HOUR([TimeStamp])",
+  "sql_reference_raw": "`HOUR(timestamp_col)`",
+  "curated": false
+ },
+ "MINUTE": {
+  "name": "MINUTE",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MINUTE([TimeStamp])",
+  "sql_reference_raw": "`MINUTE(timestamp_col)`",
+  "curated": false
+ },
+ "MONTH": {
+  "name": "MONTH",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MONTH([Date])",
+  "sql_reference_raw": "`MONTH(date_col)`",
+  "curated": false
+ },
+ "NETWORKDAYS": {
+  "name": "NETWORKDAYS",
+  "category": "Date & time",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "NETWORKDAYS([StartDate], [EndDate])",
+  "sql_reference_raw": "`DATEDIFF(end_date, start_date) - (DAYOFWEEK(end_date)-1 + DAYOFWEEK(start_date)-1) / 2`",
+  "curated": false
+ },
+ "NOW": {
+  "name": "NOW",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "NOW()",
+  "sql_reference_raw": "`NOW()` or `CURRENT_TIMESTAMP()`",
+  "curated": false
+ },
+ "QUARTER": {
+  "name": "QUARTER",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "QUARTER([Date])",
+  "sql_reference_raw": "`QUARTER(date_col)`",
+  "curated": false
+ },
+ "SECOND": {
+  "name": "SECOND",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SECOND([TimeStamp])",
+  "sql_reference_raw": "`SECOND(timestamp_col)`",
+  "curated": false
+ },
+ "TIME": {
+  "name": "TIME",
+  "category": "Date & time",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "TIME(14, 30, 45)",
+  "sql_reference_raw": "`MAKE_TIMESTAMP(0, 0, 0, 14, 30, 45, 0)`",
+  "curated": false
+ },
+ "TIMEVALUE": {
+  "name": "TIMEVALUE",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TIMEVALUE(\"14:30:45\")",
+  "sql_reference_raw": "`CAST('14:30:45' AS TIMESTAMP)` or `TO_TIMESTAMP('14:30:45', 'HH:mm:ss')`",
+  "curated": false
+ },
+ "TODAY": {
+  "name": "TODAY",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TODAY()",
+  "sql_reference_raw": "`CURRENT_DATE()`",
+  "curated": false
+ },
+ "UTCNOW": {
+  "name": "UTCNOW",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "UTCNOW()",
+  "sql_reference_raw": "`NOW() AT TIME ZONE 'UTC'`",
+  "curated": false
+ },
+ "UTCTODAY": {
+  "name": "UTCTODAY",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "UTCTODAY()",
+  "sql_reference_raw": "`CURRENT_DATE() AT TIME ZONE 'UTC'`",
+  "curated": false
+ },
+ "WEEKDAY": {
+  "name": "WEEKDAY",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "WEEKDAY([Date])",
+  "sql_reference_raw": "`DAYOFWEEK(date_col)`",
+  "curated": false
+ },
+ "WEEKNUM": {
+  "name": "WEEKNUM",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "WEEKNUM([Date], 1)",
+  "sql_reference_raw": "`WEEKOFYEAR(date_col)`",
+  "curated": false
+ },
+ "YEAR": {
+  "name": "YEAR",
+  "category": "Date & time",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "YEAR([Date])",
+  "sql_reference_raw": "`YEAR(date_col)`",
+  "curated": false
+ },
+ "YEARFRAC": {
+  "name": "YEARFRAC",
+  "category": "Date & time",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "YEARFRAC([StartDate], [EndDate])",
+  "sql_reference_raw": "`DATEDIFF(end_date, start_date) / 365.25`",
+  "curated": false
+ },
+ "CLOSINGBALANCEWEEK": {
+  "name": "CLOSINGBALANCEWEEK",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CLOSINGBALANCEWEEK(SUM(Sales))",
+  "sql_reference_raw": "`SUM(revenue) OVER (PARTITION BY week ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with semiadditive: last",
+  "curated": false
+ },
+ "CLOSINGBALANCEMONTH": {
+  "name": "CLOSINGBALANCEMONTH",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CLOSINGBALANCEMONTH(SUM(Inventory))",
+  "sql_reference_raw": "`SUM(quantity) OVER (PARTITION BY month ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with semiadditive: last",
+  "curated": false
+ },
+ "CLOSINGBALANCEQUARTER": {
+  "name": "CLOSINGBALANCEQUARTER",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CLOSINGBALANCEQUARTER(SUM(Balance))",
+  "sql_reference_raw": "`SUM(balance) OVER (PARTITION BY quarter ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with semiadditive: last",
+  "curated": false
+ },
+ "CLOSINGBALANCEYEAR": {
+  "name": "CLOSINGBALANCEYEAR",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CLOSINGBALANCEYEAR(SUM(Reserve))",
+  "sql_reference_raw": "`SUM(reserve) OVER (PARTITION BY year ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with semiadditive: last",
+  "curated": false
+ },
+ "OPENINGBALANCEWEEK": {
+  "name": "OPENINGBALANCEWEEK",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "OPENINGBALANCEWEEK(SUM(Sales))",
+  "sql_reference_raw": "`SUM(revenue) OVER (PARTITION BY week ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with semiadditive: first",
+  "curated": false
+ },
+ "OPENINGBALANCEMONTH": {
+  "name": "OPENINGBALANCEMONTH",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "OPENINGBALANCEMONTH(SUM(Inventory))",
+  "sql_reference_raw": "`SUM(quantity) OVER (PARTITION BY month ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with semiadditive: first",
+  "curated": false
+ },
+ "OPENINGBALANCEQUARTER": {
+  "name": "OPENINGBALANCEQUARTER",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "OPENINGBALANCEQUARTER(SUM(Balance))",
+  "sql_reference_raw": "`SUM(balance) OVER (PARTITION BY quarter ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with semiadditive: first",
+  "curated": false
+ },
+ "OPENINGBALANCEYEAR": {
+  "name": "OPENINGBALANCEYEAR",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "OPENINGBALANCEYEAR(SUM(Reserve))",
+  "sql_reference_raw": "`SUM(reserve) OVER (PARTITION BY year ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with semiadditive: first",
+  "curated": false
+ },
+ "DATESYTD": {
+  "name": "DATESYTD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATETABLE(Sales, DATESYTD(Dates[Date]))",
+  "sql_reference_raw": "`WHERE date BETWEEN date_trunc('year', current_date) AND current_date`",
+  "curated": false
+ },
+ "TOTALYTD": {
+  "name": "TOTALYTD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TOTALYTD(SUM(Sales), Dates[Date])",
+  "sql_reference_raw": "`SUM(amount) OVER (PARTITION BY year(date) ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with range: cumulative",
+  "curated": false
+ },
+ "DATESQTD": {
+  "name": "DATESQTD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATETABLE(Sales, DATESQTD(Dates[Date]))",
+  "sql_reference_raw": "`WHERE date BETWEEN date_trunc('quarter', current_date) AND current_date`",
+  "curated": false
+ },
+ "TOTALQTD": {
+  "name": "TOTALQTD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TOTALQTD(SUM(Sales), Dates[Date])",
+  "sql_reference_raw": "`SUM(amount) OVER (PARTITION BY quarter(date) ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with range: cumulative",
+  "curated": false
+ },
+ "DATESMTD": {
+  "name": "DATESMTD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATETABLE(Sales, DATESMTD(Dates[Date]))",
+  "sql_reference_raw": "`WHERE date BETWEEN date_trunc('month', current_date) AND current_date`",
+  "curated": false
+ },
+ "TOTALMTD": {
+  "name": "TOTALMTD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TOTALMTD(SUM(Sales), Dates[Date])",
+  "sql_reference_raw": "`SUM(amount) OVER (PARTITION BY month(date), year(date) ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with range: cumulative",
+  "curated": false
+ },
+ "DATESWTD": {
+  "name": "DATESWTD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATETABLE(Sales, DATESWTD(Dates[Date]))",
+  "sql_reference_raw": "`WHERE date BETWEEN date_trunc('week', current_date) AND current_date`",
+  "curated": false
+ },
+ "TOTALWTD": {
+  "name": "TOTALWTD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TOTALWTD(SUM(Sales), Dates[Date])",
+  "sql_reference_raw": "`SUM(amount) OVER (PARTITION BY week(date), year(date) ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)` with range: cumulative",
+  "curated": false
+ },
+ "STARTOFYEAR": {
+  "name": "STARTOFYEAR",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), STARTOFYEAR(Dates[Date]))",
+  "sql_reference_raw": "`date_trunc('year', date)` or `MIN(date) FILTER (PARTITION BY year(date))`",
+  "curated": false
+ },
+ "STARTOFQUARTER": {
+  "name": "STARTOFQUARTER",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), STARTOFQUARTER(Dates[Date]))",
+  "sql_reference_raw": "`date_trunc('quarter', date)`",
+  "curated": false
+ },
+ "STARTOFMONTH": {
+  "name": "STARTOFMONTH",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), STARTOFMONTH(Dates[Date]))",
+  "sql_reference_raw": "`date_trunc('month', date)` or `CAST(date AS DATE)` of first day",
+  "curated": false
+ },
+ "STARTOFWEEK": {
+  "name": "STARTOFWEEK",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), STARTOFWEEK(Dates[Date]))",
+  "sql_reference_raw": "`date_trunc('week', date)`",
+  "curated": false
+ },
+ "ENDOFYEAR": {
+  "name": "ENDOFYEAR",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), ENDOFYEAR(Dates[Date]))",
+  "sql_reference_raw": "`last_day(date_trunc('year', date))`",
+  "curated": false
+ },
+ "ENDOFQUARTER": {
+  "name": "ENDOFQUARTER",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), ENDOFQUARTER(Dates[Date]))",
+  "sql_reference_raw": "`last_day(date_trunc('quarter', date))`",
+  "curated": false
+ },
+ "ENDOFMONTH": {
+  "name": "ENDOFMONTH",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), ENDOFMONTH(Dates[Date]))",
+  "sql_reference_raw": "`last_day(date)`",
+  "curated": false
+ },
+ "ENDOFWEEK": {
+  "name": "ENDOFWEEK",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), ENDOFWEEK(Dates[Date]))",
+  "sql_reference_raw": "`date_add(date_trunc('week', date), 6)` or window for last_day of week",
+  "curated": false
+ },
+ "FIRSTDATE": {
+  "name": "FIRSTDATE",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "FIRSTDATE(Dates[Date])",
+  "sql_reference_raw": "`MIN(date)` aggregate or FIRST_VALUE() window",
+  "curated": false
+ },
+ "LASTDATE": {
+  "name": "LASTDATE",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "LASTDATE(Dates[Date])",
+  "sql_reference_raw": "`MAX(date)` aggregate or LAST_VALUE() window",
+  "curated": false
+ },
+ "SAMEPERIODLASTYEAR": {
+  "name": "SAMEPERIODLASTYEAR",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), SAMEPERIODLASTYEAR(Dates[Date]))",
+  "sql_reference_raw": "`LAG(date, 365) OVER (ORDER BY date)` or UCMV offset: -12 month",
+  "curated": false
+ },
+ "PARALLELPERIOD": {
+  "name": "PARALLELPERIOD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), PARALLELPERIOD(Dates[Date], -1, QUARTER))",
+  "sql_reference_raw": "`LAG(amount, n) OVER (PARTITION BY period ORDER BY date)` or UCMV offset: -n period",
+  "curated": false
+ },
+ "DATEADD": {
+  "name": "DATEADD",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), DATEADD(Dates[Date], 30, DAY))",
+  "sql_reference_raw": "`date_add(date, INTERVAL 30 DAY)` with window frame",
+  "curated": false
+ },
+ "DATESBETWEEN": {
+  "name": "DATESBETWEEN",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), DATESBETWEEN(Dates[Date], start_date, end_date))",
+  "sql_reference_raw": "`WHERE date BETWEEN start_date AND end_date` or window frame",
+  "curated": false
+ },
+ "DATESINPERIOD": {
+  "name": "DATESINPERIOD",
+  "category": "Time intelligence",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CALCULATE(SUM(Sales), DATESINPERIOD(Dates[Date], start_date, 3, MONTH))",
+  "sql_reference_raw": "`WHERE date BETWEEN start_date AND date_add(start_date, INTERVAL 3 MONTH)`",
+  "curated": false
+ },
+ "NEXTDAY": {
+  "name": "NEXTDAY",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), NEXTDAY(Dates[Date]))",
+  "sql_reference_raw": "`LEAD(date, 1) OVER (ORDER BY date)`",
+  "curated": false
+ },
+ "NEXTWEEK": {
+  "name": "NEXTWEEK",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), NEXTWEEK(Dates[Date]))",
+  "sql_reference_raw": "`LEAD(date, 7) OVER (ORDER BY date)` or window for next week's dates",
+  "curated": false
+ },
+ "NEXTMONTH": {
+  "name": "NEXTMONTH",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), NEXTMONTH(Dates[Date]))",
+  "sql_reference_raw": "`date_add(date_trunc('month', date), INTERVAL 1 MONTH)` with LEAD",
+  "curated": false
+ },
+ "NEXTQUARTER": {
+  "name": "NEXTQUARTER",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), NEXTQUARTER(Dates[Date]))",
+  "sql_reference_raw": "`date_add(date_trunc('quarter', date), INTERVAL 1 QUARTER)` with LEAD",
+  "curated": false
+ },
+ "NEXTYEAR": {
+  "name": "NEXTYEAR",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), NEXTYEAR(Dates[Date]))",
+  "sql_reference_raw": "`date_add(date_trunc('year', date), INTERVAL 1 YEAR)` with LEAD",
+  "curated": false
+ },
+ "PREVIOUSDAY": {
+  "name": "PREVIOUSDAY",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), PREVIOUSDAY(Dates[Date]))",
+  "sql_reference_raw": "`LAG(date, 1) OVER (ORDER BY date)` or UCMV offset: -1 day",
+  "curated": false
+ },
+ "PREVIOUSWEEK": {
+  "name": "PREVIOUSWEEK",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), PREVIOUSWEEK(Dates[Date]))",
+  "sql_reference_raw": "`LAG(date, 7) OVER (ORDER BY date)` or window for previous week",
+  "curated": false
+ },
+ "PREVIOUSMONTH": {
+  "name": "PREVIOUSMONTH",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), PREVIOUSMONTH(Dates[Date]))",
+  "sql_reference_raw": "`date_add(date_trunc('month', date), INTERVAL -1 MONTH)` with LAG",
+  "curated": false
+ },
+ "PREVIOUSQUARTER": {
+  "name": "PREVIOUSQUARTER",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), PREVIOUSQUARTER(Dates[Date]))",
+  "sql_reference_raw": "`date_add(date_trunc('quarter', date), INTERVAL -1 QUARTER)` with LAG",
+  "curated": false
+ },
+ "PREVIOUSYEAR": {
+  "name": "PREVIOUSYEAR",
+  "category": "Time intelligence",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CALCULATE(SUM(Sales), PREVIOUSYEAR(Dates[Date]))",
+  "sql_reference_raw": "`date_add(date_trunc('year', date), INTERVAL -1 YEAR)` with LAG or UCMV offset: -12 month",
+  "curated": false
+ },
+ "ALL": {
+  "name": "ALL",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CALCULATE(SUM(sales), ALL(date))",
+  "sql_reference_raw": "Remove all date filters: `OVER (PARTITION BY 1)` or full table aggregate",
+  "curated": false
+ },
+ "ALLCROSSFILTERED": {
+  "name": "ALLCROSSFILTERED",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CALCULATE(SUM(sales), ALLCROSSFILTERED(table_name))",
+  "sql_reference_raw": "Clear all filters on table: `OVER ()` or `SELECT SUM(...) FROM table_name` (reset context)",
+  "curated": false
+ },
+ "ALLEXCEPT": {
+  "name": "ALLEXCEPT",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CALCULATE(SUM(sales), ALLEXCEPT(date, date_year))",
+  "sql_reference_raw": "Keep only year filter, drop day/month: `OVER (PARTITION BY date_year)`",
+  "curated": false
+ },
+ "ALLNOBLANKROW": {
+  "name": "ALLNOBLANKROW",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CALCULATE(SUM(sales), ALLNOBLANKROW(category))",
+  "sql_reference_raw": "Same as ALL but exclude nulls: `WHERE category IS NOT NULL OVER (PARTITION BY 1)`",
+  "curated": false
+ },
+ "ALLSELECTED": {
+  "name": "ALLSELECTED",
+  "category": "Filter",
+  "feasibility": "ai_bi",
+  "default_dax_class": "display_layer",
+  "dax_example": "CALCULATE(SUM(sales), ALLSELECTED(region))",
+  "sql_reference_raw": "Outer query filter scope; in Databricks use WITH cte or subquery to capture dashboard-level filters",
+  "curated": false
+ },
+ "CALCULATE": {
+  "name": "CALCULATE",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CALCULATE(SUM(sales), date[year]=2024)",
+  "sql_reference_raw": "Scoped aggregate with WHERE: `SELECT SUM(sales) WHERE date_year=2024` or subquery with filter",
+  "curated": false
+ },
+ "CALCULATETABLE": {
+  "name": "CALCULATETABLE",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CALCULATETABLE(VALUES(product), product[category]=\"A\")",
+  "sql_reference_raw": "Subquery with WHERE: `(SELECT DISTINCT product WHERE category='A')`",
+  "curated": false
+ },
+ "EARLIER": {
+  "name": "EARLIER",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "COLUMN1 + EARLIER(COLUMN1)",
+  "sql_reference_raw": "Correlated subquery / self-join: `SELECT t1.col + t2.col FROM t AS t1 JOIN t AS t2 ON t1.id = t2.id`",
+  "curated": false
+ },
+ "EARLIEST": {
+  "name": "EARLIEST",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "EARLIEST(COLUMN1)",
+  "sql_reference_raw": "Outermost evaluation pass; in Databricks use CTE or LAG() to reference outermost context",
+  "curated": false
+ },
+ "FILTER": {
+  "name": "FILTER",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "FILTER(product, product[price]>100)",
+  "sql_reference_raw": "WHERE clause: `SELECT * WHERE price > 100` or `CASE WHEN price > 100 THEN 1 ELSE 0 END`",
+  "curated": false
+ },
+ "FIRST": {
+  "name": "FIRST",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "FIRST(ORDERBY(sales_column, ASC))",
+  "sql_reference_raw": "Visual calculation only; in SQL use `ROW_NUMBER() OVER (ORDER BY sales) = 1` or `FIRST_VALUE()`",
+  "curated": false
+ },
+ "INDEX": {
+  "name": "INDEX",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "INDEX(1, ORDERBY(date, ASC))",
+  "sql_reference_raw": "Visual calculation only; in SQL use `ROW_NUMBER() OVER (ORDER BY date) = position`",
+  "curated": false
+ },
+ "KEEPFILTERS": {
+  "name": "KEEPFILTERS",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CALCULATE(SUM(sales), KEEPFILTERS(date[year]=2024), region=\"North\")",
+  "sql_reference_raw": "Intersect filters with AND: `WHERE date_year=2024 AND region='North'`",
+  "curated": false
+ },
+ "LAST": {
+  "name": "LAST",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "LAST(ORDERBY(sales_column, DESC))",
+  "sql_reference_raw": "Visual calculation only; in SQL use `ROW_NUMBER() OVER (ORDER BY sales DESC) = 1` or `LAST_VALUE()`",
+  "curated": false
+ },
+ "LOOKUP": {
+  "name": "LOOKUP",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "LOOKUP(filter_expression)",
+  "sql_reference_raw": "Visual calculation only; in Databricks use scalar subquery or JOIN",
+  "curated": false
+ },
+ "LOOKUPWITHTOTALS": {
+  "name": "LOOKUPWITHTOTALS",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "LOOKUPWITHTOTALS(filter_expression)",
+  "sql_reference_raw": "Visual calculation only; in Databricks use scalar subquery with explicit total logic",
+  "curated": false
+ },
+ "LOOKUPVALUE": {
+  "name": "LOOKUPVALUE",
+  "category": "Filter",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "LOOKUPVALUE(product[id], product[name], \"Widget\")",
+  "sql_reference_raw": "Scalar subquery / JOIN: `(SELECT id FROM product WHERE name='Widget' LIMIT 1)` or `JOIN...ON product.name='Widget'`",
+  "curated": false
+ },
+ "MATCHBY": {
+  "name": "MATCHBY",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "WINDOW(..., MATCHBY(dimension1, dimension2))",
+  "sql_reference_raw": "Window function partition matching; in SQL use `PARTITION BY dimension1, dimension2` in OVER clause",
+  "curated": false
+ },
+ "MOVINGAVERAGE": {
+  "name": "MOVINGAVERAGE",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "MOVINGAVERAGE(sales, ORDERBY(date))",
+  "sql_reference_raw": "Visual calculation only; in SQL use `AVG() OVER (ROWS BETWEEN N PRECEDING AND CURRENT ROW)`",
+  "curated": false
+ },
+ "NEXT": {
+  "name": "NEXT",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "NEXT(sales_column)",
+  "sql_reference_raw": "Visual calculation only; in SQL use `LEAD(sales_column, 1) OVER (ORDER BY ...)`",
+  "curated": false
+ },
+ "OFFSET": {
+  "name": "OFFSET",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "OFFSET(1, ORDERBY(date), PARTITION BY(region))",
+  "sql_reference_raw": "Window function: `LAG() or LEAD() OVER (PARTITION BY region ORDER BY date)`",
+  "curated": false
+ },
+ "ORDERBY": {
+  "name": "ORDERBY",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "WINDOW(..., ORDERBY(date, ASC))",
+  "sql_reference_raw": "Window function ORDER BY; in SQL use `ORDER BY date ASC` in OVER clause",
+  "curated": false
+ },
+ "PARTITIONBY": {
+  "name": "PARTITIONBY",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "WINDOW(..., PARTITIONBY(region))",
+  "sql_reference_raw": "Window function partition; in SQL use `PARTITION BY region` in OVER clause",
+  "curated": false
+ },
+ "PREVIOUS": {
+  "name": "PREVIOUS",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "PREVIOUS(sales_column)",
+  "sql_reference_raw": "Visual calculation only; in SQL use `LAG(sales_column, 1) OVER (ORDER BY ...)`",
+  "curated": false
+ },
+ "RANGE": {
+  "name": "RANGE",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "RANGE(ALLSELECTED(), [offset_start], [offset_end])",
+  "sql_reference_raw": "Visual calculation only; in SQL use `ROWS/RANGE BETWEEN ... AND ...` in OVER clause",
+  "curated": false
+ },
+ "RANK": {
+  "name": "RANK",
+  "category": "Filter",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "RANK(ORDERBY(sales, DESC))",
+  "sql_reference_raw": "Window function: `RANK() OVER (ORDER BY sales DESC)`",
+  "curated": false
+ },
+ "REMOVEFILTERS": {
+  "name": "REMOVEFILTERS",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CALCULATE(SUM(sales), REMOVEFILTERS(date))",
+  "sql_reference_raw": "Clear date filter: `OVER ()` or full aggregate without date predicate",
+  "curated": false
+ },
+ "ROWNUMBER": {
+  "name": "ROWNUMBER",
+  "category": "Filter",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ROWNUMBER(ORDERBY(date))",
+  "sql_reference_raw": "Window function: `ROW_NUMBER() OVER (ORDER BY date)`",
+  "curated": false
+ },
+ "RUNNINGSUM": {
+  "name": "RUNNINGSUM",
+  "category": "Filter",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "RUNNINGSUM(sales, ORDERBY(date))",
+  "sql_reference_raw": "Visual calculation only; in SQL use `SUM() OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`",
+  "curated": false
+ },
+ "SELECTEDVALUE": {
+  "name": "SELECTEDVALUE",
+  "category": "Filter",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "SELECTEDVALUE(product[category], \"Unknown\")",
+  "sql_reference_raw": "Conditional aggregate: `CASE WHEN COUNT(DISTINCT category)=1 THEN MIN(category) ELSE 'Unknown' END`",
+  "curated": false
+ },
+ "WINDOW": {
+  "name": "WINDOW",
+  "category": "Filter",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "WINDOW(ORDERBY(date), PARTITIONBY(region), RANGE(...))",
+  "sql_reference_raw": "Full window function: `ROW_NUMBER/RANK/SUM etc. OVER (PARTITION BY region ORDER BY date RANGE/ROWS BETWEEN ...)`",
+  "curated": false
+ },
+ "PMT": {
+  "name": "PMT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PMT(0.05/12, 360, -200000)` → 1073.64",
+  "sql_reference_raw": "`ROUND(pv * (r * (1 + r)^n) / ((1 + r)^n - 1), 2)` where r=rate/periods, n=nper",
+  "curated": false
+ },
+ "FV": {
+  "name": "FV",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "FV(0.05, 10, -1000, 0)` → 12578.0",
+  "sql_reference_raw": "`pv * (1 + r)^n + pmt * (((1 + r)^n - 1) / r)`",
+  "curated": false
+ },
+ "PV": {
+  "name": "PV",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PV(0.05, 10, -1000)` → 7721.7",
+  "sql_reference_raw": "`fv / (1 + r)^n - pmt * ((1 - (1 + r)^-n) / r)`",
+  "curated": false
+ },
+ "NPER": {
+  "name": "NPER",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "NPER(0.05, -1000, -100000, 0)` → 119.7",
+  "sql_reference_raw": "`SQL/Python UDF (iterative)` - no closed form",
+  "curated": false
+ },
+ "RATE": {
+  "name": "RATE",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "RATE(360, -1073.64, 200000)` → 0.00417",
+  "sql_reference_raw": "`SQL/Python UDF (Newton-Raphson iterative)`",
+  "curated": false
+ },
+ "IPMT": {
+  "name": "IPMT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "IPMT(0.05, 1, 10, -100000)",
+  "sql_reference_raw": "`(1 + r)^(per-1) * (pmt - pv * r) / ((1 + r)^n - 1)`",
+  "curated": false
+ },
+ "PPMT": {
+  "name": "PPMT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PPMT(0.05, 1, 10, -100000)",
+  "sql_reference_raw": "`pmt - ipmt(...)` - use above IPMT formula",
+  "curated": false
+ },
+ "CUMIPMT": {
+  "name": "CUMIPMT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CUMIPMT(0.05, 360, 200000, 1, 12, 0)",
+  "sql_reference_raw": "Sum of IPMT across periods; `SQL/Python UDF`",
+  "curated": false
+ },
+ "CUMPRINC": {
+  "name": "CUMPRINC",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CUMPRINC(0.05, 360, 200000, 1, 12, 0)",
+  "sql_reference_raw": "Sum of PPMT across periods; `SQL/Python UDF`",
+  "curated": false
+ },
+ "XNPV": {
+  "name": "XNPV",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "XNPV(0.08, {-10000, 2750, 4250, 3250, 2750}, {date1, date2, ...})",
+  "sql_reference_raw": "`SQL/Python UDF: SUM(CF / (1 + rate)^(DAYS(date, date0)/365))`",
+  "curated": false
+ },
+ "XIRR": {
+  "name": "XIRR",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "XIRR({-10000, 2750, 4250, 3250, 2750}, {date1, date2, ...})",
+  "sql_reference_raw": "`SQL/Python UDF (iterative)` - solve for rate where NPV=0",
+  "curated": false
+ },
+ "SLN": {
+  "name": "SLN",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "SLN(100000, 10000, 10)` → 9000",
+  "sql_reference_raw": "`(cost - salvage) / life`",
+  "curated": false
+ },
+ "DB": {
+  "name": "DB",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "DB(100000, 10000, 10, 1)` → 20000",
+  "sql_reference_raw": "Declining balance: `cost * POWER(salvage/cost, 1/life) / life` per period",
+  "curated": false
+ },
+ "DDB": {
+  "name": "DDB",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "DDB(100000, 10000, 10, 1)` → 20000",
+  "sql_reference_raw": "Double declining: `cost * 2 / life` first period; then `(cost - prior_depn) * 2 / life`",
+  "curated": false
+ },
+ "SYD": {
+  "name": "SYD",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "SYD(100000, 10000, 10, 1)` → 16363.64",
+  "sql_reference_raw": "`(depn_base * (life - period + 1)) / (life * (life + 1) / 2)`",
+  "curated": false
+ },
+ "VDB": {
+  "name": "VDB",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "VDB(100000, 10000, 10, 1, 2, 2)",
+  "sql_reference_raw": "Hybrid declining/straight-line; `SQL/Python UDF` - switches to SLN when SLN > declining",
+  "curated": false
+ },
+ "AMORDEGRC": {
+  "name": "AMORDEGRC",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "AMORDEGRC(100000, 100000, 1, 0, 0.2)",
+  "sql_reference_raw": "French accelerated depreciation; `SQL/Python UDF`",
+  "curated": false
+ },
+ "AMORLINC": {
+  "name": "AMORLINC",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "AMORLINC(100000, 100000, 1, 0, 0.2)",
+  "sql_reference_raw": "French straight-line; `SQL/Python UDF`",
+  "curated": false
+ },
+ "PRICE": {
+  "name": "PRICE",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PRICE(settlement, maturity, coupon, yld, redemption, basis)",
+  "sql_reference_raw": "Bond price formula: `redemption / (1+yld)^years + SUM(coupon_pmt / (1+yld)^t)`",
+  "curated": false
+ },
+ "YIELD": {
+  "name": "YIELD",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "YIELD(settlement, maturity, coupon, price, redemption, basis)",
+  "sql_reference_raw": "`SQL/Python UDF (iterative)` - solve for yield given price",
+  "curated": false
+ },
+ "PRICEMAT": {
+  "name": "PRICEMAT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PRICEMAT(settlement, maturity, issue, coupon, yld, basis)",
+  "sql_reference_raw": "`(100 + coupon * yearfrac(issue, maturity)) / (1 + yld * yearfrac(settlement, maturity))`",
+  "curated": false
+ },
+ "YIELDMAT": {
+  "name": "YIELDMAT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "YIELDMAT(settlement, maturity, issue, coupon, price, basis)",
+  "sql_reference_raw": "`SQL/Python UDF (iterative)` - solve for yield with accrued interest",
+  "curated": false
+ },
+ "PRICEDISC": {
+  "name": "PRICEDISC",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PRICEDISC(settlement, maturity, discount, redemption, basis)",
+  "sql_reference_raw": "`redemption * (1 - discount * yearfrac(settlement, maturity))`",
+  "curated": false
+ },
+ "YIELDDISC": {
+  "name": "YIELDDISC",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "YIELDDISC(settlement, maturity, price, redemption, basis)",
+  "sql_reference_raw": "`(redemption - price) / redemption / yearfrac(settlement, maturity)`",
+  "curated": false
+ },
+ "ACCRINT": {
+  "name": "ACCRINT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ACCRINT(issue, first_coupon, settlement, coupon, par, basis)",
+  "sql_reference_raw": "Accrued coupon interest; `par * coupon * yearfrac(last_coupon, settlement)`",
+  "curated": false
+ },
+ "ACCRINTM": {
+  "name": "ACCRINTM",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ACCRINTM(issue, maturity, coupon, par, basis)",
+  "sql_reference_raw": "`par * coupon * yearfrac(issue, maturity)`",
+  "curated": false
+ },
+ "INTRATE": {
+  "name": "INTRATE",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "INTRATE(settlement, maturity, investment, redemption, basis)",
+  "sql_reference_raw": "`(redemption - investment) / investment / yearfrac(settlement, maturity)`",
+  "curated": false
+ },
+ "RECEIVED": {
+  "name": "RECEIVED",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "RECEIVED(settlement, maturity, investment, discount, basis)",
+  "sql_reference_raw": "`investment / (1 - discount * yearfrac(settlement, maturity))`",
+  "curated": false
+ },
+ "DISC": {
+  "name": "DISC",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "DISC(settlement, maturity, price, redemption, basis)",
+  "sql_reference_raw": "`(redemption - price) / redemption / yearfrac(settlement, maturity)`",
+  "curated": false
+ },
+ "COUPNCD": {
+  "name": "COUPNCD",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COUPNCD(settlement, maturity, frequency, basis)",
+  "sql_reference_raw": "Next coupon date calculation; `SQL/Python UDF` - date arithmetic",
+  "curated": false
+ },
+ "COUPPCD": {
+  "name": "COUPPCD",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COUPPCD(settlement, maturity, frequency, basis)",
+  "sql_reference_raw": "Previous coupon date calculation; `SQL/Python UDF` - date arithmetic",
+  "curated": false
+ },
+ "COUPDAYBS": {
+  "name": "COUPDAYBS",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COUPDAYBS(settlement, maturity, frequency, basis)",
+  "sql_reference_raw": "Days from coupon start to settlement; `SQL/Python UDF` - date difference",
+  "curated": false
+ },
+ "COUPDAYS": {
+  "name": "COUPDAYS",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COUPDAYS(settlement, maturity, frequency, basis)",
+  "sql_reference_raw": "Days in coupon period; `SQL/Python UDF` - typically 360/frequency or 365/frequency",
+  "curated": false
+ },
+ "COUPDAYSNC": {
+  "name": "COUPDAYSNC",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COUPDAYSNC(settlement, maturity, frequency, basis)",
+  "sql_reference_raw": "Days from settlement to next coupon; `SQL/Python UDF` - date difference",
+  "curated": false
+ },
+ "COUPNUM": {
+  "name": "COUPNUM",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COUPNUM(settlement, maturity, frequency)",
+  "sql_reference_raw": "Count of coupons from settlement to maturity; `SQL/Python UDF` - date-based count",
+  "curated": false
+ },
+ "TBILLPRICE": {
+  "name": "TBILLPRICE",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "TBILLPRICE(settlement, maturity, discount)",
+  "sql_reference_raw": "`100 * (1 - discount * days_to_maturity / 360)`",
+  "curated": false
+ },
+ "TBILLYIELD": {
+  "name": "TBILLYIELD",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "TBILLYIELD(settlement, maturity, price)",
+  "sql_reference_raw": "`(100 - price) * 360 / (price * days_to_maturity)`",
+  "curated": false
+ },
+ "TBILLEQ": {
+  "name": "TBILLEQ",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "TBILLEQ(settlement, maturity, discount)",
+  "sql_reference_raw": "`(365 * discount) / (360 - discount * days_to_maturity)`",
+  "curated": false
+ },
+ "EFFECT": {
+  "name": "EFFECT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "EFFECT(0.08, 4)` → 0.0824",
+  "sql_reference_raw": "`(1 + nominal_rate / periods)^periods - 1`",
+  "curated": false
+ },
+ "NOMINAL": {
+  "name": "NOMINAL",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "NOMINAL(0.0824, 4)` → 0.08",
+  "sql_reference_raw": "`periods * ((1 + effective_rate)^(1/periods) - 1)`",
+  "curated": false
+ },
+ "RRI": {
+  "name": "RRI",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "RRI(10, 1000, 2000)` → 0.0718",
+  "sql_reference_raw": "`(fv / pv)^(1/periods) - 1`",
+  "curated": false
+ },
+ "DURATION": {
+  "name": "DURATION",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "DURATION(settlement, maturity, coupon, yld, basis)",
+  "sql_reference_raw": "Macauley duration; `SQL/Python UDF` - weighted avg of cash flow times",
+  "curated": false
+ },
+ "MDURATION": {
+  "name": "MDURATION",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "MDURATION(settlement, maturity, coupon, yld, basis)",
+  "sql_reference_raw": "Modified duration = DURATION / (1 + yld / freq); `SQL/Python UDF`",
+  "curated": false
+ },
+ "ODDFPRICE": {
+  "name": "ODDFPRICE",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ODDFPRICE(settlement, maturity, issue, first_coupon, coupon, yld, redemption, basis)",
+  "sql_reference_raw": "Bond price with odd first period; `SQL/Python UDF` - special accrual calc",
+  "curated": false
+ },
+ "ODDFYIELD": {
+  "name": "ODDFYIELD",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ODDFYIELD(settlement, maturity, issue, first_coupon, coupon, price, redemption, basis)",
+  "sql_reference_raw": "Yield with odd first period; `SQL/Python UDF (iterative)`",
+  "curated": false
+ },
+ "ODDLPRICE": {
+  "name": "ODDLPRICE",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ODDLPRICE(settlement, maturity, last_coupon, coupon, yld, redemption, basis)",
+  "sql_reference_raw": "Bond price with odd last period; `SQL/Python UDF` - special accrual calc",
+  "curated": false
+ },
+ "ODDLYIELD": {
+  "name": "ODDLYIELD",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ODDLYIELD(settlement, maturity, last_coupon, coupon, price, redemption, basis)",
+  "sql_reference_raw": "Yield with odd last period; `SQL/Python UDF (iterative)`",
+  "curated": false
+ },
+ "DOLLARDE": {
+  "name": "DOLLARDE",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "DOLLARDE(1.02, 32)` → 1.0625",
+  "sql_reference_raw": "`INT(price) + FRAC(price) / 100`",
+  "curated": false
+ },
+ "DOLLARFR": {
+  "name": "DOLLARFR",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "DOLLARFR(1.0625, 32)` → 1.02",
+  "sql_reference_raw": "`INT(price) + (FRAC(price) * 100) / divisor`",
+  "curated": false
+ },
+ "PDURATION": {
+  "name": "PDURATION",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PDURATION(0.05, 1000, 2000)` → 14.2",
+  "sql_reference_raw": "Periods to reach target: `LOG(fv / pv) / LOG(1 + rate)`",
+  "curated": false
+ },
+ "ISPMT": {
+  "name": "ISPMT",
+  "category": "Financial",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ISPMT(0.05, 1, 10, -100000)",
+  "sql_reference_raw": "Interest on even principal payments: `(n - per + 1) * pmt * rate / n`",
+  "curated": false
+ },
+ "COLUMNSTATISTICS": {
+  "name": "COLUMNSTATISTICS",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COLUMNSTATISTICS()",
+  "sql_reference_raw": "`DESCRIBE TABLE table_name` or catalog metadata queries",
+  "curated": false
+ },
+ "CONTAINS": {
+  "name": "CONTAINS",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CONTAINS(VALUES(Col), Values)",
+  "sql_reference_raw": "`EXISTS (SELECT 1 FROM table WHERE col IN (...))`",
+  "curated": false
+ },
+ "CONTAINSROW": {
+  "name": "CONTAINSROW",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CONTAINSROW(VALUES(...), Col1, Val1)",
+  "sql_reference_raw": "`EXISTS (SELECT 1 FROM table WHERE col1 = val1 AND ...)`",
+  "curated": false
+ },
+ "CONTAINSSTRING": {
+  "name": "CONTAINSSTRING",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CONTAINSSTRING(Name, \"City\")",
+  "sql_reference_raw": "`Name ILIKE '%' \\",
+  "curated": false
+ },
+ "CONTAINSSTRINGEXACT": {
+  "name": "CONTAINSSTRINGEXACT",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CONTAINSSTRINGEXACT(\"USA\", Country)",
+  "sql_reference_raw": "`Country = 'USA'`",
+  "curated": false
+ },
+ "CUSTOMDATA": {
+  "name": "CUSTOMDATA",
+  "category": "Information",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "CUSTOMDATA()",
+  "sql_reference_raw": "Session/connection context (no direct equivalent)",
+  "curated": false
+ },
+ "HASONEFILTER": {
+  "name": "HASONEFILTER",
+  "category": "Information",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "HASONEFILTER(Product[Category])",
+  "sql_reference_raw": "`COUNT(DISTINCT category) = 1` in GROUP BY context",
+  "curated": false
+ },
+ "HASONEVALUE": {
+  "name": "HASONEVALUE",
+  "category": "Information",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "HASONEVALUE(Date[Year])",
+  "sql_reference_raw": "`COUNT(DISTINCT year) = 1` in filtered context",
+  "curated": false
+ },
+ "ISAFTER": {
+  "name": "ISAFTER",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ISAFTER(Date, DATE(2024,1,1))",
+  "sql_reference_raw": "`Date > '2024-01-01'` (with order context)",
+  "curated": false
+ },
+ "ISBLANK": {
+  "name": "ISBLANK",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISBLANK(Sales), 0, Sales)",
+  "sql_reference_raw": "`Sales IS NULL`",
+  "curated": false
+ },
+ "ISBOOLEAN": {
+  "name": "ISBOOLEAN",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISBOOLEAN(x), x, FALSE)",
+  "sql_reference_raw": "`typeof(x) = 'boolean'`",
+  "curated": false
+ },
+ "ISCROSSFILTERED": {
+  "name": "ISCROSSFILTERED",
+  "category": "Information",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "ISCROSSFILTERED(Table1[Col])",
+  "sql_reference_raw": "Related table filter applied; context-dependent",
+  "curated": false
+ },
+ "ISCURRENCY": {
+  "name": "ISCURRENCY",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISCURRENCY(Amount), Amount, 0)",
+  "sql_reference_raw": "`typeof(Amount) = 'decimal'`",
+  "curated": false
+ },
+ "ISDATETIME": {
+  "name": "ISDATETIME",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISDATETIME(CreatedAt), CreatedAt, NOW())",
+  "sql_reference_raw": "`typeof(CreatedAt) IN ('timestamp', 'date')`",
+  "curated": false
+ },
+ "ISDECIMAL": {
+  "name": "ISDECIMAL",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISDECIMAL(Price), Price, 0.0)",
+  "sql_reference_raw": "`typeof(Price) = 'decimal'`",
+  "curated": false
+ },
+ "ISDOUBLE": {
+  "name": "ISDOUBLE",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISDOUBLE(Value), Value, 0.0)",
+  "sql_reference_raw": "`typeof(Value) = 'double'`",
+  "curated": false
+ },
+ "ISEMPTY": {
+  "name": "ISEMPTY",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISEMPTY(Table), 0, COUNTA(Table))",
+  "sql_reference_raw": "`COUNT(*) = 0` (table expression)",
+  "curated": false
+ },
+ "ISERROR": {
+  "name": "ISERROR",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "IF(ISERROR(1/Divisor), 0, 1/Divisor)",
+  "sql_reference_raw": "`TRY_DIVIDE(1, Divisor)` or error-handling UDF",
+  "curated": false
+ },
+ "ISEVEN": {
+  "name": "ISEVEN",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISEVEN(Number), Number, NULL)",
+  "sql_reference_raw": "`Number % 2 = 0`",
+  "curated": false
+ },
+ "ISFILTERED": {
+  "name": "ISFILTERED",
+  "category": "Information",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "IF(ISFILTERED(Product[ID]), \"Filtered\", \"All\")",
+  "sql_reference_raw": "Direct filter applied; context-dependent",
+  "curated": false
+ },
+ "ISINSCOPE": {
+  "name": "ISINSCOPE",
+  "category": "Information",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "IF(ISINSCOPE(Date[Year]), \"Year\", \"Other\")",
+  "sql_reference_raw": "Hierarchy level in GROUP BY context",
+  "curated": false
+ },
+ "ISINT64": {
+  "name": "ISINT64",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISINT64(ID), ID, 0)",
+  "sql_reference_raw": "`typeof(ID) IN ('long', 'bigint', 'int')`",
+  "curated": false
+ },
+ "ISINTEGER": {
+  "name": "ISINTEGER",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISINTEGER(ID), ID, 0)",
+  "sql_reference_raw": "`typeof(ID) IN ('long', 'bigint', 'int')`",
+  "curated": false
+ },
+ "ISLOGICAL": {
+  "name": "ISLOGICAL",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISLOGICAL(Flag), Flag, FALSE)",
+  "sql_reference_raw": "`typeof(Flag) = 'boolean'`",
+  "curated": false
+ },
+ "ISNONTEXT": {
+  "name": "ISNONTEXT",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISNONTEXT(Value), Value, NULL)",
+  "sql_reference_raw": "`typeof(Value) != 'string' AND Value IS NOT NULL`",
+  "curated": false
+ },
+ "ISNUMBER": {
+  "name": "ISNUMBER",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISNUMBER(Qty), Qty, 0)",
+  "sql_reference_raw": "`typeof(Qty) IN ('byte', 'short', 'int', 'long', 'float', 'double', 'decimal')`",
+  "curated": false
+ },
+ "ISNUMERIC": {
+  "name": "ISNUMERIC",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISNUMERIC(Qty), Qty, 0)",
+  "sql_reference_raw": "`typeof(Qty) IN ('byte', 'short', 'int', 'long', 'float', 'double', 'decimal')`",
+  "curated": false
+ },
+ "ISODD": {
+  "name": "ISODD",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISODD(Number), Number, NULL)",
+  "sql_reference_raw": "`Number % 2 != 0`",
+  "curated": false
+ },
+ "ISONORAFTER": {
+  "name": "ISONORAFTER",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ISONORAFTER(Date, DATE(2024,1,1))",
+  "sql_reference_raw": "`Date >= '2024-01-01'` (with order context)",
+  "curated": false
+ },
+ "ISSELECTEDMEASURE": {
+  "name": "ISSELECTEDMEASURE",
+  "category": "Information",
+  "feasibility": "ai_bi",
+  "default_dax_class": "display_layer",
+  "dax_example": "ISSELECTEDMEASURE([Sales], [Cost])",
+  "sql_reference_raw": "Measure selection context (AI/BI calculation items only)",
+  "curated": false
+ },
+ "ISSTRING": {
+  "name": "ISSTRING",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISSTRING(Name), UPPER(Name), NULL)",
+  "sql_reference_raw": "`typeof(Name) = 'string'`",
+  "curated": false
+ },
+ "ISSUBTOTAL": {
+  "name": "ISSUBTOTAL",
+  "category": "Information",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "ISSUBTOTAL(ISODD(Number))",
+  "sql_reference_raw": "`GROUPING(number) = 1` in ROLLUP context",
+  "curated": false
+ },
+ "ISTEXT": {
+  "name": "ISTEXT",
+  "category": "Information",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(ISTEXT(Category), Category, NULL)",
+  "sql_reference_raw": "`typeof(Category) = 'string'`",
+  "curated": false
+ },
+ "NAMEOF": {
+  "name": "NAMEOF",
+  "category": "Information",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "NAMEOF(Sales[Amount])",
+  "sql_reference_raw": "No direct equivalent (metadata reference as string)",
+  "curated": false
+ },
+ "NONVISUAL": {
+  "name": "NONVISUAL",
+  "category": "Information",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "NONVISUAL(VALUES(Product[ID]))",
+  "sql_reference_raw": "Filter context marked as non-visual (structural)",
+  "curated": false
+ },
+ "SELECTEDMEASURE": {
+  "name": "SELECTEDMEASURE",
+  "category": "Information",
+  "feasibility": "ai_bi",
+  "default_dax_class": "display_layer",
+  "dax_example": "SELECTEDMEASURE() + 0.1",
+  "sql_reference_raw": "Current measure context (calculation items)",
+  "curated": false
+ },
+ "SELECTEDMEASUREFORMATSTRING": {
+  "name": "SELECTEDMEASUREFORMATSTRING",
+  "category": "Information",
+  "feasibility": "ai_bi",
+  "default_dax_class": "display_layer",
+  "dax_example": "SELECTEDMEASUREFORMATSTRING()",
+  "sql_reference_raw": "Format string metadata (calculation items)",
+  "curated": false
+ },
+ "SELECTEDMEASURENAME": {
+  "name": "SELECTEDMEASURENAME",
+  "category": "Information",
+  "feasibility": "ai_bi",
+  "default_dax_class": "display_layer",
+  "dax_example": "SELECTEDMEASURENAME()",
+  "sql_reference_raw": "Name of current measure (calculation items)",
+  "curated": false
+ },
+ "TABLEOF": {
+  "name": "TABLEOF",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "TABLEOF(Sales[Amount])",
+  "sql_reference_raw": "Implicit table reference (metadata)",
+  "curated": false
+ },
+ "USERCULTURE": {
+  "name": "USERCULTURE",
+  "category": "Information",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "FORMAT(TODAY(), USERCULTURE())",
+  "sql_reference_raw": "Session locale or connection parameter",
+  "curated": false
+ },
+ "USERNAME": {
+  "name": "USERNAME",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "IF(USERNAME() = \"Admin\", Data, BLANK())",
+  "sql_reference_raw": "`current_user()`",
+  "curated": false
+ },
+ "USEROBJECTID": {
+  "name": "USEROBJECTID",
+  "category": "Information",
+  "feasibility": "no_equivalent",
+  "default_dax_class": "unsupported",
+  "dax_example": "USEROBJECTID()",
+  "sql_reference_raw": "Session/Azure AD object ID (no native SQL equivalent)",
+  "curated": false
+ },
+ "USERPRINCIPALNAME": {
+  "name": "USERPRINCIPALNAME",
+  "category": "Information",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "IF(USERPRINCIPALNAME() = \"user@org.com\", Data, NULL)",
+  "sql_reference_raw": "`current_user()`",
+  "curated": false
+ },
+ "AND": {
+  "name": "AND",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "AND(Sales > 100, Region = \"West\")",
+  "sql_reference_raw": "`WHERE sales > 100 AND region = 'West'`",
+  "curated": false
+ },
+ "BITAND": {
+  "name": "BITAND",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "BITAND(12, 10)",
+  "sql_reference_raw": "`12 & 10`",
+  "curated": false
+ },
+ "BITLSHIFT": {
+  "name": "BITLSHIFT",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "BITLSHIFT(1, 3)",
+  "sql_reference_raw": "`shiftleft(1, 3)`",
+  "curated": false
+ },
+ "BITOR": {
+  "name": "BITOR",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "BITOR(12, 10)",
+  "sql_reference_raw": "`12 \\",
+  "curated": false
+ },
+ "BITRSHIFT": {
+  "name": "BITRSHIFT",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "BITRSHIFT(16, 2)",
+  "sql_reference_raw": "`shiftright(16, 2)`",
+  "curated": false
+ },
+ "BITXOR": {
+  "name": "BITXOR",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "BITXOR(12, 10)",
+  "sql_reference_raw": "`12 ^ 10`",
+  "curated": false
+ },
+ "COALESCE": {
+  "name": "COALESCE",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COALESCE(col1, col2, 0)",
+  "sql_reference_raw": "`coalesce(col1, col2, 0)`",
+  "curated": false
+ },
+ "FALSE": {
+  "name": "FALSE",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(1=2, \"yes\", FALSE)",
+  "sql_reference_raw": "`case when 1=2 then 'yes' else false end`",
+  "curated": false
+ },
+ "IF": {
+  "name": "IF",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(Sales > 1000, \"High\", \"Low\")",
+  "sql_reference_raw": "`case when sales > 1000 then 'High' else 'Low' end`",
+  "curated": false
+ },
+ "IF.EAGER": {
+  "name": "IF.EAGER",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF.EAGER(x>0, 1/x, 0)",
+  "sql_reference_raw": "`case when x>0 then 1/x else 0 end`",
+  "curated": false
+ },
+ "IFERROR": {
+  "name": "IFERROR",
+  "category": "Logical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "IFERROR(1/0, 0)",
+  "sql_reference_raw": "`coalesce(try(1/0), 0)` or UDF wrapper",
+  "curated": false
+ },
+ "NOT": {
+  "name": "NOT",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "NOT(IsActive)",
+  "sql_reference_raw": "`NOT is_active`",
+  "curated": false
+ },
+ "OR": {
+  "name": "OR",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "OR(Region=\"West\", Region=\"East\")",
+  "sql_reference_raw": "`region = 'West' OR region = 'East'`",
+  "curated": false
+ },
+ "SWITCH": {
+  "name": "SWITCH",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SWITCH(Status, 1, \"Active\", 2, \"Inactive\", \"Unknown\")",
+  "sql_reference_raw": "`case status when 1 then 'Active' when 2 then 'Inactive' else 'Unknown' end`",
+  "curated": false
+ },
+ "TRUE": {
+  "name": "TRUE",
+  "category": "Logical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "IF(1=1, TRUE, FALSE)",
+  "sql_reference_raw": "`case when 1=1 then true else false end`",
+  "curated": false
+ },
+ "ABS": {
+  "name": "ABS",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ABS(-42)",
+  "sql_reference_raw": "`ABS(-42)`",
+  "curated": false
+ },
+ "ACOS": {
+  "name": "ACOS",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ACOS(0.5)",
+  "sql_reference_raw": "`ACOS(0.5)`",
+  "curated": false
+ },
+ "ACOSH": {
+  "name": "ACOSH",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ACOSH(1.5)",
+  "sql_reference_raw": "`ACOSH(1.5)`",
+  "curated": false
+ },
+ "ACOT": {
+  "name": "ACOT",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ACOT(2)",
+  "sql_reference_raw": "`ATAN(1.0/x)` or UDF",
+  "curated": false
+ },
+ "ACOTH": {
+  "name": "ACOTH",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ACOTH(2)",
+  "sql_reference_raw": "`ATANH(1.0/x)` or UDF",
+  "curated": false
+ },
+ "ASIN": {
+  "name": "ASIN",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ASIN(0.5)",
+  "sql_reference_raw": "`ASIN(0.5)`",
+  "curated": false
+ },
+ "ASINH": {
+  "name": "ASINH",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ASINH(1)",
+  "sql_reference_raw": "`ASINH(1)`",
+  "curated": false
+ },
+ "ATAN": {
+  "name": "ATAN",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ATAN(1)",
+  "sql_reference_raw": "`ATAN(1)`",
+  "curated": false
+ },
+ "ATANH": {
+  "name": "ATANH",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ATANH(0.5)",
+  "sql_reference_raw": "`ATANH(0.5)`",
+  "curated": false
+ },
+ "CEILING": {
+  "name": "CEILING",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CEILING(3.2, 1)",
+  "sql_reference_raw": "`CEIL(3.2)`",
+  "curated": false
+ },
+ "CONVERT": {
+  "name": "CONVERT",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CONVERT(123, STRING)",
+  "sql_reference_raw": "`CAST(123 AS STRING)`",
+  "curated": false
+ },
+ "COS": {
+  "name": "COS",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COS(PI()/2)",
+  "sql_reference_raw": "`COS(PI()/2)`",
+  "curated": false
+ },
+ "COSH": {
+  "name": "COSH",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COSH(1)",
+  "sql_reference_raw": "`COSH(1)`",
+  "curated": false
+ },
+ "COT": {
+  "name": "COT",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COT(PI()/4)",
+  "sql_reference_raw": "`1/TAN(x)` or UDF",
+  "curated": false
+ },
+ "COTH": {
+  "name": "COTH",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COTH(1)",
+  "sql_reference_raw": "`1/TANH(x)` or UDF",
+  "curated": false
+ },
+ "CURRENCY": {
+  "name": "CURRENCY",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CURRENCY(123)",
+  "sql_reference_raw": "`CAST(123 AS DECIMAL(19,4))`",
+  "curated": false
+ },
+ "DEGREES": {
+  "name": "DEGREES",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DEGREES(PI())",
+  "sql_reference_raw": "`DEGREES(PI())`",
+  "curated": false
+ },
+ "DIVIDE": {
+  "name": "DIVIDE",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DIVIDE(10, 2)",
+  "sql_reference_raw": "`TRY_DIVIDE(10, 2)` or `10 / NULLIF(2, 0)`",
+  "curated": false
+ },
+ "EVEN": {
+  "name": "EVEN",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "EVEN(3)` → 4",
+  "sql_reference_raw": "`CEIL(x / 2) * 2` or UDF",
+  "curated": false
+ },
+ "EXP": {
+  "name": "EXP",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "EXP(1)",
+  "sql_reference_raw": "`EXP(1)`",
+  "curated": false
+ },
+ "FACT": {
+  "name": "FACT",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "FACT(5)",
+  "sql_reference_raw": "`FACTORIAL(5)` or UDF",
+  "curated": false
+ },
+ "FLOOR": {
+  "name": "FLOOR",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "FLOOR(3.7, 1)",
+  "sql_reference_raw": "`FLOOR(3.7)`",
+  "curated": false
+ },
+ "GCD": {
+  "name": "GCD",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "GCD(48, 18)",
+  "sql_reference_raw": "UDF (greatest common divisor)",
+  "curated": false
+ },
+ "INT": {
+  "name": "INT",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "INT(3.7)",
+  "sql_reference_raw": "`FLOOR(3.7)` or `INT(3.7)`",
+  "curated": false
+ },
+ "ISO.CEILING": {
+  "name": "ISO.CEILING",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ISO.CEILING(3.2, 1)",
+  "sql_reference_raw": "`CEIL(3.2)`",
+  "curated": false
+ },
+ "LCM": {
+  "name": "LCM",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "LCM(12, 18)",
+  "sql_reference_raw": "UDF (least common multiple)",
+  "curated": false
+ },
+ "LN": {
+  "name": "LN",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "LN(2.718)",
+  "sql_reference_raw": "`LN(2.718)`",
+  "curated": false
+ },
+ "LOG": {
+  "name": "LOG",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "LOG(100, 10)",
+  "sql_reference_raw": "`LOG(10, 100)`",
+  "curated": false
+ },
+ "LOG10": {
+  "name": "LOG10",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "LOG10(100)",
+  "sql_reference_raw": "`LOG10(100)`",
+  "curated": false
+ },
+ "MOD": {
+  "name": "MOD",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MOD(10, 3)",
+  "sql_reference_raw": "`MOD(10, 3)` or `10 % 3`",
+  "curated": false
+ },
+ "MROUND": {
+  "name": "MROUND",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "MROUND(10, 3)` → 9",
+  "sql_reference_raw": "UDF (round to nearest multiple)",
+  "curated": false
+ },
+ "ODD": {
+  "name": "ODD",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ODD(4)` → 5",
+  "sql_reference_raw": "`CEIL(x / 2) * 2 - 1` or UDF",
+  "curated": false
+ },
+ "PI": {
+  "name": "PI",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "PI()",
+  "sql_reference_raw": "`PI()`",
+  "curated": false
+ },
+ "POWER": {
+  "name": "POWER",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "POWER(2, 3)",
+  "sql_reference_raw": "`POWER(2, 3)` or `2 ^ 3`",
+  "curated": false
+ },
+ "QUOTIENT": {
+  "name": "QUOTIENT",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "QUOTIENT(10, 3)",
+  "sql_reference_raw": "`DIV(10, 3)` or `FLOOR(10 / 3)`",
+  "curated": false
+ },
+ "RADIANS": {
+  "name": "RADIANS",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "RADIANS(180)",
+  "sql_reference_raw": "`RADIANS(180)`",
+  "curated": false
+ },
+ "RAND": {
+  "name": "RAND",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "RAND()",
+  "sql_reference_raw": "`RAND()`",
+  "curated": false
+ },
+ "RANDBETWEEN": {
+  "name": "RANDBETWEEN",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "RANDBETWEEN(1, 10)",
+  "sql_reference_raw": "`FLOOR(RAND() * (10 - 1 + 1)) + 1`",
+  "curated": false
+ },
+ "ROUND": {
+  "name": "ROUND",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ROUND(3.14159, 2)",
+  "sql_reference_raw": "`ROUND(3.14159, 2)`",
+  "curated": false
+ },
+ "ROUNDDOWN": {
+  "name": "ROUNDDOWN",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ROUNDDOWN(3.7, 0)",
+  "sql_reference_raw": "`FLOOR(3.7)` or `TRUNC(3.7)`",
+  "curated": false
+ },
+ "ROUNDUP": {
+  "name": "ROUNDUP",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ROUNDUP(3.2, 0)",
+  "sql_reference_raw": "`CEIL(3.2)`",
+  "curated": false
+ },
+ "SIGN": {
+  "name": "SIGN",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SIGN(-5)` → -1",
+  "sql_reference_raw": "`SIGN(-5)`",
+  "curated": false
+ },
+ "SIN": {
+  "name": "SIN",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SIN(PI()/2)",
+  "sql_reference_raw": "`SIN(PI()/2)`",
+  "curated": false
+ },
+ "SINH": {
+  "name": "SINH",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SINH(1)",
+  "sql_reference_raw": "`SINH(1)`",
+  "curated": false
+ },
+ "SQRT": {
+  "name": "SQRT",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SQRT(16)",
+  "sql_reference_raw": "`SQRT(16)`",
+  "curated": false
+ },
+ "SQRTPI": {
+  "name": "SQRTPI",
+  "category": "Math & trig",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "SQRTPI(2)",
+  "sql_reference_raw": "`SQRT(2 * PI())` or UDF",
+  "curated": false
+ },
+ "TAN": {
+  "name": "TAN",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TAN(PI()/4)",
+  "sql_reference_raw": "`TAN(PI()/4)`",
+  "curated": false
+ },
+ "TANH": {
+  "name": "TANH",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TANH(1)",
+  "sql_reference_raw": "`TANH(1)`",
+  "curated": false
+ },
+ "TRUNC": {
+  "name": "TRUNC",
+  "category": "Math & trig",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TRUNC(3.7)",
+  "sql_reference_raw": "`TRUNC(3.7)`",
+  "curated": false
+ },
+ "BLANK": {
+  "name": "BLANK",
+  "category": "Other",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "BLANK()",
+  "sql_reference_raw": "`NULL`",
+  "curated": false
+ },
+ "ERROR": {
+  "name": "ERROR",
+  "category": "Other",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ERROR(\"Invalid value\")",
+  "sql_reference_raw": "`raise_error(\"Invalid value\")`",
+  "curated": false
+ },
+ "EVALUATEANDLOG": {
+  "name": "EVALUATEANDLOG",
+  "category": "Other",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "EVALUATEANDLOG([Sales], \"trace\")",
+  "sql_reference_raw": "N/A (use `COMMENT` or logging UDF)",
+  "curated": false
+ },
+ "EXTERNALMEASURE": {
+  "name": "EXTERNALMEASURE",
+  "category": "Other",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "EXTERNALMEASURE([remote_model], [measure_name])",
+  "sql_reference_raw": "Federated query or external table",
+  "curated": false
+ },
+ "TOCSV": {
+  "name": "TOCSV",
+  "category": "Other",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "TOCSV(table_expr)",
+  "sql_reference_raw": "Custom Python UDF or `concat_ws()` loop",
+  "curated": false
+ },
+ "TOJSON": {
+  "name": "TOJSON",
+  "category": "Other",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TOJSON(table_expr)",
+  "sql_reference_raw": "`to_json(struct)` or `to_json(col)`",
+  "curated": false
+ },
+ "PATH": {
+  "name": "PATH",
+  "category": "Parent-child",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PATH([ID], [PARENT_ID])` returns `\"1\\",
+  "sql_reference_raw": "2\\",
+  "curated": false
+ },
+ "PATHCONTAINS": {
+  "name": "PATHCONTAINS",
+  "category": "Parent-child",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PATHCONTAINS(path, item)` returns TRUE if `\"1\\",
+  "sql_reference_raw": "2\\",
+  "curated": false
+ },
+ "PATHITEM": {
+  "name": "PATHITEM",
+  "category": "Parent-child",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PATHITEM(path, 2)` returns `\"2\"` (2nd element in path)",
+  "sql_reference_raw": "`element_at(split(path, '\\",
+  "curated": false
+ },
+ "PATHITEMREVERSE": {
+  "name": "PATHITEMREVERSE",
+  "category": "Parent-child",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PATHITEMREVERSE(path, 1)` returns `\"5\"` (1st from end in `\"1\\",
+  "sql_reference_raw": "2\\",
+  "curated": false
+ },
+ "PATHLENGTH": {
+  "name": "PATHLENGTH",
+  "category": "Parent-child",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PATHLENGTH(path)` returns `3` (count of elements in `\"1\\",
+  "sql_reference_raw": "2\\",
+  "curated": false
+ },
+ "RELATED": {
+  "name": "RELATED",
+  "category": "Relationship",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "RELATED(Customer[Name])",
+  "sql_reference_raw": "`SELECT c.Name FROM Sales s JOIN Customer c ON s.CustomerKey = c.CustomerKey`",
+  "curated": false
+ },
+ "RELATEDTABLE": {
+  "name": "RELATEDTABLE",
+  "category": "Relationship",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "SUMX(RELATEDTABLE(Orders), Orders[Amount])",
+  "sql_reference_raw": "`(SELECT SUM(Amount) FROM Orders WHERE Orders.CustomerKey = Customer.CustomerKey)`",
+  "curated": false
+ },
+ "USERELATIONSHIP": {
+  "name": "USERELATIONSHIP",
+  "category": "Relationship",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "USERELATIONSHIP(Sales[DateKey], Date[AltKey])",
+  "sql_reference_raw": "`JOIN Date ON Sales.DateKey = Date.AltKey`",
+  "curated": false
+ },
+ "CROSSFILTER": {
+  "name": "CROSSFILTER",
+  "category": "Relationship",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CROSSFILTER(Sales[CustKey], Cust[CustKey], BOTH)",
+  "sql_reference_raw": "Bidirectional filter in JOIN context / WHERE clause propagation",
+  "curated": false
+ },
+ "BETA.DIST": {
+  "name": "BETA.DIST",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "BETA.DIST(0.5, 2, 3)",
+  "sql_reference_raw": "`betadist(x, alpha, beta)` UDF or scipy",
+  "curated": false
+ },
+ "BETA.INV": {
+  "name": "BETA.INV",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "BETA.INV(0.5, 2, 3)",
+  "sql_reference_raw": "`betainv(prob, alpha, beta)` UDF",
+  "curated": false
+ },
+ "CHISQ.DIST": {
+  "name": "CHISQ.DIST",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CHISQ.DIST(3, 2, FALSE)",
+  "sql_reference_raw": "`chisqdist(x, df, cumulative)` UDF or scipy",
+  "curated": false
+ },
+ "CHISQ.DIST.RT": {
+  "name": "CHISQ.DIST.RT",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CHISQ.DIST.RT(3, 2)",
+  "sql_reference_raw": "`1 - chisqdist(x, df, TRUE)` UDF",
+  "curated": false
+ },
+ "CHISQ.INV": {
+  "name": "CHISQ.INV",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CHISQ.INV(0.05, 2)",
+  "sql_reference_raw": "`chisqinv(prob, df)` UDF",
+  "curated": false
+ },
+ "CHISQ.INV.RT": {
+  "name": "CHISQ.INV.RT",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CHISQ.INV.RT(0.05, 2)",
+  "sql_reference_raw": "`chisqinv(1 - prob, df)` UDF",
+  "curated": false
+ },
+ "COMBIN": {
+  "name": "COMBIN",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COMBIN(5, 2)",
+  "sql_reference_raw": "`FACTORIAL(n) / (FACTORIAL(k) * FACTORIAL(n-k))` or UDF",
+  "curated": false
+ },
+ "COMBINA": {
+  "name": "COMBINA",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "COMBINA(5, 2)",
+  "sql_reference_raw": "`FACTORIAL(n+k-1) / (FACTORIAL(k) * FACTORIAL(n-1))` or UDF",
+  "curated": false
+ },
+ "CONFIDENCE.NORM": {
+  "name": "CONFIDENCE.NORM",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CONFIDENCE.NORM(0.05, 2.5, 100)",
+  "sql_reference_raw": "`1.96 * stddev / sqrt(n)` formula or UDF",
+  "curated": false
+ },
+ "CONFIDENCE.T": {
+  "name": "CONFIDENCE.T",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CONFIDENCE.T(0.05, 2.5, 100)",
+  "sql_reference_raw": "`t_critical * stddev / sqrt(n)` UDF",
+  "curated": false
+ },
+ "EXPON.DIST": {
+  "name": "EXPON.DIST",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "EXPON.DIST(0.5, 1, FALSE)",
+  "sql_reference_raw": "`expodist(x, lambda, cumulative)` UDF or scipy",
+  "curated": false
+ },
+ "GEOMEAN": {
+  "name": "GEOMEAN",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "GEOMEAN([Sales])",
+  "sql_reference_raw": "`EXP(AVG(LN(sales)))`",
+  "curated": false
+ },
+ "GEOMEANX": {
+  "name": "GEOMEANX",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "GEOMEANX(Table, [Value])",
+  "sql_reference_raw": "`EXP(AVG(LN(value)))`",
+  "curated": false
+ },
+ "LINEST": {
+  "name": "LINEST",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "LINEST(...slope, intercept)",
+  "sql_reference_raw": "`regression_slope(y, x)` / `regression_intercept(y, x)` UDF",
+  "curated": false
+ },
+ "LINESTX": {
+  "name": "LINESTX",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "LINESTX(Table, y_expr, x_expr)",
+  "sql_reference_raw": "`regression_slope(y, x)` / `regression_intercept(y, x)` UDF",
+  "curated": false
+ },
+ "MEDIAN": {
+  "name": "MEDIAN",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MEDIAN([Sales])",
+  "sql_reference_raw": "`PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY sales)` or `MEDIAN(sales)`",
+  "curated": false
+ },
+ "MEDIANX": {
+  "name": "MEDIANX",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MEDIANX(Table, [Value])",
+  "sql_reference_raw": "`PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY value)`",
+  "curated": false
+ },
+ "NORM.DIST": {
+  "name": "NORM.DIST",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "NORM.DIST(2, 1, 0.5, FALSE)",
+  "sql_reference_raw": "`normdist(x, mean, stddev, cumulative)` UDF or scipy",
+  "curated": false
+ },
+ "NORM.INV": {
+  "name": "NORM.INV",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "NORM.INV(0.95, 1, 0.5)",
+  "sql_reference_raw": "`norminv(prob, mean, stddev)` UDF",
+  "curated": false
+ },
+ "NORM.S.DIST": {
+  "name": "NORM.S.DIST",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "NORM.S.DIST(1.96, FALSE)",
+  "sql_reference_raw": "`normdist(z, 0, 1, cumulative)` UDF or scipy",
+  "curated": false
+ },
+ "NORM.S.INV": {
+  "name": "NORM.S.INV",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "NORM.S.INV(0.975)",
+  "sql_reference_raw": "`norminv(prob, 0, 1)` UDF",
+  "curated": false
+ },
+ "PERCENTILE.EXC": {
+  "name": "PERCENTILE.EXC",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "PERCENTILE.EXC([Sales], 0.75)",
+  "sql_reference_raw": "`PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY sales)`",
+  "curated": false
+ },
+ "PERCENTILE.INC": {
+  "name": "PERCENTILE.INC",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "PERCENTILE.INC([Sales], 0.75)",
+  "sql_reference_raw": "`PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY sales)`",
+  "curated": false
+ },
+ "PERCENTILEX.EXC": {
+  "name": "PERCENTILEX.EXC",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "PERCENTILEX.EXC(Table, [Value], 0.75)",
+  "sql_reference_raw": "`PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY value)`",
+  "curated": false
+ },
+ "PERCENTILEX.INC": {
+  "name": "PERCENTILEX.INC",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "PERCENTILEX.INC(Table, [Value], 0.75)",
+  "sql_reference_raw": "`PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY value)`",
+  "curated": false
+ },
+ "PERMUT": {
+  "name": "PERMUT",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "PERMUT(5, 2)",
+  "sql_reference_raw": "`FACTORIAL(n) / FACTORIAL(n-k)` or UDF",
+  "curated": false
+ },
+ "POISSON.DIST": {
+  "name": "POISSON.DIST",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "POISSON.DIST(2, 1.5, FALSE)",
+  "sql_reference_raw": "`poissondist(x, lambda, cumulative)` UDF or scipy",
+  "curated": false
+ },
+ "RANK.EQ": {
+  "name": "RANK.EQ",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "RANK.EQ(100, [Sales])",
+  "sql_reference_raw": "`RANK() OVER (ORDER BY sales)`",
+  "curated": false
+ },
+ "RANKX": {
+  "name": "RANKX",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "RANKX(Table, [Value])",
+  "sql_reference_raw": "`RANK() OVER (ORDER BY value)` or `DENSE_RANK() OVER (ORDER BY value)`",
+  "curated": false
+ },
+ "SAMPLE": {
+  "name": "SAMPLE",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SAMPLE(10, Table)",
+  "sql_reference_raw": "`TABLESAMPLE (BERNOULLI (10 PERCENT))` or `ORDER BY RAND() LIMIT 10`",
+  "curated": false
+ },
+ "STDEV.P": {
+  "name": "STDEV.P",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "STDEV.P([Sales])",
+  "sql_reference_raw": "`STDDEV_POP(sales)`",
+  "curated": false
+ },
+ "STDEV.S": {
+  "name": "STDEV.S",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "STDEV.S([Sales])",
+  "sql_reference_raw": "`STDDEV_SAMP(sales)` or `STDDEV(sales)`",
+  "curated": false
+ },
+ "STDEVX.P": {
+  "name": "STDEVX.P",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "STDEVX.P(Table, [Value])",
+  "sql_reference_raw": "`STDDEV_POP(value)`",
+  "curated": false
+ },
+ "STDEVX.S": {
+  "name": "STDEVX.S",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "STDEVX.S(Table, [Value])",
+  "sql_reference_raw": "`STDDEV_SAMP(value)` or `STDDEV(value)`",
+  "curated": false
+ },
+ "T.DIST": {
+  "name": "T.DIST",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "T.DIST(1.5, 10, FALSE)",
+  "sql_reference_raw": "`tdist(t, df, cumulative)` UDF or scipy",
+  "curated": false
+ },
+ "T.DIST.2T": {
+  "name": "T.DIST.2T",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "T.DIST.2T(1.5, 10)",
+  "sql_reference_raw": "`2 * (1 - tdist(ABS(t), df, TRUE))` UDF",
+  "curated": false
+ },
+ "T.DIST.RT": {
+  "name": "T.DIST.RT",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "T.DIST.RT(1.5, 10)",
+  "sql_reference_raw": "`1 - tdist(t, df, TRUE)` UDF",
+  "curated": false
+ },
+ "T.INV": {
+  "name": "T.INV",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "T.INV(0.05, 10)",
+  "sql_reference_raw": "`tinv(prob, df)` UDF",
+  "curated": false
+ },
+ "T.INV.2t": {
+  "name": "T.INV.2t",
+  "category": "Statistical",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "T.INV.2t(0.05, 10)",
+  "sql_reference_raw": "`tinv(prob/2, df)` UDF",
+  "curated": false
+ },
+ "VAR.P": {
+  "name": "VAR.P",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "VAR.P([Sales])",
+  "sql_reference_raw": "`VAR_POP(sales)`",
+  "curated": false
+ },
+ "VAR.S": {
+  "name": "VAR.S",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "VAR.S([Sales])",
+  "sql_reference_raw": "`VAR_SAMP(sales)` or `VARIANCE(sales)`",
+  "curated": false
+ },
+ "VARX.P": {
+  "name": "VARX.P",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "VARX.P(Table, [Value])",
+  "sql_reference_raw": "`VAR_POP(value)`",
+  "curated": false
+ },
+ "VARX.S": {
+  "name": "VARX.S",
+  "category": "Statistical",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "VARX.S(Table, [Value])",
+  "sql_reference_raw": "`VAR_SAMP(value)` or `VARIANCE(value)`",
+  "curated": false
+ },
+ "ADDCOLUMNS": {
+  "name": "ADDCOLUMNS",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ADDCOLUMNS(Sales, \"Qty+1\", [Qty]+1)",
+  "sql_reference_raw": "`SELECT *, qty + 1 AS 'Qty+1' FROM Sales`",
+  "curated": false
+ },
+ "ADDMISSINGITEMS": {
+  "name": "ADDMISSINGITEMS",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ADDMISSINGITEMS(Sales, Product[ID])",
+  "sql_reference_raw": "`CROSS JOIN spine_table AS st ON 1=1` with dedup",
+  "curated": false
+ },
+ "CROSSJOIN": {
+  "name": "CROSSJOIN",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CROSSJOIN(Cities, Years)",
+  "sql_reference_raw": "`SELECT * FROM Cities CROSS JOIN Years`",
+  "curated": false
+ },
+ "CURRENTGROUP": {
+  "name": "CURRENTGROUP",
+  "category": "Table manipulation",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "CURRENTGROUP()` in GROUPBY",
+  "sql_reference_raw": "Window function or `GROUP_CONCAT()` in iteration context",
+  "curated": false
+ },
+ "DATATABLE": {
+  "name": "DATATABLE",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DATATABLE(\"C\", STRING, {{\"a\"},{\"b\"}})",
+  "sql_reference_raw": "`SELECT * FROM (VALUES ('a'), ('b')) t(C)`",
+  "curated": false
+ },
+ "DETAILROWS": {
+  "name": "DETAILROWS",
+  "category": "Table manipulation",
+  "feasibility": "ai_bi",
+  "default_dax_class": "display_layer",
+  "dax_example": "Measure detail rows expression",
+  "sql_reference_raw": "Drill-down query result (computed at query time)",
+  "curated": false
+ },
+ "DISTINCT": {
+  "name": "DISTINCT (table)",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "DISTINCT(Sales)",
+  "sql_reference_raw": "`SELECT DISTINCT * FROM Sales`",
+  "curated": false
+ },
+ "EXCEPT": {
+  "name": "EXCEPT",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "EXCEPT(Table1, Table2)",
+  "sql_reference_raw": "`SELECT * FROM Table1 EXCEPT SELECT * FROM Table2`",
+  "curated": false
+ },
+ "FILTERS": {
+  "name": "FILTERS",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "FILTERS(Product)` within CALCULATE",
+  "sql_reference_raw": "`WHERE column IN (SELECT ... FROM filter_context)`",
+  "curated": false
+ },
+ "GENERATE": {
+  "name": "GENERATE",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "GENERATE(Years, YearSales)",
+  "sql_reference_raw": "`CROSS APPLY lateral join: FROM Years CROSS JOIN LATERAL (SELECT ...)`",
+  "curated": false
+ },
+ "GENERATEALL": {
+  "name": "GENERATEALL",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "GENERATEALL(Years, YearSales)",
+  "sql_reference_raw": "`OUTER APPLY lateral join: FROM Years LEFT JOIN LATERAL (SELECT ...)`",
+  "curated": false
+ },
+ "GENERATESERIES": {
+  "name": "GENERATESERIES",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "GENERATESERIES(1, 10)",
+  "sql_reference_raw": "`SELECT * FROM GENERATE_SERIES(1, 10)` or recursive CTE",
+  "curated": false
+ },
+ "GROUPBY": {
+  "name": "GROUPBY",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "GROUPBY(Sales, Product[ID], \"Qty\", SUMX(...))",
+  "sql_reference_raw": "`SELECT product_id, SUM(...) FROM Sales GROUP BY product_id`",
+  "curated": false
+ },
+ "IGNORE": {
+  "name": "IGNORE",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "SUMMARIZECOLUMNS(..., IGNORE(...))",
+  "sql_reference_raw": "Conditional NULL handling in aggregation",
+  "curated": false
+ },
+ "INTERSECT": {
+  "name": "INTERSECT",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "INTERSECT(Table1, Table2)",
+  "sql_reference_raw": "`SELECT * FROM Table1 INTERSECT SELECT * FROM Table2`",
+  "curated": false
+ },
+ "NATURALINNERJOIN": {
+  "name": "NATURALINNERJOIN",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "NATURALINNERJOIN(Table1, Table2)",
+  "sql_reference_raw": "`SELECT * FROM Table1 INNER JOIN Table2 USING (common_cols)`",
+  "curated": false
+ },
+ "NATURALLEFTOUTERJOIN": {
+  "name": "NATURALLEFTOUTERJOIN",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "NATURALLEFTOUTERJOIN(Table1, Table2)",
+  "sql_reference_raw": "`SELECT * FROM Table1 LEFT JOIN Table2 USING (common_cols)`",
+  "curated": false
+ },
+ "ROLLUP": {
+  "name": "ROLLUP",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ROLLUP(Sales, Product[Category])",
+  "sql_reference_raw": "`SELECT category, SUM(amount) FROM Sales GROUP BY ROLLUP(category)`",
+  "curated": false
+ },
+ "ROLLUPADDISSUBTOTAL": {
+  "name": "ROLLUPADDISSUBTOTAL",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "Part of ROLLUP definition",
+  "sql_reference_raw": "Add subtotal marker column via CASE + GROUPING()",
+  "curated": false
+ },
+ "ROLLUPISSUBTOTAL": {
+  "name": "ROLLUPISSUBTOTAL",
+  "category": "Table manipulation",
+  "feasibility": "context_clause",
+  "default_dax_class": "filtered",
+  "dax_example": "Predicate for ROLLUP rows",
+  "sql_reference_raw": "`CASE WHEN GROUPING(col)=1 THEN 1 ELSE 0 END`",
+  "curated": false
+ },
+ "ROLLUPGROUP": {
+  "name": "ROLLUPGROUP",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "ROLLUPGROUP(Sales, Product[Category], ...)",
+  "sql_reference_raw": "`SELECT category, grouping_id, ... FROM Sales GROUP BY GROUPING SETS(...)`",
+  "curated": false
+ },
+ "ROW": {
+  "name": "ROW",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "ROW(\"Value\", 42)",
+  "sql_reference_raw": "`SELECT 42 AS 'Value'`",
+  "curated": false
+ },
+ "SELECTCOLUMNS": {
+  "name": "SELECTCOLUMNS",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SELECTCOLUMNS(Sales, \"ID\", [ID], \"Qty\", [Qty])",
+  "sql_reference_raw": "`SELECT id AS 'ID', qty AS 'Qty' FROM Sales`",
+  "curated": false
+ },
+ "SUBSTITUTEWITHINDEX": {
+  "name": "SUBSTITUTEWITHINDEX",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "Left semi join logic",
+  "sql_reference_raw": "`WHERE col IN (subquery)` or EXISTS clause",
+  "curated": false
+ },
+ "SUMMARIZE": {
+  "name": "SUMMARIZE",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SUMMARIZE(Sales, Product[ID], \"Total\", SUM([Qty]))",
+  "sql_reference_raw": "`SELECT product_id, SUM(qty) AS Total FROM Sales GROUP BY product_id`",
+  "curated": false
+ },
+ "SUMMARIZECOLUMNS": {
+  "name": "SUMMARIZECOLUMNS",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "SUMMARIZECOLUMNS(Product[Cat], \"Sales\", SUM([Qty]))",
+  "sql_reference_raw": "`SELECT category, SUM(qty) FROM Sales JOIN Product GROUP BY category`",
+  "curated": false
+ },
+ "TableConstructor": {
+  "name": "Table Constructor",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "{(1),(2),(3)}",
+  "sql_reference_raw": "`SELECT * FROM (VALUES (1), (2), (3)) t(col)`",
+  "curated": false
+ },
+ "TOPN": {
+  "name": "TOPN",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TOPN(10, Sales, [Date])",
+  "sql_reference_raw": "`SELECT * FROM Sales ORDER BY date DESC LIMIT 10` or `QUALIFY ROW_NUMBER()...<=10`",
+  "curated": false
+ },
+ "TREATAS": {
+  "name": "TREATAS",
+  "category": "Table manipulation",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "TREATAS({1,2,3}, Product[ID])",
+  "sql_reference_raw": "`WHERE product_id IN (1,2,3)` via JOIN on treated columns",
+  "curated": false
+ },
+ "UNION": {
+  "name": "UNION",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "UNION(Table1, Table2)",
+  "sql_reference_raw": "`SELECT * FROM Table1 UNION ALL SELECT * FROM Table2`",
+  "curated": false
+ },
+ "VALUES": {
+  "name": "VALUES",
+  "category": "Table manipulation",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "VALUES(Product[Category])",
+  "sql_reference_raw": "`SELECT DISTINCT category FROM Product`",
+  "curated": false
+ },
+ "COMBINEVALUES": {
+  "name": "COMBINEVALUES",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "COMBINEVALUES(\";\", [FirstName], [LastName])",
+  "sql_reference_raw": "`CONCAT_WS(';', first_name, last_name)`",
+  "curated": false
+ },
+ "CONCATENATE": {
+  "name": "CONCATENATE",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "CONCATENATE([First], \" \", [Last])",
+  "sql_reference_raw": "`CONCAT(first, ' ', last)` or `first \\",
+  "curated": false
+ },
+ "CONCATENATEX": {
+  "name": "CONCATENATEX",
+  "category": "Text",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "CONCATENATEX(Employees, [Name], \",\")",
+  "sql_reference_raw": "`STRING_AGG(name, ',')` or `ARRAY_JOIN(COLLECT_LIST(name), ',')`",
+  "curated": false
+ },
+ "EXACT": {
+  "name": "EXACT",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "EXACT([Email1], [Email2])",
+  "sql_reference_raw": "`email1 = email2` (binary-safe comparison)",
+  "curated": false
+ },
+ "FIND": {
+  "name": "FIND",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "FIND(\"@\", [Email])",
+  "sql_reference_raw": "`INSTR(email, '@')` or `POSITION('@' IN email)`",
+  "curated": false
+ },
+ "FIXED": {
+  "name": "FIXED",
+  "category": "Text",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "FIXED(3.14159, 2)",
+  "sql_reference_raw": "`FORMAT_NUMBER(3.14159, 2)` or `ROUND(3.14159, 2)`",
+  "curated": false
+ },
+ "FORMAT": {
+  "name": "FORMAT",
+  "category": "Text",
+  "feasibility": "sql_view_udf",
+  "default_dax_class": "architecture_change",
+  "dax_example": "FORMAT([Date], \"yyyy-mm-dd\")",
+  "sql_reference_raw": "`DATE_FORMAT(date_col, 'yyyy-MM-dd')` or `TO_CHAR(date_col, 'YYYY-MM-DD')`",
+  "curated": false
+ },
+ "LEFT": {
+  "name": "LEFT",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "LEFT([Name], 3)",
+  "sql_reference_raw": "`LEFT(name, 3)` or `SUBSTR(name, 1, 3)`",
+  "curated": false
+ },
+ "LEN": {
+  "name": "LEN",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "LEN([Text])",
+  "sql_reference_raw": "`LENGTH(text)` or `CHAR_LENGTH(text)`",
+  "curated": false
+ },
+ "LOWER": {
+  "name": "LOWER",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "LOWER([Text])",
+  "sql_reference_raw": "`LOWER(text)`",
+  "curated": false
+ },
+ "MID": {
+  "name": "MID",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "MID([Text], 3, 5)",
+  "sql_reference_raw": "`SUBSTR(text, 3, 5)`",
+  "curated": false
+ },
+ "REPLACE": {
+  "name": "REPLACE",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "REPLACE([Text], 2, 3, \"XX\")",
+  "sql_reference_raw": "`OVERLAY(text PLACING 'XX' FROM 2 FOR 3)` or `SUBSTR(text, 1, 1) \\",
+  "curated": false
+ },
+ "REPT": {
+  "name": "REPT",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "REPT(\"*\", 5)",
+  "sql_reference_raw": "`REPEAT('*', 5)`",
+  "curated": false
+ },
+ "RIGHT": {
+  "name": "RIGHT",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "RIGHT([Name], 3)",
+  "sql_reference_raw": "`RIGHT(name, 3)` or `SUBSTR(name, -3)`",
+  "curated": false
+ },
+ "SEARCH": {
+  "name": "SEARCH",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SEARCH(\"o\", [Text])",
+  "sql_reference_raw": "`LOCATE(LOWER(text), LOWER('o'))` or case-insensitive `INSTR`",
+  "curated": false
+ },
+ "SUBSTITUTE": {
+  "name": "SUBSTITUTE",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "SUBSTITUTE([Text], \"old\", \"new\")",
+  "sql_reference_raw": "`REPLACE(text, 'old', 'new')` or `REGEXP_REPLACE(text, 'old', 'new')`",
+  "curated": false
+ },
+ "TRIM": {
+  "name": "TRIM",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "TRIM([Text])",
+  "sql_reference_raw": "`TRIM(text)` or `TRIM(BOTH ' ' FROM text)`",
+  "curated": false
+ },
+ "UNICHAR": {
+  "name": "UNICHAR",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "UNICHAR(65)",
+  "sql_reference_raw": "`CHAR(65)` or `CHR(65)`",
+  "curated": false
+ },
+ "UNICODE": {
+  "name": "UNICODE",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "UNICODE(\"A\")",
+  "sql_reference_raw": "`ASCII('A')` or `ORD('A')`",
+  "curated": false
+ },
+ "UPPER": {
+  "name": "UPPER",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "UPPER([Text])",
+  "sql_reference_raw": "`UPPER(text)`",
+  "curated": false
+ },
+ "VALUE": {
+  "name": "VALUE",
+  "category": "Text",
+  "feasibility": "ucmv_direct",
+  "default_dax_class": "translatable_direct",
+  "dax_example": "VALUE(\"123.45\")",
+  "sql_reference_raw": "`CAST('123.45' AS DECIMAL)` or `TRY_CAST('123.45' AS DOUBLE)`",
+  "curated": false
+ }
+}

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/table_processor.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/table_processor.py
@@ -585,10 +585,33 @@ def process_table(
             _ctx_lines.append(f"- fact source columns (use as source.<col>): {', '.join(sorted(set(_agg_cols))[:60])}")
         if table_info.group_by_columns:
             _ctx_lines.append(f"- dimension / group-by columns: {', '.join(table_info.group_by_columns[:60])}")
-        if getattr(table_info, 'dim_source_tables', None):
-            _joins = [f"{alias} → {tbl}" for alias, tbl in table_info.dim_source_tables.items()]
-            if _joins:
-                _ctx_lines.append(f"- joined dimensions (use as alias.<col>): {'; '.join(_joins[:30])}")
+        # Joined dimensions the LLM may reference as alias.<col>. Source these from
+        # the AUTHORITATIVE `joins` list (DAX-detected + relationship-enrichment +
+        # fact joins, Step 3) — NOT just table_info.dim_source_tables, which carries
+        # only MQuery-embedded joins and omitted the enrichment joins, causing the
+        # LLM to (correctly, given its context) report "missing join to Dim_X" for
+        # measures whose dim join WAS in fact declared on the emitted spec.
+        # Show ONLY the alias (never the physical table name): the alias is the
+        # single valid namespace in the emitted view, and the DAX dim name maps to
+        # it by lowercase (Dim_Wkctr → dim_wkctr). Displaying "alias → table" led
+        # the LLM to reference the physical table name instead of the alias.
+        _join_aliases: list[str] = []
+        _seen_alias: set[str] = set()
+        for _j in joins:
+            _nm = _j.get('name')
+            if _nm and _nm not in _seen_alias:
+                _seen_alias.add(_nm)
+                _join_aliases.append(_nm)
+        for alias in (getattr(table_info, 'dim_source_tables', None) or {}):
+            if alias not in _seen_alias:
+                _seen_alias.add(alias)
+                _join_aliases.append(alias)
+        if _join_aliases:
+            _ctx_lines.append(
+                "- joined dimensions (reference columns as ALIAS.<col> using EXACTLY "
+                "these aliases; a DAX filter on a dim table maps to its alias, "
+                "e.g. Dim_Wkctr[x] → dim_wkctr.x): "
+                f"{', '.join(_join_aliases[:30])}")
         if getattr(table_info, 'static_filters', None):
             _ctx_lines.append(f"- table-level filters already applied: {'; '.join(table_info.static_filters[:10])}")
         _table_context = "\n".join(_ctx_lines)

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/yaml_emitter.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/yaml_emitter.py
@@ -173,6 +173,31 @@ def _usage_suffix(referenced_by: int) -> str:
     return f' — referenced by {referenced_by} {noun}'
 
 
+_MAX_EXPLANATION = 140
+
+
+def _provenance_suffix(measure) -> str:
+    """Provenance annotation for an LLM-translated measure comment.
+
+    Makes best-effort output auditable: a reviewer sees the confidence, the
+    7-category dax_class, and the LLM's one-line justification for every measure
+    the LLM produced — so high-confidence ones can be trusted and lower-confidence
+    ones triaged. Empty for non-LLM (deterministic regex) measures, which are
+    exact by construction and need no justification.
+    """
+    if getattr(measure, 'category', None) != 'llm_translated':
+        return ''
+    conf = getattr(measure, 'confidence', '') or 'medium'
+    dax_class = getattr(measure, 'dax_class', '') or 'llm'
+    parts = f'LLM[{conf}/{dax_class}]'
+    explanation = (getattr(measure, 'explanation', '') or '').strip()
+    if explanation:
+        if len(explanation) > _MAX_EXPLANATION:
+            explanation = explanation[:_MAX_EXPLANATION - 1].rstrip() + '…'
+        parts += f': {explanation}'
+    return f' · {parts}'
+
+
 def _yaml_needs_quoting(val: str) -> bool:
     """Check if a YAML scalar value needs quoting."""
     if not val:
@@ -698,7 +723,10 @@ def emit_yaml(spec: MetricViewSpec,
             lines.append(f'    expr: {expr}')
             # Use per-table metadata override, fall back to generated
             m_override = _mm.get(m.measure_name, {})
-            comment = m_override.get('comment') or m.skip_reason or col_to_readable(m.measure_name)
+            if m_override.get('comment'):
+                comment = m_override['comment']          # human override wins verbatim
+            else:
+                comment = (m.skip_reason or col_to_readable(m.measure_name)) + _provenance_suffix(m)
             comment += _usage_suffix(m.referenced_by)
             lines.append(f'    comment: {_yaml_val(comment)}')
             m_meta = _meta_gen.get_measure_meta(m.measure_name, expr)
@@ -760,8 +788,10 @@ def emit_yaml(spec: MetricViewSpec,
             # Comment and metadata from per-table overrides or auto-generated
             m_override = _mm.get(m.measure_name, {})
             dax_comment = m_override.get('comment', '')
-            if not dax_comment and m.original_name != m.measure_name:
-                dax_comment = f'PBI: {m.original_name}'
+            if not dax_comment:
+                if m.original_name != m.measure_name:
+                    dax_comment = f'PBI: {m.original_name}'
+                dax_comment += _provenance_suffix(m)
             dax_comment += _usage_suffix(m.referenced_by)
             if dax_comment:
                 lines.append(f'    comment: {_yaml_val(dax_comment)}')

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_utils/yaml_emitter.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_utils/yaml_emitter.py
@@ -893,6 +893,19 @@ def emit_yaml(spec: MetricViewSpec,
                     lines.append(f'  #       DAX:')
                     for dax_line in dax.split('\n'):
                         lines.append(f'  #         {dax_line}')
+                # Best-effort, UNVERIFIED source-view SQL scaffold for the cross-fact /
+                # multi-stage cases — a starting point to build a new view + UCMV on it.
+                # Never an emitted measure; the reviewer completes + verifies it.
+                try:
+                    from .recovery_recommender import draft_source_view
+                    _draft = draft_source_view(
+                        dax, measure_name=m.measure_name, fact_table=spec.fact_table_key)
+                except Exception:
+                    _draft = None
+                if _draft:
+                    lines.append(f'  #       SOURCE-VIEW DRAFT (build this, then a UCMV on it):')
+                    for _dl in _draft.split('\n'):
+                        lines.append(f'  #         {_dl}')
 
     lines.append('')
     return '\n'.join(lines)

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_validation_utils/dax_expression_parser.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_validation_utils/dax_expression_parser.py
@@ -15,6 +15,20 @@ _RETURN_PATTERN = re.compile(r'RETURN(.*)$', re.IGNORECASE | re.DOTALL)
 _MAX_VAR_SUBSTITUTION_ITERATIONS = 100
 _VAR_SUBSTITUTION_WARNING_THRESHOLD = 95
 
+# Hard cap on the character length of any expression produced by variable
+# substitution. Textual VAR substitution expands chained VARs that each
+# reference the next more than once as ~2^N: a ~28-deep chain expands to
+# multiple GB, and both the substitution and the follow-on parse_function_call()
+# then peg CPU/RAM for ~an hour with zero log output before an outer watchdog
+# kills the run (observed on large Power BI reports, e.g. DCC/PAAT). The
+# 100-iteration cap above never trips because the size explodes within ~21
+# iterations. Legit measures expand to at most a few KB even fully substituted,
+# so 200 KB is a generous ceiling. Exceeding it fails OPEN: a RuntimeError is
+# raised and the caller (ExpressionValidator.validate_measure_by_name /
+# MetricExpressionValidatorPipeline) already catches it, marking that one
+# measure ERROR/skipped instead of hanging the entire per-table validation loop.
+_MAX_EXPANDED_EXPR_CHARS = 200_000
+
 
 class DAXExpressionParser:
     """Parser for DAX expressions with hierarchical decomposition."""
@@ -220,9 +234,21 @@ class DAXExpressionParser:
                     )
                     
                     if new_expr != var["variable_expr"]:
+                        if len(new_expr) > _MAX_EXPANDED_EXPR_CHARS:
+                            logger.error(
+                                "DAX variable substitution for '%s' exceeded %d chars "
+                                "(likely exponential VAR-chain expansion); aborting to "
+                                "avoid a parser hang.",
+                                var["variable_name"], _MAX_EXPANDED_EXPR_CHARS,
+                            )
+                            raise RuntimeError(
+                                "DAX variable substitution exceeded maximum expression "
+                                f"size ({_MAX_EXPANDED_EXPR_CHARS} chars); possible "
+                                "exponential VAR-chain expansion."
+                            )
                         var["variable_expr"] = new_expr
                         changed = True
-                
+
                 # Update the working list
                 working_vars[i] = var
             
@@ -262,7 +288,21 @@ class DAXExpressionParser:
             }
         """
         expr = expr.strip()
-        
+
+        # Defense-in-depth: never recurse over a pathologically large expression
+        # (e.g. one produced by exponential VAR-chain substitution). The
+        # substitution guards above normally catch this first; this covers the
+        # no-VAR branch where a raw expression is already enormous.
+        if len(expr) > _MAX_EXPANDED_EXPR_CHARS:
+            logger.error(
+                "DAX expression to parse exceeded %d chars; aborting to avoid a "
+                "parser hang.", _MAX_EXPANDED_EXPR_CHARS,
+            )
+            raise RuntimeError(
+                "DAX expression exceeded maximum size "
+                f"({_MAX_EXPANDED_EXPR_CHARS} chars) for parsing."
+            )
+
         # Find the function name (everything before the first '(' or '{')
         paren_pos = expr.find('(')
         
@@ -367,20 +407,34 @@ class DAXExpressionParser:
         toplevel_components = self.decompose_toplevel(cleaned)
         
         if toplevel_components.get("variables"):
-            substituted_vars = self.substitute_all_variables_recursively(toplevel_components["variables"])
-            
-            resulting_return_expr = toplevel_components["return_expr"]
-            for svar in substituted_vars:
-                resulting_return_expr = self._substitute_single_variable(
-                    resulting_return_expr, 
-                    svar["variable_name"], 
-                    svar["variable_expr"]
-                )
+            # Chained VARs where each references the next more than once expand
+            # as ~2^N under *textual* substitution and wedge the parser for ~an
+            # hour (see substitute_all_variables_recursively). We don't need the
+            # flattened text: every downstream comparison in ExpressionValidator
+            # is over SETS of aggregations / filters / column-references
+            # (_compare_aggregations / _compare_filters / _compare_columns), so a
+            # subtree that appears N times carries no more signal than once.
+            #
+            # So instead of substituting, parse the RETURN expression and each
+            # RELEVANT VAR expression exactly ONCE and union them under a
+            # synthetic root. The _extract_*_from_tree walkers then collect the
+            # union across all of them. This is linear in the DAX length, yields
+            # the same component sets as full substitution for normal measures,
+            # and no longer explodes on chained-VAR measures. Repeated variable
+            # references (e.g. "v1 + v1") become inert `{"value": "v1"}` leaves,
+            # while each variable's real content is parsed from its own subtree.
+            subtrees: List[Dict[str, Any]] = []
+            return_expr = toplevel_components.get("return_expr")
+            if return_expr:
+                subtrees.append(self.parse_function_call(return_expr))
+            for var in toplevel_components["variables"]:
+                subtrees.append(self.parse_function_call(var["variable_expr"]))
+            return {"function": "__VARS_ROOT__", "arguments": subtrees}
         elif toplevel_components.get("return_expr"):
             resulting_return_expr = toplevel_components["return_expr"]
         else:
             resulting_return_expr = toplevel_components["expr"]
-        
+
         return self.parse_function_call(resulting_return_expr)
     
     def _parse_condition(self, condition: str) -> Dict[str, Any]:

--- a/src/backend/src/engines/crewai/tools/custom/metric_view_validator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/metric_view_validator_tool.py
@@ -96,6 +96,11 @@ class MetricViewValidatorTool(BaseTool):
             except Exception as _e:
                 logger.debug(f"[Validator] Could not check for saved edits: {_e}")
 
+        # Non-transpiled measures carried through from the UCMV generator so the
+        # validation UI can list WHICH measures were not emitted and why (the
+        # per-table counts alone don't tell a reviewer that). Passed through
+        # untouched — the validator does not evaluate them (they have no SQL).
+        untranslatable_items: list = []
         try:
             # If ucmv_output is provided, extract yaml from it
             if ucmv_raw:
@@ -107,6 +112,9 @@ class MetricViewValidatorTool(BaseTool):
                         pass  # Config Proposer output, not UCMV
                     else:
                         yaml_raw = ucmv_data
+                    _ui = ucmv_data.get('untranslatable_items')
+                    if isinstance(_ui, list):
+                        untranslatable_items = _ui
                 logger.info(f"[Validator] Extracted YAML from ucmv_output: {len(yaml_raw) if isinstance(yaml_raw, dict) else 'str'}")
 
             yaml_tables = json.loads(yaml_raw) if isinstance(yaml_raw, str) else yaml_raw
@@ -123,6 +131,8 @@ class MetricViewValidatorTool(BaseTool):
                     # Full UCMV output — extract yaml and keep the rest for validation
                     yaml_tables = _db_result['yaml']
                     ucmv_raw = json.dumps(_db_result)  # Store full output for built-in validation
+                    if not untranslatable_items and isinstance(_db_result.get('untranslatable_items'), list):
+                        untranslatable_items = _db_result['untranslatable_items']
                     logger.info(f"[Validator] Fetched full UCMV output from DB: {len(yaml_tables)} tables")
                 elif isinstance(_db_result, dict):
                     yaml_tables = _db_result
@@ -408,6 +418,10 @@ class MetricViewValidatorTool(BaseTool):
             # `per_table_summary` counts represent them). Full per-measure detail
             # remains queryable in the execution trace.
             "yaml": yaml_tables,
+            # Non-transpiled measures (passed through from the UCMV generator, not
+            # evaluated here — they have no SQL). Lets the validation UI list WHICH
+            # measures were not emitted + why, next to the per-table quality counts.
+            "untranslatable_items": untranslatable_items,
             "full_detail_in_trace": True,
         }
 

--- a/src/backend/src/engines/crewai/tools/custom/pipeline_config_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/pipeline_config_generator_tool.py
@@ -635,6 +635,17 @@ class PipelineConfigGeneratorTool(BaseTool):
                 _um["referenced_by"] = _usage.get(
                     _um.get("original_name") or _um.get("measure_name"), 0)
 
+            # Ship the raw Power Query M per table so the UCMV pipeline can resolve
+            # physical table/column names and materialize generated (List.Dates)
+            # tables — KASAL_FIXES Gaps 1-3 — without a separate scan_data handoff.
+            # Rides inside proposed_config (already injected into the generator's
+            # config_json), so no new flow field/wiring is needed. Keyed table→raw M.
+            config["table_mquery_expressions"] = {
+                _n: (_t.get("mquery_expression") or _t.get("mquery") or "")
+                for _n, _t in (admin_tables or {}).items()
+                if isinstance(_t, dict) and (_t.get("mquery_expression") or _t.get("mquery"))
+            }
+
             output = {
                 "proposed_config": config,
                 # Consumed by the flow handoff → UCMV JSON mode.

--- a/src/backend/src/engines/crewai/tools/custom/pipeline_config_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/pipeline_config_generator_tool.py
@@ -24,6 +24,13 @@ logger = logging.getLogger(__name__)
 # a model field.
 _DAX_TABLE_REF = re.compile(r"(?:'([^']+)'|(\w+))\s*\[")
 
+# Cap on the raw M shipped downstream for a table `resolve_mquery_with_context`
+# couldn't compile. Matches the truncation `metric_view_utils/pipeline.py`
+# already applies to its OWN "tables not emitted" report — kept consistent
+# rather than inventing a second cutoff. See `_build_ucmv_mquery`. Module-level
+# for the same Pydantic-private-attribute reason as `_DAX_TABLE_REF` above.
+_UNRESOLVED_MQUERY_PREVIEW_CHARS = 2000
+
 
 class PipelineConfigGeneratorSchema(BaseModel):
     """Input schema — drives the Kasal UI form."""
@@ -289,11 +296,32 @@ class PipelineConfigGeneratorTool(BaseTool):
             # NOT fatal: on failure we fall back to Fabric TMDL (which a Service
             # Account CAN read), mirroring the Semantic Model Fetcher.
             admin_tables = {}
+            # {name: raw_M} of the model's named/shared expressions — parsed
+            # from the SAME scan_result/tmdl_parts as admin_tables (no extra
+            # API calls). Needed for two M shapes a table's own mquery_
+            # expression can't resolve alone: a table that's nothing but a
+            # passthrough to a disabled staging query, and a table whose
+            # physical source is built from model PARAMETERS (also surfaced
+            # here, not in `tables`) via string concatenation. See
+            # metric_view_utils.mquery_parser.resolve_mquery_with_context.
+            expressions: dict[str, str] = {}
+            # Which tier actually supplied each — surfaced in `summary` below so a
+            # rerun is self-diagnosing (which tier fired, how many expressions it
+            # found) without needing a live repro script to find out.
+            admin_tables_source: str | None = None
+            expressions_source: str | None = None
             logger.info("[PipelineConfigGen] API 3: Admin Scanner (workspace scan)...")
             try:
                 scan_result = gen.trigger_admin_scan(admin_token, workspace_id)
                 admin_tables = gen.parse_admin_tables(scan_result, dataset_id=dataset_id)
-                logger.info(f"[PipelineConfigGen]   → {len(admin_tables)} tables (admin scanner)")
+                if admin_tables:
+                    admin_tables_source = "admin scanner"
+                expressions = gen.parse_admin_expressions(scan_result, dataset_id=dataset_id)
+                if expressions:
+                    expressions_source = "admin scanner"
+                logger.info(
+                    f"[PipelineConfigGen]   → {len(admin_tables)} tables, "
+                    f"{len(expressions)} shared expressions (admin scanner)")
             except Exception as e:
                 msg = f"API 3 (Admin Scanner) failed: {e}"
                 logger.warning(f"[PipelineConfigGen] {msg}")
@@ -302,8 +330,19 @@ class PipelineConfigGeneratorTool(BaseTool):
             # API 3 fallback: Fabric TMDL (works for Service Accounts that the
             # Admin Scanner blocks). Uses whichever non-admin creds are present
             # (SA username/password OR SP client_secret) to mint a Fabric token.
-            if not admin_tables:
-                logger.info("[PipelineConfigGen] Admin scan empty — trying Fabric TMDL fallback...")
+            #
+            # Gated on EITHER admin_tables OR expressions being empty, not just
+            # admin_tables — a tier can return real tables but empty expressions
+            # (e.g. a token whose rights cover dataset schema but not the
+            # tenant-admin-gated "detailed metadata" expressions/parameters
+            # section within the same API), which used to be silently accepted
+            # as "done" and skip every remaining tier, leaving every
+            # reference-following / parameter-driven M unresolved even though
+            # admin_tables looked like a success. Each tier below only fills in
+            # whichever of the two is still missing — it never overwrites a
+            # good result from an earlier tier with a worse one.
+            if not admin_tables or not expressions:
+                logger.info("[PipelineConfigGen] Admin scan tables/expressions incomplete — trying Fabric TMDL fallback...")
                 try:
                     fabric_token = gen.get_fabric_token(
                         tenant_id, client_id, client_secret,
@@ -311,8 +350,17 @@ class PipelineConfigGeneratorTool(BaseTool):
                     )
                     tmdl_parts = gen.fetch_tmdl_parts(fabric_token, workspace_id, dataset_id)
                     if tmdl_parts:
-                        admin_tables = gen.parse_tmdl_to_admin_tables(tmdl_parts, dataset_id=dataset_id)
-                        logger.info(f"[PipelineConfigGen]   → {len(admin_tables)} tables (Fabric TMDL)")
+                        if not admin_tables:
+                            admin_tables = gen.parse_tmdl_to_admin_tables(tmdl_parts, dataset_id=dataset_id)
+                            if admin_tables:
+                                admin_tables_source = "Fabric TMDL"
+                        if not expressions:
+                            expressions = gen.parse_tmdl_expressions(tmdl_parts)
+                            if expressions:
+                                expressions_source = "Fabric TMDL"
+                        logger.info(
+                            f"[PipelineConfigGen]   → {len(admin_tables)} tables, "
+                            f"{len(expressions)} shared expressions (Fabric TMDL)")
                     else:
                         logger.warning("[PipelineConfigGen] Fabric TMDL returned no parts (workspace may not be Fabric-enabled)")
                         warnings.append("Fabric TMDL fallback returned no data (workspace may not be Fabric-enabled).")
@@ -325,9 +373,10 @@ class PipelineConfigGeneratorTool(BaseTool):
             # PRINCIPAL token, if an admin client_secret was supplied. Covers the
             # case where the workspace is NOT Fabric-enabled (TMDL unavailable)
             # and the SA cannot use the Admin Scanner — an SP with admin rights
-            # still can. Only runs when a distinct SP secret is available.
-            if not admin_tables and admin_client_secret:
-                logger.info("[PipelineConfigGen] TMDL empty — retrying Admin Scanner with Service Principal...")
+            # still can. Only runs when a distinct SP secret is available. Same
+            # independent-fill behavior as the TMDL tier above.
+            if (not admin_tables or not expressions) and admin_client_secret:
+                logger.info("[PipelineConfigGen] Tables/expressions still incomplete — retrying Admin Scanner with Service Principal...")
                 try:
                     sp_admin_token = self._resolve_token(
                         tenant_id=tenant_id, client_id=admin_client_id,
@@ -336,8 +385,17 @@ class PipelineConfigGeneratorTool(BaseTool):
                         auth_method="service_principal", label="admin-SP-fallback",
                     )
                     scan_result = gen.trigger_admin_scan(sp_admin_token, workspace_id)
-                    admin_tables = gen.parse_admin_tables(scan_result, dataset_id=dataset_id)
-                    logger.info(f"[PipelineConfigGen]   → {len(admin_tables)} tables (SP fallback)")
+                    if not admin_tables:
+                        admin_tables = gen.parse_admin_tables(scan_result, dataset_id=dataset_id)
+                        if admin_tables:
+                            admin_tables_source = "SP fallback"
+                    if not expressions:
+                        expressions = gen.parse_admin_expressions(scan_result, dataset_id=dataset_id)
+                        if expressions:
+                            expressions_source = "SP fallback"
+                    logger.info(
+                        f"[PipelineConfigGen]   → {len(admin_tables)} tables, "
+                        f"{len(expressions)} shared expressions (SP fallback)")
                 except Exception as e:
                     msg = f"Service Principal Admin Scanner fallback failed: {e}"
                     logger.warning(f"[PipelineConfigGen] {msg}")
@@ -466,7 +524,7 @@ class PipelineConfigGeneratorTool(BaseTool):
             # P1 (below) is deterministic — no warehouse, no LLM. P2/P3 are gated on
             # `warehouse_id` and added in later phases.
             enrichment_log: list[dict] = []
-            enrichment_log += self._enrich_source_tables_from_mquery(config, admin_tables)
+            enrichment_log += self._enrich_source_tables_from_mquery(config, admin_tables, expressions)
 
             # P2 (warehouse): resolve flag-column filter_sets whose values live in
             # DB rows, not DAX. Gated on warehouse_id; uses run_async_with_context so
@@ -532,7 +590,32 @@ class PipelineConfigGeneratorTool(BaseTool):
             # though config extraction (measures + DAX) fully succeeded.
             ucmv_measures = self._build_ucmv_measures(
                 measures, admin_tables=admin_tables, config=config)
-            ucmv_mquery = self._build_ucmv_mquery(admin_tables)
+            ucmv_mquery = self._build_ucmv_mquery(admin_tables, expressions)
+
+            # Diagnostic split: how many tables resolve via the DIRECT path alone
+            # (resolve_mquery_to_sql — no `expressions` needed) vs how many the
+            # ACTUAL ucmv_mquery got (resolve_mquery_with_context — reference-
+            # following + parameter-substitution, needs `expressions`). If these
+            # two numbers come out equal despite `expressions` being non-empty,
+            # the context-aware half of resolve_mquery_with_context isn't
+            # contributing anything at runtime — points at a stale/uncommitted
+            # deploy of metric_view_utils/mquery_parser.py or
+            # mquery_let_evaluator.py rather than a data problem.
+            try:
+                from src.engines.crewai.tools.custom.metric_view_utils.mquery_parser import (
+                    resolve_mquery_to_sql as _direct_resolve,
+                )
+                _direct_resolved = sum(
+                    1 for _tname, _tinfo in (admin_tables or {}).items()
+                    if isinstance(_tinfo, dict)
+                    and _direct_resolve((_tinfo.get("mquery_expression") or _tinfo.get("mquery") or "").strip())
+                )
+            except Exception:
+                _direct_resolved = None
+            _context_resolved = sum(
+                1 for _e in ucmv_mquery
+                if _e.get("transpiled_sql", "").strip().upper().startswith("SELECT")
+            )
 
             # ── Measure usage ranking (reviewer prioritization) ──────────────
             # How many OTHER measures reference each measure (in-degree). Lets
@@ -574,6 +657,11 @@ class PipelineConfigGeneratorTool(BaseTool):
                     "measures_referenced_by_others": len(usage_ranking),
                     "mquery_tables_for_ucmv": len(ucmv_mquery),
                     "admin_tables_scanned": len(admin_tables),
+                    "admin_tables_source": admin_tables_source,
+                    "expressions_captured": len(expressions),
+                    "expressions_source": expressions_source,
+                    "mquery_resolved_direct_only": _direct_resolved,
+                    "mquery_resolved_with_context": _context_resolved,
                 },
                 "warnings": warnings,
                 # Additive-enrichment audit trail (source_table parse, warehouse
@@ -619,11 +707,21 @@ class PipelineConfigGeneratorTool(BaseTool):
                     workspace_id=workspace_id,
                     dataset_id=dataset_id,
                     report_id=report_id,
+                    expressions=expressions,
                 ))
             except Exception as _ext_err:
                 logger.warning(f"[PipelineConfigGen] powerbi_extraction persistence skipped: {_ext_err}")
 
-            return json.dumps(output, indent=2, default=str)
+            output_json = json.dumps(output, indent=2, default=str)
+
+            # NOTE: no /tmp fallback file here. Crews run in separate subprocesses
+            # (confirmed empirically — a /tmp file written here is not visible to
+            # the UC Metric View Generator tool's own process), so that never
+            # worked as a handoff mechanism. The powerbi_extraction row saved
+            # above (keyed by execution_id == this flow's job_id) is what the
+            # UCMV Generator's DB fallback reads instead — a normal DB write
+            # through Kasal's async session, which does cross process boundaries.
+            return output_json
 
         except Exception as e:
             logger.exception("[PipelineConfigGen] Failed")
@@ -763,7 +861,7 @@ class PipelineConfigGeneratorTool(BaseTool):
         return out
 
     @staticmethod
-    def _build_ucmv_mquery(admin_tables: dict) -> list[dict]:
+    def _build_ucmv_mquery(admin_tables: dict, expressions: dict | None = None) -> list[dict]:
         """Convert admin_tables into the UCMV `mquery_json` shape.
 
         Both `parse_admin_tables` and `parse_tmdl_to_admin_tables` populate
@@ -772,14 +870,56 @@ class PipelineConfigGeneratorTool(BaseTool):
             {table_name, transpiled_sql, validation_passed}
         and skips any entry without both a table_name and sql — so tables with
         no source expression are omitted (they carry no fact/source signal).
+
+        Prefers a deterministic compile to compact SQL
+        (``resolve_mquery_with_context``) over shipping the raw M. Three
+        reasons, not one:
+        (1) M authored via a catalog-browse connector (``Databricks.Catalogs`` et
+            al — "Get Data → browse catalog/schema/table" in the PBI UI) carries
+            no embedded SQL text at all, so the downstream SQL-only parser finds
+            no FROM clause and silently treats the table as non-fact — every such
+            table was dropped, 0 views generated.
+        (2) Some tables are nothing but a reference to a disabled "staging"
+            query (their own M has no source at all), or build their physical
+            source from model PARAMETERS via string concatenation rather than
+            a literal — both need the model's named/shared ``expressions``
+            (parsed alongside ``admin_tables`` — see ``parse_admin_expressions``
+            / ``parse_tmdl_expressions``) to resolve at all.
+        (3) That M is also the largest text in this payload (a single table's
+            source can run 10-15K+ chars once the connector's ordinary column
+            select/rename steps are included). Shipping it raw, per table, is
+            what breaks the pipeline-config → UCMV task handoff: the receiving
+            agent has to reproduce this JSON verbatim as its own tool-call
+            argument, which is bounded by its own output-token budget — nowhere
+            near enough for a payload like that. A table with unresolved M and
+            no embedded SQL previously still shipped in full; now it's capped.
         """
+        from src.engines.crewai.tools.custom.metric_view_utils.mquery_parser import (
+            resolve_mquery_with_context,
+        )
         out: list[dict] = []
         for tbl_name, tbl_info in (admin_tables or {}).items():
             if not isinstance(tbl_info, dict):
                 continue
-            sql = (tbl_info.get("mquery_expression") or tbl_info.get("mquery") or "").strip()
-            if not tbl_name or not sql:
+            raw = (tbl_info.get("mquery_expression") or tbl_info.get("mquery") or "").strip()
+            if not tbl_name or not raw:
                 continue
+            resolved = resolve_mquery_with_context(raw, expressions)
+            if resolved:
+                sql = resolved
+            elif len(raw) <= _UNRESOLVED_MQUERY_PREVIEW_CHARS:
+                # Small enough to ship as-is: covers Value.NativeQuery-style M
+                # (the downstream parser finds the embedded SELECT/FROM
+                # regardless of the M wrapper around it) and non-warehouse /
+                # DAX-calc / inline-constant tables the migration report still
+                # wants to explain as "correctly skipped" rather than vanishing.
+                sql = raw
+            else:
+                # Large AND unresolved — cap it. The table still gets reported
+                # (with enough of the M to classify why it was skipped), without
+                # repeating the handoff-breaking mistake. The full text remains
+                # queryable via the persisted powerbi_extraction row.
+                sql = raw[:_UNRESOLVED_MQUERY_PREVIEW_CHARS]
             out.append({
                 "table_name": tbl_name,
                 "transpiled_sql": sql,
@@ -867,7 +1007,7 @@ class PipelineConfigGeneratorTool(BaseTool):
 
     async def _save_powerbi_extraction(
         self, relationships, measures, admin_tables, report_def, config, warnings,
-        workspace_id, dataset_id, report_id,
+        workspace_id, dataset_id, report_id, expressions=None,
     ) -> None:
         """Persist the FULL raw extraction to the powerbi_extraction table (fail-open).
 
@@ -913,6 +1053,7 @@ class PipelineConfigGeneratorTool(BaseTool):
                 relationships=relationships,
                 measures=measures,
                 admin_tables=admin_tables,
+                expressions=expressions or {},
                 report_definition=report_def or None,
                 proposed_config=config,
                 warnings=warnings or [],
@@ -938,19 +1079,24 @@ class PipelineConfigGeneratorTool(BaseTool):
             )
 
     @staticmethod
-    def _enrich_source_tables_from_mquery(config: dict, admin_tables: dict) -> list[dict]:
+    def _enrich_source_tables_from_mquery(
+        config: dict, admin_tables: dict, expressions: dict | None = None,
+    ) -> list[dict]:
         """P1 enrichment: fill ``join_key_map[dim].source_table`` from the dimension's
         Power Query M source (deterministic — no warehouse, no LLM).
 
         A dimension's physical UC table name isn't in the PBI APIs, but a
         Databricks-connector / native-query M source spells it out. For each join
         entry lacking a ``source_table`` (or holding a ``TODO:`` placeholder), parse
-        it from ``admin_tables[dim]["mquery_expression"]``. Strictly additive: an
-        existing non-TODO value is never overwritten. Returns an audit log of what
-        was filled vs. skipped (and why), for the Config Editor.
+        it from ``admin_tables[dim]["mquery_expression"]`` — following a reference
+        to a disabled staging query, or evaluating a parameter-driven source, via
+        the model's named/shared ``expressions`` when the dimension's own M alone
+        isn't enough (see ``extract_source_table_with_context``). Strictly
+        additive: an existing non-TODO value is never overwritten. Returns an
+        audit log of what was filled vs. skipped (and why), for the Config Editor.
         """
         from src.engines.crewai.tools.custom.metric_view_utils.mquery_parser import (
-            classify_mquery_source, extract_source_table,
+            classify_mquery_source, extract_source_table_with_context,
         )
         log: list[dict] = []
         join_key_map = config.get("join_key_map", {}) or {}
@@ -962,7 +1108,7 @@ class PipelineConfigGeneratorTool(BaseTool):
                 continue  # human/derived value — never overwrite
             tinfo = admin_tables.get(dim) or {}
             mquery = tinfo.get("mquery_expression") or tinfo.get("mquery") or ""
-            resolved = extract_source_table(mquery) if mquery else None
+            resolved = extract_source_table_with_context(mquery, expressions) if mquery else None
             if resolved:
                 entry["source_table"] = resolved
                 log.append({

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -429,6 +429,10 @@ class UCMetricViewGeneratorTool(BaseTool):
             # thin-report run is never a silent empty result.
             'zero_view_diagnosis': zero_view_diagnosis,
             'views_generated': len(yaml_output) if isinstance(yaml_output, dict) else 0,
+            # Flattened non-transpiled measures for the validation-UI review panel
+            # (full DAX + reason + category + dependency count). Additive; [] when
+            # everything translated.
+            'untranslatable_items': self._build_untranslatable_items(results.get('specs', {})),
             'specs_summary': {
                 k: {
                     'view_name': v.get('view_name'),
@@ -499,6 +503,36 @@ class UCMetricViewGeneratorTool(BaseTool):
                 'proposed_allocation': m.get('proposed_allocation') or '',
             })
         return extract
+
+    @staticmethod
+    def _build_untranslatable_items(specs: dict) -> list:
+        """Flatten every spec's untranslatable measures into one UI-ready list.
+
+        Feeds the validation-UI "Not transpiled" review panel: reviewers see the
+        non-emitted measures as first-class rows (original DAX + why skipped +
+        category + dependency in-degree) instead of digging through the YAML
+        `-- comment` block. Additive — does not change any existing output field.
+        Each row is keyed by (table_key, original_name) on the frontend so review
+        annotations round-trip via the persisted result. Returns [] when nothing
+        was skipped.
+        """
+        items: list = []
+        for table_key, spec in (specs or {}).items():
+            view_name = spec.get('view_name')
+            for m in spec.get('untranslatable', []) or []:
+                items.append({
+                    'table_key': table_key,
+                    'view_name': view_name,
+                    'original_name': m.get('original_name') or m.get('name'),
+                    'dax_expression': m.get('dax_expression', ''),
+                    'skip_reason': m.get('skip_reason', ''),
+                    'category': m.get('category', ''),
+                    'dax_class': m.get('dax_class'),
+                    'referenced_by': m.get('referenced_by', 0),
+                })
+        # High-impact gaps first (most-depended-on measures at the top).
+        items.sort(key=lambda x: x.get('referenced_by', 0), reverse=True)
+        return items
 
     @staticmethod
     def _build_fallback_extract(measures: Any, mquery_entries: Any) -> list:

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -87,7 +87,14 @@ class UCMetricViewGeneratorTool(BaseTool):
                        'workspace_id', 'dataset_id', 'tenant_id', 'client_id',
                        'client_secret', 'username', 'password', 'auth_method',
                        'access_token', 'pbi_api_base_url',
-                       'admin_client_id', 'admin_client_secret')
+                       'admin_client_id', 'admin_client_secret',
+                       # Best-effort UCMV for thin-report models (no M-Query source
+                       # tables). Opt-in only; see thin-report-and-source-resolution.md.
+                       #   allow_best_effort : gate (default off → today's behavior)
+                       #   fact_source_map   : { pbi_table : "catalog.schema.table" }
+                       #                       physical sources the human supplies when
+                       #                       the model didn't carry them.
+                       'allow_best_effort', 'fact_source_map')
         default_config = {}
         for key in config_keys:
             val = kwargs.pop(key, None)

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -361,6 +361,26 @@ class UCMetricViewGeneratorTool(BaseTool):
                 rel_data = json.loads(relationships_raw) if isinstance(relationships_raw, str) else relationships_raw
                 loader = RelationshipsLoader()
                 fact_keys = {k for k, v in mquery_tables.items() if v.is_fact}
+                # Also enrich tables that have DAX measures allocated to them but are
+                # NOT aggregate-SQL facts (raw-grain / data-vault sources like fact_pe005,
+                # whose M is a plain SELECT). Phase 1b promotes these to facts *during*
+                # the run — but RelationshipsLoader only builds joins for tables in
+                # fact_keys, so without adding them here they get ZERO joins and their
+                # join-dependent measures (e.g. the *_Yeild_Actual ratios filtering on
+                # Dim_wkctr/Dim_Plant) decline. Gate on a real source_table (matches
+                # Phase 1b) so UI/selection/measure-holder tables aren't pulled in.
+                try:
+                    _measures = (json.loads(measures_raw)
+                                 if isinstance(measures_raw, str) else (measures_raw or []))
+                except Exception:
+                    _measures = []
+                for _m in (_measures or []):
+                    _allocs = [a.get('table') for a in (_m.get('all_allocations') or [])] \
+                        or [_m.get('proposed_allocation')]
+                    for _t in _allocs:
+                        _ti = mquery_tables.get(_t)
+                        if _t and _ti is not None and getattr(_ti, 'source_table', None):
+                            fact_keys.add(_t)
                 relationships_enrichment = loader.load(rel_data, mquery_tables, fact_keys)
                 m2n_relationships = loader.get_skipped_m2n()
                 inactive_relationships = loader.get_inactive_relationships()

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -82,7 +82,14 @@ class UCMetricViewGeneratorTool(BaseTool):
                        'use_llm_fallback', 'translation_mode', 'llm_model', 'llm_workspace_url', 'llm_token',
                        'workspace_id', 'dataset_id', 'tenant_id', 'client_id',
                        'client_secret', 'username', 'password', 'auth_method',
-                       'access_token', 'pbi_api_base_url')
+                       'access_token', 'pbi_api_base_url',
+                       # Best-effort UCMV for thin-report models (no M-Query source
+                       # tables). Opt-in only; see thin-report-and-source-resolution.md.
+                       #   allow_best_effort : gate (default off → today's behavior)
+                       #   fact_source_map   : { pbi_table : "catalog.schema.table" }
+                       #                       physical sources the human supplies when
+                       #                       the model didn't carry them.
+                       'allow_best_effort', 'fact_source_map')
         default_config = {}
         for key in config_keys:
             val = kwargs.pop(key, None)
@@ -366,6 +373,32 @@ class UCMetricViewGeneratorTool(BaseTool):
         # regardless of whether the transpilation pipeline succeeded.
         fallback_extract = self._build_fallback_extract(measures, mquery_entries)
 
+        # ── Opt-in best-effort views for a THIN-REPORT model ────────────────
+        # When the normal path produced 0 views AND the user opted in
+        # (allow_best_effort) AND supplied physical sources (fact_source_map),
+        # draft thin UCMVs from measures that already resolved to real SQL. This
+        # is the fallback-of-the-fallback — the preferred fix is to convert the
+        # upstream semantic model (see thin-report-and-source-resolution.md). The
+        # coverage_report makes the gap explicit (tables/measures skipped), and
+        # every drafted measure is flagged TODO: verify.
+        best_effort_report = None
+        if (not yaml_output) and _get('allow_best_effort') and _get('fact_source_map'):
+            fsm = _get('fact_source_map')
+            if isinstance(fsm, str):
+                try:
+                    fsm = json.loads(fsm)
+                except Exception:
+                    fsm = None
+            be_views, best_effort_report = self._build_best_effort_views(
+                fact_source_map=fsm, config=config, measures=measures)
+            if be_views:
+                yaml_output = be_views
+                logger.warning(
+                    f"[UCMVGenerator] BEST-EFFORT mode: drafted {best_effort_report['tables_emitted']} "
+                    f"view(s) / {best_effort_report['measures_emitted']} measure(s) from a thin report; "
+                    f"{best_effort_report['measures_skipped_unresolved']} measure(s) unresolved and skipped. "
+                    f"Tables/measures may be MISSING — every measure marked TODO: verify.")
+
         output = {
             'yaml': yaml_output,
             'sql': sql_output,
@@ -379,6 +412,9 @@ class UCMetricViewGeneratorTool(BaseTool):
             # Always present; the UI shows it as a tabular reference and falls back
             # to it as the primary artifact when `yaml` is empty (0 views).
             'fallback_extract': fallback_extract,
+            # Present only when best-effort mode fired: surfaces the coverage gap
+            # (skipped tables/measures) so the UI/consumer can warn "may be missing".
+            'best_effort_report': best_effort_report,
             'views_generated': len(yaml_output) if isinstance(yaml_output, dict) else 0,
             'specs_summary': {
                 k: {
@@ -510,6 +546,112 @@ class UCMetricViewGeneratorTool(BaseTool):
             r['measure_count'] = len(r['measures'])
             r['has_mquery'] = bool(r['mquery'])
         return rows
+
+    @staticmethod
+    def _build_best_effort_views(
+        fact_source_map: Any,
+        config: Any,
+        measures: Any,
+    ) -> tuple[dict, dict]:
+        """Best-effort UCMVs for a THIN-REPORT model (no M-Query source tables).
+
+        Opt-in fallback used ONLY when the normal path produced 0 views AND the
+        human supplied `fact_source_map` (PBI table -> physical catalog.schema.table).
+        See docs/powerbi/thin-report-and-source-resolution.md — the PREFERRED fix is
+        to point Kasal at the upstream semantic model; this is for when that model is
+        unreachable.
+
+        Emits one thin metric view per supplied source, containing only measures that
+        ALREADY resolved to real aggregatable SQL in `config['measure_resolutions']`
+        (reusing the pipeline's own base_expr + base_filters). It NEVER fabricates SQL:
+        - measures with a `TODO`/empty resolution are skipped (documented, not emitted);
+        - tables not in `fact_source_map` are skipped;
+        so the "never emit silently-wrong SQL" contract holds.
+
+        Every emitted measure is flagged `TODO: verify` because it is a DRAFT produced
+        without a validated transpiled source. Returns (views, coverage_report) where
+        coverage_report makes the GAP explicit — tables/measures that were skipped.
+        """
+        views: dict = {}
+        report = {
+            'mode': 'best_effort',
+            'warning': ('DRAFT views built from a thin report without validated source '
+                        'tables. Tables/measures may be MISSING; every emitted measure '
+                        'is marked "TODO: verify". Prefer converting the upstream '
+                        'semantic model — see thin-report-and-source-resolution.md.'),
+            'sources_supplied': 0,
+            'tables_emitted': 0,
+            'measures_emitted': 0,
+            'measures_skipped_unresolved': 0,
+            'tables_without_source': [],
+            'skipped_measures': [],
+        }
+        if not isinstance(fact_source_map, dict) or not fact_source_map:
+            return views, report
+        resolutions = (config or {}).get('measure_resolutions', {}) if isinstance(config, dict) else {}
+        report['sources_supplied'] = len(fact_source_map)
+
+        _AGG = ('SUM', 'COUNT', 'AVG', 'MIN', 'MAX', 'DIVIDE', 'CALCULATE', 'SUMX', 'COUNTX')
+
+        def _to_snake(name: str) -> str:
+            import re as _re
+            s = _re.sub(r'[^0-9a-zA-Z]+', '_', str(name)).strip('_').lower()
+            return s or 'measure'
+
+        def _alloc(m: dict) -> str:
+            return (m.get('proposed_allocation') or m.get('table_name')
+                    or m.get('table') or '__unassigned__')
+
+        # measure name -> its allocated PBI table (from the measures list)
+        measure_table = {}
+        if isinstance(measures, list):
+            for m in measures:
+                if isinstance(m, dict):
+                    nm = m.get('measure_name') or m.get('original_name') or ''
+                    if nm:
+                        measure_table[nm] = _alloc(m)
+
+        # group RESOLVED measures by their allocated PBI table
+        by_table: dict[str, list] = {}
+        for mname, res in (resolutions or {}).items():
+            base = (res or {}).get('base_expr', '') if isinstance(res, dict) else ''
+            if (not base) or base.strip().upper().startswith('TODO') \
+                    or not base.strip().upper().startswith(_AGG):
+                report['measures_skipped_unresolved'] += 1
+                report['skipped_measures'].append(mname)
+                continue
+            by_table.setdefault(measure_table.get(mname, '__unassigned__'), []).append((mname, res))
+
+        for pbi_table, source in fact_source_map.items():
+            rows = by_table.get(pbi_table, [])
+            if not rows:
+                report['tables_without_source'].append(pbi_table)
+                continue
+            measures_out = []
+            for mname, res in rows:
+                expr = res['base_expr']
+                filters = res.get('base_filters') or []
+                if filters:
+                    expr = f"{expr} FILTER (WHERE {' AND '.join(filters)})"
+                measures_out.append({
+                    'name': _to_snake(mname),
+                    'expr': expr,
+                    'comment': (f"BEST-EFFORT DRAFT — no validated source. TODO: verify. "
+                                f"From DAX '{mname}'."),
+                })
+            views[pbi_table] = {
+                'version': '1.1',
+                'source': source,
+                'comment': (f"BEST-EFFORT UC Metric View (thin-report model). "
+                            f"{len(measures_out)} measures drafted from resolved SQL; "
+                            f"NOT validated against a transpiled source. Review before "
+                            f"deploy. Some measures/tables from the original model may "
+                            f"be MISSING."),
+                'measures': measures_out,
+            }
+            report['tables_emitted'] += 1
+            report['measures_emitted'] += len(measures_out)
+        return views, report
 
     async def _save_dax_to_conversion_history(
         self,

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -471,6 +471,7 @@ class UCMetricViewGeneratorTool(BaseTool):
                 dataset_id=_get('dataset_id'),
                 catalog=catalog,
                 schema=schema,
+                untranslatable_items=output.get('untranslatable_items') or [],
             ))
         except Exception as _hist_err:
             logger.warning(f"[UCMVGenerator] conversion_history persistence skipped: {_hist_err}")
@@ -791,6 +792,7 @@ class UCMetricViewGeneratorTool(BaseTool):
         dataset_id: Optional[str],
         catalog: Optional[str],
         schema: Optional[str],
+        untranslatable_items: Optional[list] = None,
     ) -> None:
         """Persist the full raw DAX extract to conversion_history (fail-open).
 
@@ -800,7 +802,23 @@ class UCMetricViewGeneratorTool(BaseTool):
         ``source_format=powerbi_dax`` / ``execution_id``) or
         ``GET /conversion-history/{id}``. Any failure here is non-fatal — it must
         never break the generation itself.
+
+        Also records the non-transpiled measures plus the transpiler's CAPABILITY
+        FINGERPRINT. That pair is what makes re-evaluation possible: a later sweep
+        can ask "has the transpiler changed since this run, and which measures did
+        it fail on?" without re-hitting the PowerBI API. See
+        src/docs/powerbi/ucmv-reevaluation-recoverable-measures.md.
         """
+        def _capability_fp() -> str:
+            """Current transpiler capability fingerprint (fail-open)."""
+            try:
+                from src.engines.crewai.tools.custom.metric_view_utils.capability_version import (
+                    capability_fingerprint,
+                )
+                return capability_fingerprint()
+            except Exception:
+                return "unknown"
+
         try:
             from src.engines.crewai.tools.tool_session_provider import ToolSessionProvider
             from src.schemas.conversion import ConversionHistoryCreate
@@ -832,6 +850,9 @@ class UCMetricViewGeneratorTool(BaseTool):
                     "sql": sql_output,
                     "catalog": catalog,
                     "schema": schema,
+                    # Re-evaluation inputs: WHICH measures failed, and at WHAT
+                    # capability level. A later sweep re-tries only these.
+                    "untranslatable_items": untranslatable_items or [],
                 },
                 output_summary=(
                     f"Generated {view_count} UC metric view(s)"
@@ -842,6 +863,10 @@ class UCMetricViewGeneratorTool(BaseTool):
                     "dataset_id": dataset_id,
                     "catalog": catalog,
                     "schema": schema,
+                    # Capability level that produced this result. Re-evaluation
+                    # compares it against the current fingerprint to decide whether a
+                    # retry can possibly gain anything.
+                    "capability_fingerprint": _capability_fp(),
                 },
                 status="success",
                 measure_count=measure_count,

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -367,15 +367,31 @@ class UCMetricViewGeneratorTool(BaseTool):
             except Exception as e:
                 logger.warning(f"Failed to parse relationships: {e}")
 
-        # Parse scan data
+        # Parse scan data. scan_data carries the raw Power Query M per table, which
+        # drives physical-name resolution (Gaps 1-2) and generated-view SQL (Gap 3).
+        # It comes from the Power BI Admin Scanner (config-gen API 3), which REJECTS
+        # service-principal / service-account tokens (401/403) and then degrades to
+        # an empty payload — so a missing/blank scan is a *credentials* signal, not a
+        # code error. Log it clearly and actionably rather than as a scary parse fail.
         scan_data = {}
         scan_parser = ScanDataParser()
-        if scan_raw:
+        _scan_raw = (scan_raw or "").strip()
+        if _scan_raw and _scan_raw not in ("{}", "[]", "null"):
             try:
-                scan_obj = json.loads(scan_raw) if isinstance(scan_raw, str) else scan_raw
+                scan_obj = json.loads(_scan_raw) if isinstance(_scan_raw, str) else scan_raw
                 scan_data = scan_parser.parse(scan_obj)
             except Exception as e:
-                logger.warning(f"Failed to parse scan data: {e}")
+                logger.warning(
+                    "[UCMV] scan_data_json present but unparseable (%s) — physical-name "
+                    "resolution and generated-view SQL will be SKIPPED for this run.", e)
+        if not scan_data:
+            logger.warning(
+                "[UCMV] No usable scan_data (the Power BI Admin Scanner likely rejected the "
+                "token or returned empty). The raw Power Query M lives only in the scan, so "
+                "physical-name resolution (Gaps 1-2) and generated-view SQL (Gap 3) are SKIPPED "
+                "— tables/columns will use model (display) names. Provide admin credentials the "
+                "Admin Scanner accepts (admin_username/password or an admin SP with the tenant's "
+                "read-only-admin-API setting enabled) to enable them.")
 
         # Run pipeline
         pipeline = MetricViewPipeline(

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -528,6 +528,16 @@ class UCMetricViewGeneratorTool(BaseTool):
                     f"{best_effort_report['measures_skipped_unresolved']} measure(s) unresolved and skipped. "
                     f"Tables/measures may be MISSING — every measure marked TODO: verify.")
 
+        # Completeness reconciliation: every measure must be translated, noted
+        # untranslatable, or surfaced here for review — never silently dropped.
+        unallocated_items = self._build_unallocated_items(
+            _measures_for_validation, results.get('specs', {}), results.get('stats', {}))
+        if unallocated_items:
+            logger.warning(
+                f"[UCMVGenerator] {len(unallocated_items)} measure(s) reached neither a view "
+                f"nor the untranslatable notes — surfaced in 'unallocated_items' for human "
+                f"review (completeness guarantee; e.g. holder table skipped / no fact reference)")
+
         output = {
             'yaml': yaml_output,
             'sql': sql_output,
@@ -552,6 +562,11 @@ class UCMetricViewGeneratorTool(BaseTool):
             # (full DAX + reason + category + dependency count). Additive; [] when
             # everything translated.
             'untranslatable_items': self._build_untranslatable_items(results.get('specs', {})),
+            # Measures that reached neither a view nor the untranslatable notes —
+            # every measure is now accounted for (translated / untranslatable /
+            # unallocated), so nothing is silently dropped. [] when fully covered.
+            'unallocated_items': unallocated_items,
+            'unallocated_count': len(unallocated_items),
             'specs_summary': {
                 k: {
                     'view_name': v.get('view_name'),
@@ -652,6 +667,74 @@ class UCMetricViewGeneratorTool(BaseTool):
                     'referenced_by': m.get('referenced_by', 0),
                 })
         # High-impact gaps first (most-depended-on measures at the top).
+        items.sort(key=lambda x: x.get('referenced_by', 0), reverse=True)
+        return items
+
+    @staticmethod
+    def _build_unallocated_items(all_measures: Any, specs: dict, stats: dict) -> list:
+        """Measures that reached NEITHER a view NOR the untranslatable notes.
+
+        Completeness guarantee: every measure must end up (1) translated into a
+        view, (2) documented as untranslatable in a view (``untranslatable_items``),
+        or (3) listed HERE with a reason — never silently dropped. These are the
+        measures whose holder table produced no view (inline/UI table, unparsed M
+        source, or all-measures-dropped-by-validation) or that were never allocated
+        to a fact. Surfaced so the run's true coverage is visible and a reviewer
+        can map a source/fact by hand. Additive; [] when everything is accounted for.
+        """
+        def _norm(s: Any) -> str:
+            return str(s or '').strip().lower()
+
+        def _as_int(v: Any) -> int:
+            try:
+                return int(str(v or 0))
+            except (TypeError, ValueError):
+                return 0
+
+        # Names already accounted for: emitted into a view OR noted untranslatable.
+        accounted: set = set()
+        for spec in (specs or {}).values():
+            if not isinstance(spec, dict):
+                continue
+            for m in (spec.get('measures') or []):
+                if isinstance(m, dict):
+                    accounted.add(_norm(m.get('original_name') or m.get('name')))
+            for m in (spec.get('untranslatable') or []):
+                if isinstance(m, dict):
+                    accounted.add(_norm(m.get('original_name') or m.get('name')))
+
+        stats = stats if isinstance(stats, dict) else {}
+        specs = specs if isinstance(specs, dict) else {}
+        items: list = []
+        for m in (all_measures or []):
+            if not isinstance(m, dict):
+                continue
+            name = m.get('original_name') or m.get('measure_name')
+            if not name or _norm(name) in accounted:
+                continue
+            alloc = m.get('proposed_allocation') or ''
+            tstat = stats.get(alloc, {}) if isinstance(stats.get(alloc), dict) else {}
+            if tstat.get('skipped'):
+                reason = f"holder table '{alloc}' produced no view — {tstat.get('skip_reason', 'skipped')}"
+                category = tstat.get('skip_category') or 'table_skipped'
+            elif alloc and alloc in specs:
+                reason = (f"allocated to '{alloc}' but not emitted "
+                          "(dropped during generation/validation) — needs review")
+                category = 'dropped_in_generation'
+            else:
+                reason = (f"not allocated to any generated view (no known fact reference; "
+                          f"allocation='{alloc or 'none'}') — needs a human to map a source table / fact")
+                category = 'unallocated'
+            items.append({
+                'original_name': name,
+                'dax_expression': m.get('dax_expression', ''),
+                'proposed_allocation': alloc,
+                'reason': reason,
+                'category': category,
+                'referenced_by': _as_int(m.get('referenced_by', 0)),
+                'needs_review': True,
+            })
+        # Most-depended-on measures first (highest review impact).
         items.sort(key=lambda x: x.get('referenced_by', 0), reverse=True)
         return items
 

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -665,6 +665,10 @@ class UCMetricViewGeneratorTool(BaseTool):
                     'category': m.get('category', ''),
                     'dax_class': m.get('dax_class'),
                     'referenced_by': m.get('referenced_by', 0),
+                    # Actionable next-step for the reviewer (HOW to handle it),
+                    # sourced from the LLM's recipe or a class-based default.
+                    'proposal': m.get('proposal', ''),
+                    'explanation': m.get('explanation'),
                 })
         # High-impact gaps first (most-depended-on measures at the top).
         items.sort(key=lambda x: x.get('referenced_by', 0), reverse=True)

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -48,6 +48,10 @@ class UCMetricViewGeneratorSchema(BaseModel):
     auth_method: Optional[str] = Field(None, description="Auth method: 'service_principal', 'service_account', or auto-detect")
     access_token: Optional[str] = Field(None, description="Pre-obtained OAuth access token (alternative to SP/SA)", repr=False)
     pbi_api_base_url: Optional[str] = Field(None, description="Power BI API base URL. Defaults to commercial cloud. Use 'https://api.powerbigov.us/v1.0/myorg' for GCC, 'https://api.powerbi.cn/v1.0/myorg' for China cloud.")
+    admin_client_id: Optional[str] = Field(
+        None, description="[Auth - Admin SP] Service Principal client ID with tenant-admin API access, for the MQuery Admin Scanner retry when client_id lacks admin rights. Distinct from client_id.")
+    admin_client_secret: Optional[str] = Field(
+        None, description="[Auth - Admin SP] Service Principal client secret with tenant-admin API access", repr=False)
 
 
 class UCMetricViewGeneratorTool(BaseTool):
@@ -82,7 +86,8 @@ class UCMetricViewGeneratorTool(BaseTool):
                        'use_llm_fallback', 'translation_mode', 'llm_model', 'llm_workspace_url', 'llm_token',
                        'workspace_id', 'dataset_id', 'tenant_id', 'client_id',
                        'client_secret', 'username', 'password', 'auth_method',
-                       'access_token', 'pbi_api_base_url')
+                       'access_token', 'pbi_api_base_url',
+                       'admin_client_id', 'admin_client_secret')
         default_config = {}
         for key in config_keys:
             val = kwargs.pop(key, None)
@@ -139,16 +144,111 @@ class UCMetricViewGeneratorTool(BaseTool):
         relationships_raw = _get_json('relationships_json')
         scan_raw = _get_json('scan_data_json')
         config_raw = _get_json('config_json') or '{}'
+        # Diagnostic: what arrived via flow injection/kwargs BEFORE any API-mode
+        # extraction or DB fallback runs below, and whether the DB fallback ends
+        # up firing. Carried into `output['_diagnostics']` (not just logged)
+        # because raw log lines aren't reliably queryable in every deployment —
+        # this makes it visible via the same execution_trace pull already used
+        # for Crew 1.
+        _diag: dict = {
+            "preinject_measures_json_chars": len(measures_raw) if isinstance(measures_raw, str) else None,
+            "preinject_mquery_json_chars": len(mquery_raw) if isinstance(mquery_raw, str) else None,
+            "preinject_config_json_chars": len(config_raw) if isinstance(config_raw, str) else None,
+            "db_fallback_fired_for": [],
+            "db_fallback_extraction_id": None,
+        }
         catalog = _get('catalog') or 'main'
         schema = _get('schema_name') or 'default'
         inner_joins = _get('inner_dim_joins') or False
         unflatten = _get('unflatten_tables') or False
 
-        # Check if API extraction mode (PBI credentials provided)
+        # DB fallback: rebuild measures_json/mquery_json/config_json from Crew
+        # 1's powerbi_extraction row for THIS SAME flow execution, whenever flow
+        # injection left them empty. Deliberately runs BEFORE API-mode extraction
+        # below, not after — API-mode extraction is Crew 2's OWN independent
+        # (and materially weaker — no reference-following / parameter-
+        # substitution resolution) re-derivation, and it always fills something
+        # non-empty when workspace_id/dataset_id are configured (as they are for
+        # every report tested so far). With the DB fallback gated on "still
+        # empty" and running AFTER API-mode extraction, it was silently dead
+        # code — API-mode had always already filled the fields with its own
+        # degraded data by the time the check ran. Running the DB fallback
+        # FIRST means Crew 1's higher-quality result is preferred, and API-mode
+        # extraction becomes the true last resort (only fills whatever's still
+        # missing after this).
+        #
+        # NOT a /tmp file — confirmed empirically that Crew 1 and Crew 2 run in
+        # separate subprocesses (a file written by one is invisible to the
+        # other), so a filesystem handoff can never work here regardless of
+        # what gets fixed in it. This goes through Kasal's DB instead (the same
+        # mechanism KasalFlowPersistence's checkpoints use, which does survive
+        # process/container boundaries), and is looked up by execution_id ==
+        # this tool's own job_id — not "most recent row for this dataset" — so
+        # a same-day rerun of the same report can never pull another run's
+        # data. Rebuilds via the exact same PipelineConfigGeneratorTool static
+        # methods Crew 1 itself used, so quality matches (not a degraded
+        # re-derivation): needs admin_tables + expressions (for the
+        # reference-following / parameter-substitution resolution), not just
+        # the raw table list a naive re-extraction would get.
+        if measures_raw == '[]' or mquery_raw == '[]' or config_raw == '{}':
+            _job_id = (getattr(self, 'trace_context', None) or {}).get('job_id')
+            if not _job_id:
+                logger.info("[UCMV] DB fallback: no job_id on trace_context — cannot look up powerbi_extraction")
+            else:
+                try:
+                    async def _load_extraction():
+                        from src.engines.crewai.tools.tool_session_provider import ToolSessionProvider
+                        async with ToolSessionProvider.powerbi_extraction_repo() as repo:
+                            rows = await repo.find_by_execution_id(_job_id)
+                            return rows[0] if rows else None
+
+                    _extraction = _run_async(_load_extraction())
+                    if _extraction is None:
+                        logger.info(f"[UCMV] DB fallback: no powerbi_extraction row found for job_id={_job_id}")
+                    else:
+                        _diag["db_fallback_extraction_id"] = _extraction.id
+                        _db_admin_tables = _extraction.admin_tables or {}
+                        _db_expressions = _extraction.expressions or {}
+                        _db_measures = _extraction.measures or []
+                        _db_config = _extraction.proposed_config or {}
+                        logger.info(
+                            f"[UCMV] DB fallback: found powerbi_extraction id={_extraction.id} for "
+                            f"job_id={_job_id} ({len(_db_admin_tables)} tables, {len(_db_expressions)} expressions)"
+                        )
+                        from src.engines.crewai.tools.custom.pipeline_config_generator_tool import (
+                            PipelineConfigGeneratorTool,
+                        )
+                        if mquery_raw == '[]' and _db_admin_tables:
+                            _rebuilt_mquery = PipelineConfigGeneratorTool._build_ucmv_mquery(
+                                _db_admin_tables, _db_expressions)
+                            if _rebuilt_mquery:
+                                mquery_raw = json.dumps(_rebuilt_mquery)
+                                _diag["db_fallback_fired_for"].append("mquery_json")
+                                logger.info(f"[UCMV] DB fallback: rebuilt mquery_json ({len(_rebuilt_mquery)} tables)")
+                        if measures_raw == '[]' and _db_measures:
+                            _rebuilt_measures = PipelineConfigGeneratorTool._build_ucmv_measures(
+                                _db_measures, admin_tables=_db_admin_tables, config=_db_config)
+                            if _rebuilt_measures:
+                                measures_raw = json.dumps(_rebuilt_measures)
+                                _diag["db_fallback_fired_for"].append("measures_json")
+                                logger.info(f"[UCMV] DB fallback: rebuilt measures_json ({len(_rebuilt_measures)} measures)")
+                        if config_raw == '{}' and _db_config:
+                            config_raw = json.dumps(_db_config)
+                            _diag["db_fallback_fired_for"].append("config_json")
+                except Exception as _db_err:
+                    _diag["db_fallback_error"] = str(_db_err)
+                    logger.warning(f"[UCMV] DB fallback failed: {_db_err}")
+
+        # Check if API extraction mode (PBI credentials provided). Skipped
+        # entirely when the DB fallback above already filled both
+        # measures_json and mquery_json — API-mode's own extraction includes
+        # a live Admin Scanner trigger+poll (up to 5 minutes) that would
+        # otherwise redo, slowly, work Crew 1 already did and this tool just
+        # reused for free.
         workspace_id = _get('workspace_id')
         dataset_id = _get('dataset_id')
 
-        if workspace_id and dataset_id:
+        if workspace_id and dataset_id and (measures_raw == '[]' or mquery_raw == '[]'):
             pbi_api_base_url = _get('pbi_api_base_url') or ''
             valid, err_msg = self._validate_pbi_inputs(workspace_id, dataset_id, pbi_api_base_url)
             if not valid:
@@ -166,6 +266,8 @@ class UCMetricViewGeneratorTool(BaseTool):
                     auth_method=_get('auth_method'),
                     access_token=_get('access_token') or '',
                     pbi_api_base_url=_get('pbi_api_base_url') or '',
+                    admin_client_id=_get('admin_client_id') or '',
+                    admin_client_secret=_get('admin_client_secret') or '',
                 )
                 # Use extracted data (override only when manually provided JSON is empty/default)
                 if extracted.get('measures') and measures_raw == '[]':
@@ -284,12 +386,21 @@ class UCMetricViewGeneratorTool(BaseTool):
             no_summarize_columns=scan_parser.get_no_summarize_columns() or None,
             rls_tables=scan_parser.get_rls_tables() or None,
         )
+        import time as _pipe_time
+        _pipe_t0 = _pipe_time.time()
         pipeline.run()
+        logger.info(f"[UCMV] pipeline.run() completed in {_pipe_time.time() - _pipe_t0:.1f}s")
 
         # Emit YAML + SQL
+        _pipe_t0 = _pipe_time.time()
         yaml_output = pipeline.emit_all_yaml(catalog=catalog, schema=schema)
+        logger.info(f"[UCMV] emit_all_yaml() completed in {_pipe_time.time() - _pipe_t0:.1f}s ({len(yaml_output)} table(s))")
+        _pipe_t0 = _pipe_time.time()
         sql_output = pipeline.emit_all_sql(catalog=catalog, schema=schema)
+        logger.info(f"[UCMV] emit_all_sql() completed in {_pipe_time.time() - _pipe_t0:.1f}s")
+        _pipe_t0 = _pipe_time.time()
         results = pipeline.get_results()
+        logger.info(f"[UCMV] get_results() completed in {_pipe_time.time() - _pipe_t0:.1f}s")
 
         # Run validation (optional — compares DAX structure vs generated SQL)
         validation_results = {}
@@ -302,7 +413,11 @@ class UCMetricViewGeneratorTool(BaseTool):
                 import tempfile  # NOTE: os is already imported at module level; importing it
                 # here too would make `os` a function-local for all of _run() and break the
                 # earlier os.environ.get(...) calls with UnboundLocalError.
-                for table_key, yml in yaml_output.items():
+                import time as _time
+                _val_table_count = len(yaml_output)
+                logger.info(f"[UCMV] Validating {_val_table_count} table(s) (DAX vs generated SQL)")
+                for _val_num, (table_key, yml) in enumerate(yaml_output.items(), start=1):
+                    _val_t0 = _time.time()
                     with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as yf:
                         yf.write(yml)
                         yf_path = yf.name
@@ -326,6 +441,10 @@ class UCMetricViewGeneratorTool(BaseTool):
                     finally:
                         os.unlink(yf_path)
                         os.unlink(mf_path)
+                    logger.info(
+                        f"[UCMV] ({_val_num}/{_val_table_count}) validated table '{table_key}' "
+                        f"in {_time.time() - _val_t0:.1f}s"
+                    )
         except ImportError:
             pass  # Validation package not available
         except Exception as e:
@@ -388,6 +507,7 @@ class UCMetricViewGeneratorTool(BaseTool):
                 }
                 for k, v in results.get('specs', {}).items()
             },
+            '_diagnostics': _diag,
         }
         output_json = json.dumps(output, indent=2)
 
@@ -692,11 +812,22 @@ class UCMetricViewGeneratorTool(BaseTool):
     def _extract_mquery_fallback(
         self, workspace_id, dataset_id, tenant_id, client_id,
         client_secret, username, password,
+        admin_client_id: str = '', admin_client_secret: str = '',
     ) -> list:
         """Recover MQuery/table-source when the Admin Scanner fails for a Service Account.
 
         Tier 1: Fabric TMDL with the SA (works if the workspace is Fabric-enabled).
         Tier 2: Fabric TMDL with a Service Principal (if client_secret provided).
+        Tier 3: retry the Admin Scanner itself with a distinct admin Service
+        Principal (admin_client_id/admin_client_secret), if TMDL also came up
+        empty. Mirrors Pipeline Config Generator's own 3rd tier — some
+        workspaces reject the primary token on the Admin Scanner specifically
+        (tenant-admin API access is commonly gated to a narrower allow-list
+        than ordinary dataset read access) AND aren't Fabric-enabled (TMDL
+        unavailable), so tiers 1+2 both come up empty; a Service Principal
+        with tenant-admin rights is the only thing that recovers MQuery for
+        such a workspace. Distinct from client_id/client_secret on purpose —
+        the two are commonly different app registrations.
         Reuses generate_config so the logic is shared with the config generator.
         """
         try:
@@ -727,6 +858,29 @@ class UCMetricViewGeneratorTool(BaseTool):
                         return entries
             except Exception as e:
                 logger.warning(f"[UCMV] MQuery TMDL fallback ({label}) failed: {e}")
+
+        if admin_client_id and admin_client_secret:
+            try:
+                from src.engines.crewai.tools.custom.powerbi_auth_utils import (
+                    get_powerbi_access_token_from_config,
+                )
+                sp_admin_token = _run_async(get_powerbi_access_token_from_config({
+                    'tenant_id': tenant_id,
+                    'client_id': admin_client_id,
+                    'client_secret': admin_client_secret,
+                    'username': None,
+                    'password': None,
+                    'auth_method': 'service_principal',
+                    'access_token': None,
+                }))
+                scan_result = gen.trigger_admin_scan(sp_admin_token, workspace_id)
+                tables = gen.parse_admin_tables(scan_result, dataset_id=dataset_id)
+                entries = self._tmdl_tables_to_mquery(tables)
+                if entries:
+                    logger.info(f"[UCMV] MQuery Admin Scanner (SP admin retry) recovered {len(entries)} tables")
+                    return entries
+            except Exception as e:
+                logger.warning(f"[UCMV] MQuery Admin Scanner (SP admin retry) failed: {e}")
         return []
 
     def _extract_measures_fallback(
@@ -783,6 +937,8 @@ class UCMetricViewGeneratorTool(BaseTool):
         auth_method: Optional[str],
         access_token: str,
         pbi_api_base_url: str = '',
+        admin_client_id: str = '',
+        admin_client_secret: str = '',
     ) -> dict:
         """Extract measures, MQuery, relationships, and scan data from PBI API.
 
@@ -890,6 +1046,7 @@ class UCMetricViewGeneratorTool(BaseTool):
                 workspace_id=workspace_id, dataset_id=dataset_id,
                 tenant_id=tenant_id, client_id=client_id, client_secret=client_secret,
                 username=username, password=password,
+                admin_client_id=admin_client_id, admin_client_secret=admin_client_secret,
             )
             if recovered_mq:
                 result['mquery'] = recovered_mq

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -705,6 +705,9 @@ class UCMetricViewGeneratorTool(BaseTool):
                     # sourced from the LLM's recipe or a class-based default.
                     'proposal': m.get('proposal', ''),
                     'explanation': m.get('explanation'),
+                    # Labeled DRAFT CREATE VIEW scaffold for cross-fact / multi-stage
+                    # (proposal artifact, never an emitted measure).
+                    'source_view_sql_draft': m.get('source_view_sql_draft'),
                 })
         # High-impact gaps first (most-depended-on measures at the top).
         items.sort(key=lambda x: x.get('referenced_by', 0), reverse=True)

--- a/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/uc_metric_view_generator_tool.py
@@ -381,6 +381,16 @@ class UCMetricViewGeneratorTool(BaseTool):
         # upstream semantic model (see thin-report-and-source-resolution.md). The
         # coverage_report makes the gap explicit (tables/measures skipped), and
         # every drafted measure is flagged TODO: verify.
+        # When nothing generated, always compute an actionable diagnosis of WHY
+        # (thin report? no source? unresolvable DAX?) so the run is never a silent
+        # empty result. Computed before best-effort so it reflects the real state.
+        zero_view_diagnosis = None
+        if not yaml_output:
+            zero_view_diagnosis = self._diagnose_zero_views(mquery_entries, measures, config)
+            logger.warning(
+                f"[UCMVGenerator] 0 views — {zero_view_diagnosis['case']}: "
+                f"{zero_view_diagnosis['recommended_action']}")
+
         best_effort_report = None
         if (not yaml_output) and _get('allow_best_effort') and _get('fact_source_map'):
             fsm = _get('fact_source_map')
@@ -415,6 +425,9 @@ class UCMetricViewGeneratorTool(BaseTool):
             # Present only when best-effort mode fired: surfaces the coverage gap
             # (skipped tables/measures) so the UI/consumer can warn "may be missing".
             'best_effort_report': best_effort_report,
+            # Present when 0 views generated: actionable "why + what to do" so a
+            # thin-report run is never a silent empty result.
+            'zero_view_diagnosis': zero_view_diagnosis,
             'views_generated': len(yaml_output) if isinstance(yaml_output, dict) else 0,
             'specs_summary': {
                 k: {
@@ -546,6 +559,88 @@ class UCMetricViewGeneratorTool(BaseTool):
             r['measure_count'] = len(r['measures'])
             r['has_mquery'] = bool(r['mquery'])
         return rows
+
+    @staticmethod
+    def _diagnose_zero_views(
+        mquery_entries: Any,
+        measures: Any,
+        config: Any,
+    ) -> dict:
+        """Explain WHY 0 UC Metric Views were generated, and what to do about it.
+
+        Today a thin-report model silently yields a fallback JSON and no views, with
+        no signal to the user about the cause or fix. This turns that into an
+        actionable diagnosis (the real, testable part of the "source not auto-
+        resolved" problem). It classifies the run by two deterministic signals:
+          * source tables present?  → any mquery entry with real transpiled SQL /
+            an M source expression (not raw/empty).
+          * measures resolvable?    → any config.measure_resolutions with real
+            aggregatable SQL (not TODO).
+
+        Returns {case, reason, recommended_action, signals} — see the customer guide
+        thin-report-and-source-resolution.md for the three cases.
+        """
+        # Signal 1: do we have any real source table?
+        has_source = False
+        if isinstance(mquery_entries, list):
+            for e in mquery_entries:
+                if not isinstance(e, dict):
+                    continue
+                sql = (e.get('transpiled_sql') or e.get('mquery_expression') or '').strip()
+                if sql and sql not in ('{}', 'null'):
+                    has_source = True
+                    break
+
+        # Signal 2: any measure that resolved to real aggregatable SQL?
+        resolvable = 0
+        _AGG = ('SUM', 'COUNT', 'AVG', 'MIN', 'MAX', 'DIVIDE', 'CALCULATE', 'SUMX', 'COUNTX')
+        resolutions = (config or {}).get('measure_resolutions', {}) if isinstance(config, dict) else {}
+        for res in (resolutions or {}).values():
+            base = (res or {}).get('base_expr', '') if isinstance(res, dict) else ''
+            if base and not base.strip().upper().startswith('TODO') \
+                    and base.strip().upper().startswith(_AGG):
+                resolvable += 1
+
+        n_measures = len(measures) if isinstance(measures, list) else 0
+        signals = {
+            'has_source_tables': has_source,
+            'resolvable_measures': resolvable,
+            'total_measures': n_measures,
+        }
+
+        if has_source:
+            # Sources exist but still 0 views — a translation/allocation issue, not
+            # a thin-report problem. Leave it to the normal migration report.
+            return {
+                'case': 'sources_present_no_views',
+                'reason': ('Source tables were found but no metric view was emitted — '
+                           'likely all measures were untranslatable DAX. See the '
+                           'migration report / not-emitted notes.'),
+                'recommended_action': 'Review the not-emitted measures; no source mapping needed.',
+                'signals': signals,
+            }
+        # No source tables → thin report (case B) or hand-entered (case C).
+        if resolvable > 0:
+            action = (f"This looks like a THIN REPORT on an upstream semantic model — its "
+                      f"source tables are not in what was extracted. PREFERRED: re-run "
+                      f"against the upstream model's dataset_id (see Power BI lineage). "
+                      f"OR: enable allow_best_effort and supply fact_source_map to draft "
+                      f"views for the {resolvable} resolvable measure(s) — tables/measures "
+                      f"may be missing. See thin-report-and-source-resolution.md.")
+        else:
+            action = ("This looks like a THIN REPORT (or a report-logic-only model): no "
+                      "source tables AND no measures reduce to a table aggregate (mostly "
+                      "selector / measure-on-measure DAX). Re-run against the upstream "
+                      "semantic model's dataset_id if one exists; otherwise these measures "
+                      "cannot be converted to metric views. See "
+                      "thin-report-and-source-resolution.md.")
+        return {
+            'case': 'thin_report_no_source_tables',
+            'reason': ('No source tables (M-Queries) were found in the extracted model, so '
+                       'there is no physical table to build a UC Metric View on.'),
+            'recommended_action': action,
+            'signals': signals,
+        }
 
     @staticmethod
     def _build_best_effort_views(

--- a/src/backend/src/engines/crewai/tools/custom/ucmv_reevaluation_tool.py
+++ b/src/backend/src/engines/crewai/tools/custom/ucmv_reevaluation_tool.py
@@ -1,0 +1,536 @@
+"""UCMV Re-evaluation Tool — find measures that TODAY's transpiler can recover.
+
+WHY: Kasal's DAX→UC-Metric-View capability keeps improving (new translator patterns,
+a better LLM-first path, an evolving skill corpus), but those gains only ever helped
+NEW conversions. A model converted last month still shows the measures that failed
+back then, even though several are translatable now.
+
+This tool replays stored state — no PowerBI API round-trip — and re-tries ONLY the
+previously-failed measures, reporting which are now recoverable so a human can choose
+to re-transpile them.
+
+Hard rules:
+  * Only previously-FAILED measures are retried. A measure that already succeeded is
+    never re-transpiled (that would risk silently changing a validated measure).
+  * PROPOSE ONLY. This tool mutates nothing; applying a recovery goes through the
+    normal UCMV route, human-triggered.
+
+Cost controls (a scheduled sweep must not quietly burn tokens):
+  * ``use_llm`` defaults to False → deterministic regex fast-path only, zero tokens.
+  * Permanent-limitation categories (display artifacts, slicer scalars, prior-year…)
+    are skipped unless ``include_impossible``.
+  * Reviewer-dismissed measures (``wont_fix``/``hand_written``) are suppressed.
+  * ``max_measures_per_dataset`` caps work per dataset, applied AFTER impact ordering.
+
+Docs: src/docs/powerbi/ucmv-reevaluation-recoverable-measures.md
+"""
+import json
+import logging
+from typing import Any, Optional, Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field, PrivateAttr
+
+from src.engines.crewai.tools.custom.metric_view_utils.utils import run_async
+
+logger = logging.getLogger(__name__)
+
+
+class UCMVReevaluationSchema(BaseModel):
+    """Input schema for UCMVReevaluationTool."""
+
+    dataset_ids: Optional[str] = Field(
+        None,
+        description=(
+            "Optional JSON list or comma-separated PBI dataset ids to re-evaluate. "
+            "Omit to sweep every dataset with a stored extraction for the group."
+        ),
+    )
+    group_id: Optional[str] = Field(
+        None, description="Group/tenant id to scope stored extractions (multi-tenant isolation).")
+    include_impossible: Optional[bool] = Field(
+        False,
+        description=(
+            "Also retry permanent-limitation categories (display artifacts, slicer "
+            "scalars, prior-year time-intelligence). Usually wasted compute."
+        ),
+    )
+    use_llm: Optional[bool] = Field(
+        False,
+        description=(
+            "Allow the LLM-first translation path (COSTS TOKENS per measure). "
+            "Default False = deterministic regex fast-path only."
+        ),
+    )
+    max_measures_per_dataset: Optional[int] = Field(
+        200, description="Cap retried measures per dataset (applied after impact ordering).")
+    max_datasets: Optional[int] = Field(
+        50, description="Cap how many datasets a single sweep scans.")
+    force: Optional[bool] = Field(
+        False,
+        description=(
+            "Re-try even when the capability fingerprint is UNCHANGED since the stored "
+            "run. Normally such a retry cannot find anything new and is skipped; use "
+            "this to verify the sweep works, or to re-check after a change the "
+            "fingerprint didn't capture."
+        ),
+    )
+
+
+class UCMVReevaluationTool(BaseTool):
+    """Report previously-untranslatable measures that today's transpiler can recover."""
+
+    name: str = "UCMV Re-evaluation"
+    description: str = (
+        "Scans stored PowerBI extractions and re-tries ONLY the measures that "
+        "previously failed to transpile, using today's (improved) DAX→UC Metric View "
+        "transpiler. Reports which measures are NOW recoverable, with their new SQL, "
+        "the reason they failed before, and how many other measures depend on them. "
+        "Read-only: it proposes re-transpilation candidates and never modifies "
+        "metric views. Deterministic by default (no LLM tokens) unless use_llm=true."
+    )
+    args_schema: Type[BaseModel] = UCMVReevaluationSchema
+    _default_config: dict = PrivateAttr(default_factory=dict)
+
+    model_config = {"arbitrary_types_allowed": True, "extra": "allow"}
+
+    def __init__(self, **kwargs: Any) -> None:
+        config_keys = (
+            'dataset_ids', 'group_id', 'include_impossible', 'use_llm',
+            'max_measures_per_dataset', 'max_datasets', 'force',
+        )
+        default_config: dict = {}
+        for key in config_keys:
+            if key in kwargs:
+                default_config[key] = kwargs.pop(key)
+        super().__init__(**kwargs)
+        self._default_config = default_config
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_dataset_ids(raw: Any) -> list[str]:
+        """Accept a JSON list, a comma-separated string, or a real list."""
+        if not raw:
+            return []
+        if isinstance(raw, list):
+            return [str(x).strip() for x in raw if str(x).strip()]
+        text = str(raw).strip()
+        if text.startswith('['):
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, list):
+                    return [str(x).strip() for x in parsed if str(x).strip()]
+            except json.JSONDecodeError:
+                pass
+        return [p.strip() for p in text.split(',') if p.strip()]
+
+    @staticmethod
+    def _stored_untranslatable(record: Any) -> list[dict]:
+        """Pull the stored ``untranslatable_items`` off a ConversionHistory row.
+
+        The UCMV generator writes them into ``output_data.untranslatable_items``.
+        Older rows predate that, so an empty list simply means "nothing recorded to
+        re-evaluate for this run".
+        """
+        out = getattr(record, 'output_data', None)
+        if isinstance(out, dict):
+            val = out.get('untranslatable_items')
+            if isinstance(val, list):
+                return [i for i in val if isinstance(i, dict)]
+        return []
+
+    @staticmethod
+    def _stored_review(record: Any) -> dict:
+        """Reviewer annotations, when a saved (edited) result carried them forward."""
+        out = getattr(record, 'output_data', None)
+        if isinstance(out, dict):
+            val = out.get('untranslatable_review')
+            if isinstance(val, dict):
+                return val
+        return {}
+
+    @staticmethod
+    def _stored_config(record: Any) -> dict:
+        """The pipeline config that produced this run (translator context)."""
+        cfg = getattr(record, 'configuration', None)
+        return cfg if isinstance(cfg, dict) else {}
+
+    @staticmethod
+    def _stored_dataset_id(record: Any) -> str:
+        cfg = getattr(record, 'configuration', None)
+        if isinstance(cfg, dict) and cfg.get('dataset_id'):
+            return str(cfg['dataset_id'])
+        inp = getattr(record, 'input_data', None)
+        if isinstance(inp, dict) and inp.get('dataset_id'):
+            return str(inp['dataset_id'])
+        return ''
+
+    @staticmethod
+    def _harvest_untranslatable(obj: Any, out: list) -> None:
+        """Walk a nested result blob collecting every ``untranslatable_items`` array.
+
+        The UCMV generator's full output lives in the EXECUTION result, and tool
+        outputs are frequently embedded as JSON *strings* inside it, so a plain
+        ``.get()`` misses them. Recursing (and parsing string-encoded JSON) is what
+        actually finds the measures.
+        """
+        if isinstance(obj, dict):
+            val = obj.get('untranslatable_items')
+            if isinstance(val, list):
+                out.extend(i for i in val if isinstance(i, dict))
+            for v in obj.values():
+                if isinstance(v, str):
+                    if 'untranslatable_items' in v:
+                        try:
+                            UCMVReevaluationTool._harvest_untranslatable(json.loads(v), out)
+                        except (json.JSONDecodeError, ValueError):
+                            pass
+                else:
+                    UCMVReevaluationTool._harvest_untranslatable(v, out)
+        elif isinstance(obj, list):
+            for v in obj:
+                UCMVReevaluationTool._harvest_untranslatable(v, out)
+
+    async def _load_executions(self, dataset_ids: list[str], group_id: Optional[str],
+                               max_datasets: int) -> list[dict]:
+        """Latest UCMV EXECUTION results carrying non-transpiled measures.
+
+        The execution result blob is the authoritative record: it is the full tool
+        output the UI renders (`untranslatable_items` included). ConversionHistory
+        only ever gets a summary copy, so it is used as a fallback, not the source.
+
+        Deliberately NOT filtered by group_id: historical execution rows frequently
+        have it unset, and filtering would silently discard nearly everything.
+        """
+        from sqlalchemy import text as _text
+        from src.engines.crewai.tools.tool_session_provider import ToolSessionProvider
+
+        out: list[dict] = []
+        async with ToolSessionProvider.session() as session:
+            rows = await session.execute(_text(
+                "SELECT job_id, run_name, created_at, result::text AS blob "
+                "FROM executionhistory "
+                "WHERE result::text LIKE '%untranslatable_items%' "
+                "ORDER BY created_at DESC "
+                "LIMIT :lim"
+            ), {"lim": max(max_datasets * 2, 20)})
+            for job_id, run_name, created_at, blob in rows.all():
+                if not blob:
+                    continue
+                try:
+                    parsed = json.loads(blob)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                items: list = []
+                self._harvest_untranslatable(parsed, items)
+                if not items:
+                    continue
+                # The execution blob carries the measures but NOT the capability
+                # fingerprint or the pipeline config — those are written to
+                # conversion_history by the generator. Pull them from the matching
+                # conversion row so (a) "nothing to gain" is detected correctly and
+                # (b) the retry sees the same translator context (filter_sets,
+                # fact_join_map, …) the original run had. Falls back to whatever the
+                # blob happens to contain.
+                fp = self._find_fingerprint(parsed)
+                cfg = self._find_config(parsed)
+                if not fp or not cfg:
+                    conv = await session.execute(_text(
+                        "SELECT configuration::text FROM conversion_history "
+                        "WHERE execution_id = :jid AND source_format = 'powerbi_dax' "
+                        "ORDER BY created_at DESC LIMIT 1"
+                    ), {"jid": str(job_id)})
+                    row = conv.first()
+                    if row and row[0]:
+                        try:
+                            conv_cfg = json.loads(row[0])
+                            if isinstance(conv_cfg, dict):
+                                fp = fp or conv_cfg.get('capability_fingerprint')
+                                cfg = cfg or conv_cfg
+                        except (json.JSONDecodeError, ValueError):
+                            pass
+
+                out.append({
+                    'source': 'execution',
+                    'key': str(job_id),
+                    'label': run_name or str(job_id),
+                    'created_at': str(created_at or ''),
+                    'items': items,
+                    # None = unknown (run pre-dates fingerprint recording), which
+                    # has_capability_changed treats as "may have gained" — the honest
+                    # default rather than silently skipping.
+                    'fingerprint': fp,
+                    'config': cfg or {},
+                })
+                if len(out) >= max_datasets:
+                    break
+        return out
+
+    @staticmethod
+    def _find_fingerprint(obj: Any) -> Optional[str]:
+        """Pull a recorded capability_fingerprint out of a nested blob, if present."""
+        if isinstance(obj, dict):
+            fp = obj.get('capability_fingerprint')
+            if isinstance(fp, str) and fp:
+                return fp
+            for v in obj.values():
+                got = UCMVReevaluationTool._find_fingerprint(v)
+                if got:
+                    return got
+        elif isinstance(obj, list):
+            for v in obj:
+                got = UCMVReevaluationTool._find_fingerprint(v)
+                if got:
+                    return got
+        return None
+
+    @staticmethod
+    def _find_config(obj: Any) -> dict:
+        """Best-effort pipeline config (translator context) from a nested blob."""
+        if isinstance(obj, dict):
+            for key in ('proposed_config', 'config', 'configuration'):
+                v = obj.get(key)
+                if isinstance(v, dict) and v:
+                    return v
+            for v in obj.values():
+                got = UCMVReevaluationTool._find_config(v)
+                if got:
+                    return got
+        elif isinstance(obj, list):
+            for v in obj:
+                got = UCMVReevaluationTool._find_config(v)
+                if got:
+                    return got
+        return {}
+
+    async def _load_records(self, dataset_ids: list[str], group_id: Optional[str],
+                            max_datasets: int) -> list[Any]:
+        """Fallback source: ConversionHistory rows (summary copies).
+
+        Kept for runs whose execution row has aged out. NOT group-filtered (most
+        historical rows have no group_id) and a row with no dataset_id falls back to
+        its conversion id rather than being dropped.
+        """
+        from src.engines.crewai.tools.tool_session_provider import ToolSessionProvider
+
+        records: list[Any] = []
+        wanted = set(dataset_ids)
+        async with ToolSessionProvider.conversion_repo() as repo:
+            rows = await repo.find_by_formats(
+                source_format='powerbi_dax',
+                target_format='uc_metrics',
+                group_id=None,
+                limit=max(max_datasets * 10, 50),
+            )
+            seen: set[str] = set()
+            for row in rows:
+                # Fall back to the conversion id so a run without dataset_id is still
+                # re-evaluable instead of silently skipped.
+                ds = self._stored_dataset_id(row) or f"conversion-{getattr(row, 'id', '?')}"
+                if ds in seen:
+                    continue
+                if wanted and ds not in wanted:
+                    continue
+                seen.add(ds)
+                records.append(row)
+                if len(records) >= max_datasets:
+                    break
+        return records
+
+    # ------------------------------------------------------------------
+    # Run
+    # ------------------------------------------------------------------
+    def _run(self, **kwargs: Any) -> str:
+        from src.engines.crewai.tools.custom.metric_view_utils.capability_version import (
+            capability_summary, has_capability_changed,
+        )
+        from src.engines.crewai.tools.custom.metric_view_utils.reevaluate import (
+            reevaluate_measures,
+        )
+
+        def _get(key: str, default: Any = None) -> Any:
+            if key in kwargs and kwargs[key] not in (None, ''):
+                return kwargs[key]
+            if key in self._default_config and self._default_config[key] not in (None, ''):
+                return self._default_config[key]
+            return default
+
+        dataset_ids = self._parse_dataset_ids(_get('dataset_ids'))
+        group_id = _get('group_id')
+        include_impossible = bool(_get('include_impossible', False))
+        use_llm = bool(_get('use_llm', False))
+        max_per_ds = int(_get('max_measures_per_dataset', 200) or 200)
+        max_datasets = int(_get('max_datasets', 50) or 50)
+        force = bool(_get('force', False))
+
+        capability = capability_summary()
+        logger.info(
+            "[UCMVReeval] capability=%s patterns=%s datasets=%s group=%s use_llm=%s",
+            capability.get('fingerprint'), capability.get('pattern_count'),
+            dataset_ids or 'ALL', group_id, use_llm,
+        )
+
+        # PRIMARY source: execution results (the full tool output the UI renders —
+        # this is where untranslatable_items actually lands). ConversionHistory only
+        # receives a summary copy, so it is the fallback.
+        executions: list[dict] = []
+        try:
+            executions = run_async(self._load_executions(dataset_ids, group_id, max_datasets))
+        except Exception as exc:
+            logger.warning("[UCMVReeval] execution scan failed (%s) — trying conversions", exc)
+
+        records: list[Any] = []
+        if not executions:
+            try:
+                records = run_async(self._load_records(dataset_ids, group_id, max_datasets))
+            except Exception as exc:
+                logger.error("[UCMVReeval] could not load stored runs: %s", exc)
+                return json.dumps({
+                    'error': f'could not load stored runs: {exc}',
+                    'capability': capability,
+                    'datasets': [],
+                    'summary': {'datasets_scanned': 0, 'measures_recovered': 0},
+                }, indent=2)
+
+        datasets_report: list[dict] = []
+        total_recovered = 0
+        total_retried = 0
+
+        # ── Execution-sourced runs (the rich path) ──────────────────────────────
+        for ex in executions:
+            items = ex['items']
+            fingerprint_changed = has_capability_changed(ex.get('fingerprint')) or force
+            base = {
+                'dataset_id': ex['label'],
+                'workspace_id': None,
+                'converted_at': ex['created_at'],
+                'conversion_id': ex['key'],
+                'source': 'execution',
+            }
+            if not fingerprint_changed:
+                datasets_report.append({
+                    **base, 'fingerprint_changed': False,
+                    'note': 'transpiler unchanged since this run — nothing to gain',
+                    'newly_translatable': [],
+                    'still_failing_count': len(items), 'skipped_count': 0,
+                })
+                continue
+
+            result = reevaluate_measures(
+                items, ex.get('config') or {},
+                review=None,
+                include_impossible=include_impossible,
+                use_llm=use_llm,
+                limit=max_per_ds,
+            )
+            counts = result.get('counts', {})
+            total_recovered += counts.get('recovered', 0)
+            total_retried += counts.get('retried', 0)
+            entry = {
+                **base, 'fingerprint_changed': True,
+                'newly_translatable': result.get('newly_translatable', []),
+                'still_failing_count': counts.get('still_failing', 0),
+                'skipped_count': counts.get('skipped', 0),
+                'counts': counts,
+            }
+            # Be explicit about WHY we retried, so "fingerprint_changed: true" is not
+            # read as "the transpiler improved" when it really means "unknown".
+            if not ex.get('fingerprint'):
+                entry['fingerprint_note'] = (
+                    'run pre-dates capability-fingerprint recording — retried because a '
+                    'gain cannot be ruled out, not because the transpiler is known to '
+                    'have changed'
+                )
+            if not counts.get('recovered') and not use_llm:
+                entry['note'] = (
+                    'deterministic fast-path only (use_llm=false). Measures previously '
+                    'routed to the LLM cannot be recovered without use_llm=true.'
+                )
+            datasets_report.append(entry)
+
+        for record in records:
+            cfg = self._stored_config(record)
+            ds_id = self._stored_dataset_id(record)
+            items = self._stored_untranslatable(record)
+            stored_fp = cfg.get('capability_fingerprint')
+            base = {
+                'dataset_id': ds_id,
+                'workspace_id': cfg.get('workspace_id'),
+                'converted_at': str(getattr(record, 'created_at', '') or ''),
+                'conversion_id': getattr(record, 'id', None),
+            }
+
+            fingerprint_changed = has_capability_changed(stored_fp) or force
+            if not items:
+                datasets_report.append({
+                    **base,
+                    'fingerprint_changed': fingerprint_changed,
+                    'note': (
+                        'no stored non-transpiled measures for this run '
+                        '(pre-dates re-evaluation recording, or everything translated)'
+                    ),
+                    'newly_translatable': [],
+                    'still_failing_count': 0,
+                    'skipped_count': 0,
+                })
+                continue
+
+            if not fingerprint_changed:
+                # Nothing changed since this run produced its result → a retry cannot
+                # find anything new. Report it explicitly instead of silently skipping.
+                datasets_report.append({
+                    **base,
+                    'fingerprint_changed': False,
+                    'note': 'transpiler unchanged since this run — nothing to gain',
+                    'newly_translatable': [],
+                    'still_failing_count': len(items),
+                    'skipped_count': 0,
+                })
+                continue
+
+            result = reevaluate_measures(
+                items,
+                cfg,
+                review=self._stored_review(record),
+                include_impossible=include_impossible,
+                use_llm=use_llm,
+                limit=max_per_ds,
+            )
+            counts = result.get('counts', {})
+            total_recovered += counts.get('recovered', 0)
+            total_retried += counts.get('retried', 0)
+
+            datasets_report.append({
+                **base,
+                'fingerprint_changed': True,
+                'newly_translatable': result.get('newly_translatable', []),
+                'still_failing_count': counts.get('still_failing', 0),
+                'skipped_count': counts.get('skipped', 0),
+                'counts': counts,
+            })
+
+        output = {
+            'capability': capability,
+            'settings': {
+                'include_impossible': include_impossible,
+                'use_llm': use_llm,
+                'max_measures_per_dataset': max_per_ds,
+                'max_datasets': max_datasets,
+                'force': force,
+            },
+            'datasets': datasets_report,
+            'summary': {
+                'datasets_scanned': len(datasets_report),
+                'measures_retried': total_retried,
+                'measures_recovered': total_recovered,
+                'datasets_with_recoveries': sum(
+                    1 for d in datasets_report if d.get('newly_translatable')),
+            },
+        }
+        logger.info(
+            "[UCMVReeval] done: %s dataset(s), %s retried, %s recoverable",
+            len(datasets_report), total_retried, total_recovered,
+        )
+        return json.dumps(output, indent=2, default=str)

--- a/src/backend/src/engines/crewai/tools/tool_factory.py
+++ b/src/backend/src/engines/crewai/tools/tool_factory.py
@@ -187,6 +187,12 @@ except ImportError as e:
     MetricViewValidatorTool = None
     logging.warning(f"Could not import MetricViewValidatorTool: {e}")
 
+try:
+    from .custom.ucmv_reevaluation_tool import UCMVReevaluationTool
+except ImportError as e:
+    UCMVReevaluationTool = None
+    logging.warning(f"Could not import UCMVReevaluationTool: {e}")
+
 # Config Generator Tool
 try:
     from .custom.config_generator_tool import ConfigGeneratorTool
@@ -311,6 +317,8 @@ class ToolFactory:
             self._tool_implementations["Metric View Deployer"] = MetricViewDeployerTool
         if MetricViewValidatorTool is not None:
             self._tool_implementations["Metric View Validator"] = MetricViewValidatorTool
+        if UCMVReevaluationTool is not None:
+            self._tool_implementations["UCMV Re-evaluation"] = UCMVReevaluationTool
         if ConfigGeneratorTool is not None:
             self._tool_implementations["Config Generator"] = ConfigGeneratorTool
         if PipelineConfigGeneratorTool is not None:

--- a/src/backend/src/main.py
+++ b/src/backend/src/main.py
@@ -46,7 +46,12 @@ os.environ["SEED_DEBUG"] = "True"
 os.environ["CREWAI_DISABLE_TELEMETRY"] = "true"
 
 # Prevent MLflow from creating local mlruns directories
-# This MUST be set before MLflow is imported anywhere to ensure Databricks backend is used
+# This MUST be set before MLflow is imported anywhere to ensure Databricks backend is used.
+# Preserve the launch value first: prompt optimization's local-registry mode
+# (MCP_SERVER_ENABLED=true + MLFLOW_TRACKING_URI=<local server>) reads the
+# value the process was STARTED with, which this override would otherwise erase.
+if os.environ.get("MLFLOW_TRACKING_URI"):
+    os.environ.setdefault("KASAL_LAUNCH_MLFLOW_TRACKING_URI", os.environ["MLFLOW_TRACKING_URI"])
 os.environ["MLFLOW_TRACKING_URI"] = "databricks"
 
 # Set log directory environment variable

--- a/src/backend/src/main.py
+++ b/src/backend/src/main.py
@@ -308,10 +308,7 @@ async def lifespan(app: FastAPI):
                 # destructive DROP SCHEMA the migrate UI would do. Best-effort.
                 try:
                     from src.db.session import run_schema_self_heal
-                    async with lb_factory._session_factory() as _heal_session:
-                        conn = await _heal_session.connection()
-                        await run_schema_self_heal(conn)
-                        await _heal_session.commit()
+                    await run_schema_self_heal(lb_factory._engine)
                     system_logger.info("Lakebase schema self-heal complete")
                 except Exception as _heal_err:
                     system_logger.warning(

--- a/src/backend/src/models/powerbi_extraction.py
+++ b/src/backend/src/models/powerbi_extraction.py
@@ -38,6 +38,14 @@ class PowerBIExtraction(Base):
     relationships = Column(JSON, nullable=True)   # [{from_table, from_column, from_cardinality, to_*, is_active, id}]
     measures = Column(JSON, nullable=True)        # [{measure_name, table_name, expression (DAX), description}]
     admin_tables = Column(JSON, nullable=True)    # {table_name: {columns, mquery_expression, measures}}
+    # {name: raw_M} model-level named/shared expressions (staging queries +
+    # parameters) — parsed alongside admin_tables (parse_admin_expressions /
+    # parse_tmdl_expressions), needed by resolve_mquery_with_context to follow
+    # a table's reference to a disabled staging query or substitute a
+    # parameter-driven Value.NativeQuery. Without this, the UCMV Generator
+    # fallback below can only redo the DIRECT resolution tier, not the fuller
+    # reference-following / parameter-substitution one.
+    expressions = Column(JSON, nullable=True)
     report_definition = Column(JSON, nullable=True)  # report visual bindings (measure expressions)
     proposed_config = Column(JSON, nullable=True)    # the derived pipeline_config
     warnings = Column(JSON, nullable=True)           # list of extraction warnings

--- a/src/backend/src/schemas/powerbi_extraction.py
+++ b/src/backend/src/schemas/powerbi_extraction.py
@@ -32,6 +32,8 @@ class PowerBIExtractionCreate(PowerBIExtractionBase):
         None, description="Raw measures with DAX expressions")
     admin_tables: Optional[Dict[str, Any]] = Field(
         None, description="Admin/TMDL table metadata {table: {columns, mquery, measures}}")
+    expressions: Optional[Dict[str, str]] = Field(
+        None, description="Model-level named/shared expressions {name: raw_M} — staging queries + parameters")
     report_definition: Optional[Dict[str, Any]] = Field(
         None, description="Report visual bindings / definition")
     proposed_config: Optional[Dict[str, Any]] = Field(
@@ -51,6 +53,7 @@ class PowerBIExtractionResponse(PowerBIExtractionBase):
     relationships: Optional[List[Dict[str, Any]]] = None
     measures: Optional[List[Dict[str, Any]]] = None
     admin_tables: Optional[Dict[str, Any]] = None
+    expressions: Optional[Dict[str, str]] = None
     report_definition: Optional[Dict[str, Any]] = None
     proposed_config: Optional[Dict[str, Any]] = None
     warnings: Optional[List[str]] = None

--- a/src/backend/src/schemas/prompt_optimization.py
+++ b/src/backend/src/schemas/prompt_optimization.py
@@ -1,0 +1,151 @@
+"""
+Pydantic schemas for prompt optimization operations.
+
+Data-driven optimization of the seeded meta-prompts (GEPA via
+mlflow.genai.optimize_prompts): a run mines training examples from the
+LLM interaction log (or takes them inline), searches for a better
+template, and proposes it for explicit review-and-apply.
+"""
+
+from datetime import datetime
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PromptOptimizationRequest(BaseModel):
+    """Request to start a prompt optimization run for a seeded template."""
+
+    template_name: Literal[
+        "detect_intent",
+        "generate_agent",
+        "generate_task",
+        "generate_crew",
+        "generate_crew_plan",
+        "generate_job_name",
+    ] = Field(
+        ...,
+        description="The prompt template to optimize (must be wired in TEMPLATE_TASKS)",
+    )
+    model: Optional[str] = Field(
+        None,
+        description="Target model the optimized prompt must perform on "
+        "(defaults to the dispatcher's fast model)",
+    )
+    judge_model: Optional[str] = Field(
+        None,
+        description="Model used to judge output correctness (defaults to the target model)",
+    )
+    reflection_model: Optional[str] = Field(
+        None,
+        description="Model GEPA uses to reflect on failures and mutate the prompt "
+        "(defaults to the target model)",
+    )
+    examples: Optional[List[str]] = Field(
+        None,
+        description="Explicit training inputs (user messages). When omitted, "
+        "examples are mined from the LLM interaction log.",
+    )
+    lookback_days: int = Field(
+        30, ge=1, le=365, description="Log-mining window in days"
+    )
+    max_examples: int = Field(50, ge=5, le=200, description="Maximum training examples")
+    max_metric_calls: int = Field(
+        40,
+        ge=8,
+        le=400,
+        description="GEPA evaluation budget — each call is one LLM invocation of the "
+        "target model (plus judge calls), so this bounds run cost",
+    )
+
+
+class CrewOptimizationRequest(BaseModel):
+    """Request to GEPA-optimize a saved crew's prompt fields.
+
+    EXPENSIVE BY DESIGN: every metric call executes the crew for real (tools
+    included) and judges the final deliverable — the budget is the number of
+    crew executions.
+    """
+
+    crew_id: str = Field(..., description="The saved crew to optimize")
+    model: Optional[str] = Field(
+        None, description="Model the crew executes with during evaluation"
+    )
+    judge_model: Optional[str] = Field(None, description="Judge model for deliverables")
+    reflection_model: Optional[str] = Field(None, description="GEPA reflection model")
+    guidance: Optional[str] = Field(
+        None, description="Optional extra judging guidance (what 'good' looks like)"
+    )
+    max_metric_calls: int = Field(
+        10,
+        ge=4,
+        le=40,
+        description="HARD CAP on crew executions (includes 1 validation + 1 "
+        "baseline, so 10 buys ~8 candidate evaluations)",
+    )
+    execution_timeout_seconds: int = Field(
+        900, ge=60, le=3600, description="Per-execution timeout"
+    )
+
+
+class PromptOptimizationStartResponse(BaseModel):
+    """Acknowledgement that an optimization run started in the background."""
+
+    run_id: str = Field(..., description="Identifier to poll for status")
+    status: str = Field(..., description="Initial run status")
+    dataset_size: int = Field(
+        ..., description="Number of training examples the run will use"
+    )
+
+
+class PromptOptimizationRunStatus(BaseModel):
+    """Status/result of an optimization run."""
+
+    run_id: str
+    template_name: str
+    status: Literal["pending", "running", "completed", "failed", "cancelled"]
+    dataset_size: int = 0
+    model: Optional[str] = None
+    initial_score: Optional[float] = Field(None, description="Baseline template score")
+    final_score: Optional[float] = Field(None, description="Optimized template score")
+    baseline_template: Optional[str] = Field(
+        None, description="Template text the run started from"
+    )
+    optimized_template: Optional[str] = Field(
+        None, description="Proposed template (present when status=completed)"
+    )
+    error: Optional[str] = None
+    applied: bool = Field(
+        False, description="Whether the proposal was applied as a group override"
+    )
+    created_at: Optional[datetime] = None
+    kind: Optional[str] = Field(
+        None, description="'template' (seeded meta-prompt) or 'crew' (saved crew)"
+    )
+    crew_id: Optional[str] = Field(None, description="Crew id for crew runs")
+    baseline_fields: Optional[Dict[str, str]] = Field(
+        None, description="Crew runs: per-field baseline texts (agent.<id>.<field>)"
+    )
+    optimized_fields: Optional[Dict[str, str]] = Field(
+        None, description="Crew runs: per-field proposed texts"
+    )
+    executions_used: Optional[int] = Field(
+        None, description="Crew runs: crew executions spent so far"
+    )
+    execution_cap: Optional[int] = Field(
+        None, description="Crew runs: hard cap on crew executions"
+    )
+
+
+class PromptOptimizationRunList(BaseModel):
+    """Recent optimization runs for the caller's group."""
+
+    runs: List[PromptOptimizationRunStatus]
+
+
+class PromptOptimizationApplyResponse(BaseModel):
+    """Result of applying a completed run's proposed template."""
+
+    run_id: str
+    template_name: str
+    applied: bool

--- a/src/backend/src/schemas/prompt_optimization.py
+++ b/src/backend/src/schemas/prompt_optimization.py
@@ -135,6 +135,14 @@ class PromptOptimizationRunStatus(BaseModel):
     execution_cap: Optional[int] = Field(
         None, description="Crew runs: hard cap on crew executions"
     )
+    human_feedback_count: Optional[int] = Field(
+        None,
+        description="Crew runs: human grades/expectations steering this run",
+    )
+    candidates_tried: Optional[int] = Field(
+        None,
+        description="Crew runs: distinct candidate prompt sets actually executed",
+    )
 
 
 class PromptOptimizationRunList(BaseModel):

--- a/src/backend/src/seeds/bi_specialist_crews.py
+++ b/src/backend/src/seeds/bi_specialist_crews.py
@@ -17,6 +17,12 @@ The seeded crews cover the full E2E flow:
 
 Plus the E2E flow that wires them all together.
 
+And one STANDALONE crew, outside that flow:
+ 10. UCMV Re-evaluation              (tool 97) — looks BACKWARDS at already-converted
+     models and re-tries only the measures that failed then, using today's improved
+     transpiler. Run manually or on a schedule after shipping transpiler improvements.
+     Read-only: it proposes re-transpilation candidates, never modifies metric views.
+
 Credential/input placeholders are left empty so the user only needs to fill in
 their workspace_id, client_id, client_secret, catalog, schema, warehouse_id etc.
 All tool logic and agent configurations are ready to run.
@@ -33,8 +39,13 @@ from src.models.task import Task
 from src.models.group import Group
 from src.models.group_tool import GroupTool
 
-# Tools required by the PBI migration pipeline — pre-enabled for bi-specialist
-BI_TOOLS = [78, 86, 88, 90, 91, 92, 93, 94, 95]
+# Tools required by the PBI migration pipeline — pre-enabled for bi-specialist.
+# These become GroupTool rows: workspace eligibility is NOT the tool's global
+# `enabled` flag, it's an explicit (group_id, tool_id) mapping. A tool missing here
+# is filtered out of /tools/enabled, so the workspace's Tools list hides it AND the
+# crew UI can only show its raw id instead of its name.
+# 97 = UCMV Re-evaluation (the standalone recovery crew).
+BI_TOOLS = [78, 86, 88, 90, 91, 92, 93, 94, 95, 97]
 
 logger = logging.getLogger(__name__)
 
@@ -900,6 +911,112 @@ GENIE_GEN_CREW = {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Crew 10 — UCMV Re-evaluation (recoverable measures)
+# ─────────────────────────────────────────────────────────────────────────────
+# STANDALONE, not part of the conversion flow: it looks BACKWARDS at models that
+# were already converted and re-tries only the measures that failed back then,
+# using today's (improved) transpiler. Run it manually or on a schedule after
+# shipping transpiler improvements. Read-only — it proposes re-transpilation
+# candidates and never modifies metric views.
+# Docs: src/docs/powerbi/ucmv-reevaluation-recoverable-measures.md
+
+UCMV_REEVAL_AGENT_ID = "bi-ucmv-reeval-agent-001"
+UCMV_REEVAL_TASK_ID = "bi-ucmv-reeval-task-001"
+UCMV_REEVAL_CREW_ID = "bi-ucmv-reeval-crew-001"
+
+UCMV_REEVAL_AGENT = {
+    "id": UCMV_REEVAL_AGENT_ID,
+    "name": "UCMV Re-evaluation Agent",
+    "role": "Metric View Recovery Analyst",
+    "goal": (
+        "Find previously-untranslatable DAX measures that today's improved "
+        "transpiler can now recover, and report them for human review."
+    ),
+    "backstory": (
+        "You track how Kasal's DAX→UC Metric View capability improves over time. "
+        "Models converted months ago still carry measures that failed back then but "
+        "are translatable today. You replay the stored conversion history and report "
+        "which measures are now recoverable. "
+        "Call the UCMV Re-evaluation tool with ZERO arguments — the group scope and "
+        "settings come from the tool config. Report the findings verbatim; do NOT "
+        "invent SQL and do NOT claim anything was applied — the tool only proposes."
+    ),
+    "llm": "databricks-claude-opus-4-8",
+    "tools": [],
+    "tool_configs": {},
+    "max_iter": 5,
+    "max_rpm": 10,
+    "max_execution_time": 600,
+    "verbose": True,
+    "allow_delegation": False,
+    "cache": True,
+    "memory": False,
+    "embedder_config": DEFAULT_EMBEDDER,
+    "max_retry_limit": 3,
+}
+
+UCMV_REEVAL_TASK = {
+    "id": UCMV_REEVAL_TASK_ID,
+    "name": "Find measures the improved transpiler can now recover",
+    "description": (
+        "Scan the stored UCMV conversion history and re-try ONLY the measures that "
+        "previously failed to transpile, using today's transpiler.\n\n"
+        "⚠️ CRITICAL: Call the UCMV Re-evaluation tool with ZERO arguments — the "
+        "group scope and settings are supplied by the tool config.\n\n"
+        "The tool is READ-ONLY. It proposes re-transpilation candidates; it never "
+        "modifies metric views. Return its report as-is, highlighting per dataset "
+        "which measures are now recoverable, the reason each failed before, and the "
+        "new SQL. If nothing is recoverable, say so plainly — that is a valid result "
+        "(either the transpiler has not changed since those runs, or the remaining "
+        "gaps are permanent limitations)."
+    ),
+    "expected_output": (
+        "A JSON report with the capability fingerprint, per-dataset lists of "
+        "newly-recoverable measures (name, previous skip reason, new SQL, impact), "
+        "and a summary of datasets scanned / measures retried / measures recovered."
+    ),
+    "agent_id": UCMV_REEVAL_AGENT_ID,
+    "tools": ["97"],
+    "tool_configs": {
+        "UCMV Re-evaluation": {
+            "result_as_answer": True,
+            # Scope: leave group_id empty to have the runtime group context apply;
+            # set dataset_ids to target specific models.
+            "group_id": None,
+            "dataset_ids": None,
+            # Cost guards. use_llm=False keeps a scheduled sweep free (deterministic
+            # fast-path only); flip it on for a deeper, token-spending pass.
+            "use_llm": False,
+            "include_impossible": False,
+            "max_measures_per_dataset": 200,
+            "max_datasets": 50,
+            # force=True re-tries even when the transpiler has NOT changed since the
+            # stored run. Useful to verify the sweep end-to-end; leave False in
+            # production so the sweep only reports genuine capability gains.
+            "force": False,
+        }
+    },
+    "config": DEFAULT_TASK_CONFIG,
+}
+
+UCMV_REEVAL_CREW = {
+    "id": UCMV_REEVAL_CREW_ID,
+    "name": "UCMV Re-evaluation",
+    "process": "sequential",
+    "planning": False,
+    "reasoning": False,
+    "memory": False,
+    "verbose": True,
+    "agent_ids": [UCMV_REEVAL_AGENT_ID],
+    "task_ids": [UCMV_REEVAL_TASK_ID],
+    "nodes": [
+        _agent_node(UCMV_REEVAL_AGENT_ID, UCMV_REEVAL_AGENT, 68, 68),
+        _task_node(UCMV_REEVAL_TASK_ID, UCMV_REEVAL_AGENT_ID, UCMV_REEVAL_TASK, 368, 68),
+    ],
+    "edges": [_agent_to_task_edge("ucmv-reeval", UCMV_REEVAL_AGENT_ID, UCMV_REEVAL_TASK_ID)],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # All crews (ordered for seeding)
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -913,6 +1030,8 @@ ALL_CREWS = [
     {"crew": DASHBOARD_CREW,       "agent": DASHBOARD_AGENT,       "task": DASHBOARD_TASK},
     {"crew": GENIE_CFG_CREW,       "agent": GENIE_CFG_AGENT,       "task": GENIE_CFG_TASK},
     {"crew": GENIE_GEN_CREW,       "agent": GENIE_GEN_AGENT,       "task": GENIE_GEN_TASK},
+    # Standalone (not part of the conversion flow) — run manually or on a schedule.
+    {"crew": UCMV_REEVAL_CREW,     "agent": UCMV_REEVAL_AGENT,     "task": UCMV_REEVAL_TASK},
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/backend/src/seeds/bi_specialist_crews.py
+++ b/src/backend/src/seeds/bi_specialist_crews.py
@@ -297,6 +297,12 @@ UCMV_GEN_TASK = {
             "tenant_id": "",
             "client_id": "",
             "client_secret": "",
+            # Distinct admin Service Principal for the MQuery Admin Scanner's
+            # 3rd fallback tier (retries the scan itself with admin rights when
+            # client_id/client_secret and Fabric TMDL both fail) — mirrors
+            # Pipeline Config Generator's admin_client_id/admin_client_secret.
+            "admin_client_id": "",
+            "admin_client_secret": "",
             "catalog": "",
             "schema_name": "",
             "use_llm_fallback": True,

--- a/src/backend/src/seeds/model_configs.py
+++ b/src/backend/src/seeds/model_configs.py
@@ -308,13 +308,6 @@ DEFAULT_MODELS = {
         "context_window": 200000,
         "max_output_tokens": 64000
     },
-    "databricks-gemini-2-5-flash": {
-        "name": "databricks-gemini-2-5-flash",
-        "temperature": 0.7,
-        "provider": "databricks",
-        "context_window": 1048576,
-        "max_output_tokens": 65536
-    },
     "databricks-gemini-3-1-flash-lite": {
         "name": "databricks-gemini-3-1-flash-lite",
         "temperature": 0.7,
@@ -475,6 +468,11 @@ REMOVED_MODEL_KEYS = [
     "databricks-gpt-5-5-pro",                    # Responses-API-only (unsupported via chat completions)
     "databricks-gpt-5-5",                        # function tools unsupported via chat completions (Responses API only) — breaks tool crews
     "databricks-gemini-2-5-pro",                 # removed per request (superseded by gemini-3-5-flash / gemini-3-1-flash-lite)
+    # Databricks deprecated this endpoint (returns BAD_REQUEST "This endpoint
+    # databricks-gemini-2-5-flash is deprecated"). It was still a high-context
+    # (1M) fallback candidate, so DatabricksRetryLLM fell back to it and crashed a
+    # UCMV flow with a non-retryable BadRequestError. Pruned 2026-09-07.
+    "databricks-gemini-2-5-flash",
     "databricks-meta-llama-3-1-405b-instruct",   # NOT_FOUND (pay-per-token disabled)
     # Reasoning model: answers the JSON-only planning prompt with a "thinking"
     # preamble ("1. Analyze the Request: ..."), so crew planning fails with

--- a/src/backend/src/seeds/tools.py
+++ b/src/backend/src/seeds/tools.py
@@ -48,6 +48,7 @@ tools_data = [
     (93, "UCMV Genie Space Config Generator", "Auto-generates Genie Space configuration from deployed UC Metric Views. Reads ucmv_output (auto-injected from flow) and uses an LLM to produce: text_instructions (business description), sample_questions (natural language questions), example_sqls_json (MEASURE() SQL queries), and join_specs_json (from UCMV join definitions). If genie_config_override is provided (manually uploaded JSON), the LLM step is skipped. Output fields match the Genie Space Generator schema for direct flow injection. Use as the step between Metric View Deployer and Genie Space Generator.", "transform"),
     (94, "PBI Visual-UCMV Mapper", "Maps Power BI report visuals to deployed UC Metric View metric views. Takes Power BI Report References (tool 78) output and ucmv_output (from flow injection) and uses an LLM to match each visual's PBI measures to UCMV SQL measures, identify the correct metric view, determine grouping dimensions, and generate executable Databricks SQL with MEASURE() syntax. Output feeds directly into the Dashboard Creator (tool 95). Part of the CI/CD dashboard pipeline: Report References → UCMV Mapper → Dashboard Creator.", "transform"),
     (95, "Databricks Dashboard Creator", "Creates Databricks AI/BI (Lakeview) dashboards from visual-to-UCMV mappings. Takes the structured visual mappings from the PBI Visual-UCMV Mapper (tool 94), generates a Lakeview dashboard JSON with correct widget types (bar, line, table, counter), datasets with MEASURE() SQL queries, and page layouts. Calls the Databricks Lakeview REST API to create or update the dashboard and optionally publishes it. Returns the dashboard URL. Final step in the CI/CD dashboard pipeline.", "database"),
+    (97, "UCMV Re-evaluation", "Finds previously-untranslatable DAX measures that TODAY's improved transpiler can now recover. Replays stored conversion history (no PowerBI API call): for each dataset it compares the capability fingerprint of the original run against the current one, and re-tries ONLY the measures that failed back then. Reports which are now recoverable with their new SQL, the reason they failed before, and how many other measures depend on them. Read-only — proposes re-transpilation candidates, never modifies metric views. Deterministic by default (no LLM tokens); set use_llm=true to also try the LLM-first path. Skips permanent-limitation categories (display artifacts, slicer scalars, prior-year) and measures a reviewer already dismissed. Schedule it or trigger manually after shipping transpiler improvements.", "database"),
 ]
 
 def get_tool_configs():
@@ -480,7 +481,9 @@ async def seed_async():
     tools_error = 0
 
     # List of tool IDs that should be enabled
-    enabled_tool_ids = [6, 16, 26, 31, 35, 36, 67, 69, 70, 71, 72, 73, 74, 75, 76, 77, 79, 80, 81, 82, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95]
+    # 97 = UCMV Re-evaluation: the seeded "UCMV Re-evaluation" crew references it, so
+    # it must be enabled or that crew's task cannot resolve its tool.
+    enabled_tool_ids = [6, 16, 26, 31, 35, 36, 67, 69, 70, 71, 72, 73, 74, 75, 76, 77, 79, 80, 81, 82, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 97]
 
     for tool_id, title, description, icon in tools_data:
         try:
@@ -543,7 +546,9 @@ def seed_sync():
     tools_error = 0
 
     # List of tool IDs that should be enabled
-    enabled_tool_ids = [6, 16, 26, 31, 35, 36, 67, 69, 70, 71, 72, 73, 74, 75, 76, 77, 79, 80, 81, 82, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95]
+    # 97 = UCMV Re-evaluation: the seeded "UCMV Re-evaluation" crew references it, so
+    # it must be enabled or that crew's task cannot resolve its tool.
+    enabled_tool_ids = [6, 16, 26, 31, 35, 36, 67, 69, 70, 71, 72, 73, 74, 75, 76, 77, 79, 80, 81, 82, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 97]
 
     for tool_id, title, description, icon in tools_data:
         try:

--- a/src/backend/src/services/execution_name_service.py
+++ b/src/backend/src/services/execution_name_service.py
@@ -64,12 +64,20 @@ class ExecutionNameService:
 
     async def _get_name_template(self) -> str:
         """Fetch the ``generate_job_name`` template, opening a standalone session
-        when none was injected (so the read never hits a ``None`` session)."""
+        when none was injected (so the read never hits a ``None`` session).
+
+        Uses ``async_session_factory`` directly rather than
+        ``request_scoped_session()``: the latter REUSES the request-scoped session
+        when the ContextVar is set (which it is for a task spawned during an HTTP
+        request), and sharing that session with the in-flight request raises
+        "This session is provisioning a new connection; concurrent operations are
+        not permitted". A private session cannot contend with the request.
+        """
         if self.template_service is not None:
             return await self.template_service.get_template_content("generate_job_name")
-        from src.db.session import request_scoped_session
+        from src.db.session import async_session_factory
         from src.services.template_service import TemplateService
-        async with request_scoped_session() as session:
+        async with async_session_factory() as session:
             return await TemplateService(session).get_template_content("generate_job_name")
 
     async def _log_llm_interaction(self, endpoint: str, prompt: str, response: str, model: str) -> None:
@@ -92,10 +100,13 @@ class ExecutionNameService:
                     status='success'
                 )
             else:
-                # No injected session: open a standalone one and COMMIT (the
+                # No injected session: open a PRIVATE one and COMMIT (the
                 # repository only flushes — a request would normally commit at end).
-                from src.db.session import request_scoped_session
-                async with request_scoped_session() as session:
+                # async_session_factory (not request_scoped_session) so this write
+                # never joins — and so never contends with — an in-flight request
+                # transaction. See _get_name_template for the full rationale.
+                from src.db.session import async_session_factory
+                async with async_session_factory() as session:
                     await LLMLogService.create(session).create_log(
                         endpoint=endpoint,
                         prompt=prompt,
@@ -126,6 +137,22 @@ class ExecutionNameService:
             Response containing the generated name
         """
         try:
+            # Standalone mode (no injected session): this call runs off a task that
+            # INHERITED the HTTP request's context, so the `_request_session`
+            # ContextVar still points at the request-scoped session. Any nested
+            # `request_scoped_session()` — notably the model-config read inside
+            # LLMManager.configure_crewai_llm — would then reuse that shared session
+            # and race the in-flight request ("This session is provisioning a new
+            # connection; concurrent operations are not permitted"). Detaching makes
+            # every nested read open a private session. Only mutates THIS task's
+            # context copy, never the originating request's.
+            if getattr(self, "_session", None) is None:
+                try:
+                    from src.db.session import detach_request_session
+                    detach_request_session()
+                except Exception as _detach_err:  # never block naming on this
+                    logger.debug(f"Could not detach request session: {_detach_err}")
+
             # Get the template for name generation (opens its own session when none
             # was injected — the chat auto-execute path builds this service with
             # session=None). This template already includes instructions to only

--- a/src/backend/src/services/lakebase_service.py
+++ b/src/backend/src/services/lakebase_service.py
@@ -660,6 +660,22 @@ class LakebaseService(BaseService):
                 await self.schema_service.set_search_path_async(conn)
 
             await self.schema_service.create_tables_async(lakebase_engine)
+
+            # create_tables_async only CREATEs tables that don't exist yet — it
+            # never ALTERs a table that's already there from a previous migrate.
+            # A customer who migrated to Lakebase before a column was added
+            # (e.g. powerbi_extraction.expressions) would otherwise never get
+            # it, since this manual "connect + migrate" flow is the only schema
+            # path that ever touches THIS Lakebase instance — main.py's own
+            # self-heal on startup only fires when Lakebase is ALREADY the
+            # active connection, which isn't true yet during this flow.
+            try:
+                from src.db.session import run_schema_self_heal
+                await run_schema_self_heal(lakebase_engine)
+                logger.info("✅ Lakebase schema self-heal complete (missing columns added)")
+            except Exception as _heal_err:
+                logger.warning(f"Lakebase schema self-heal skipped: {_heal_err}")
+
             logger.info("-" * 60)
             logger.info("📤 Starting data migration...")
 
@@ -892,6 +908,33 @@ class LakebaseService(BaseService):
             # Create tables with streaming
             for message in self.schema_service.create_tables_sync_stream(lakebase_engine):
                 yield message
+
+            # create_tables_sync_stream only CREATEs tables that don't exist yet
+            # — it never ALTERs a table that's already there from a previous
+            # migrate. This UI flow (Settings → connect + migrate) is the only
+            # schema path that ever touches a customer's Lakebase instance, so
+            # a customer who migrated before a column was added (e.g.
+            # powerbi_extraction.expressions) would otherwise never get it.
+            # Sync engine here (unlike migrate_existing_data's async one), so
+            # this runs the same idempotent ADD COLUMN IF NOT EXISTS statements
+            # directly rather than reusing session.py's async
+            # run_schema_self_heal — keep new columns there in sync with this
+            # list if you add more.
+            try:
+                with lakebase_engine.begin() as conn:
+                    # search_path is per-connection — this `begin()` opens a
+                    # fresh one that does NOT inherit the "SET search_path"
+                    # run earlier in this function on a different connection.
+                    # Without it, ALTER TABLE targets whatever schema is on
+                    # the default search_path (typically "public"), not
+                    # "kasal" where powerbi_extraction actually lives.
+                    conn.execute(text("SET search_path TO kasal, public"))
+                    conn.execute(text(
+                        "ALTER TABLE powerbi_extraction ADD COLUMN IF NOT EXISTS expressions JSON"
+                    ))
+                yield {"type": "success", "message": "✅ Schema self-heal: ensured powerbi_extraction.expressions column"}
+            except Exception as heal_err:
+                yield {"type": "warning", "message": f"Schema self-heal skipped: {heal_err}"}
 
             # Check if we should migrate data
             if not migrate_data:
@@ -1617,6 +1660,18 @@ class LakebaseService(BaseService):
                 async with lakebase_engine.begin() as conn:
                     await self.schema_service.set_search_path_async(conn)
                 await self.schema_service.create_tables_async(lakebase_engine)
+                # create_tables_async alone only CREATEs missing tables — this
+                # comment's "missing ... columns" claim needs the self-heal too
+                # (an existing table is never ALTERed by create_all/checkfirst).
+                try:
+                    from src.db.session import run_schema_self_heal
+                    # run_schema_self_heal sets search_path itself on each
+                    # fresh connection it opens from this engine — it does
+                    # NOT inherit the set_search_path_async call above, which
+                    # ran on a different connection.
+                    await run_schema_self_heal(lakebase_engine)
+                except Exception as heal_err:
+                    logger.warning(f"Lakebase schema expand self-heal skipped: {heal_err}")
                 logger.info(
                     "Lakebase schema expanded on enable (missing tables/columns "
                     "created non-destructively)"

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -20,6 +20,7 @@ import hashlib
 import logging
 import os
 import re
+import threading
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -177,6 +178,69 @@ def _judge_value_to_grade(value: Any) -> Optional[float]:
             if text in words:
                 return grade
     return None
+
+
+def _distill_requirements(raw_notes: List[str], limit: int = 8) -> List[str]:
+    """Collapse harvested human feedback into a deduplicated requirements list.
+
+    The raw harvest repeats the same complaint many times ("french side" x8)
+    and carries the grade numbers. Feeding that litany to the judge ANCHORED
+    it — a compliant answer was graded 0/10 because every historical line said
+    0.0 (verified live with an A/B judge experiment: same answer, litany
+    rubric -> 0, requirements checklist -> 6). The judge needs constraints,
+    not grade history.
+    """
+    requirements: List[str] = []
+    seen: set = set()
+    for note in raw_notes:
+        text = str(note or "").strip()
+        if not text:
+            continue
+        normalized = re.sub(r"[^a-z0-9 ]", "", text.lower())
+        normalized = re.sub(r"\s+", " ", normalized).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        requirements.append(text)
+    return requirements[:limit]
+
+
+def _parse_requirement_lines(text: str) -> List[str]:
+    """Parse 'R1. ...' numbered requirement lines from a distillation reply."""
+    return [
+        m.group(1).strip()
+        for m in re.finditer(r"^\s*R\d+[.:]\s*(.+)$", text or "", re.MULTILINE)
+        if m.group(1).strip()
+    ]
+
+
+def _checklist_grade(verdict: str, n_requirements: int) -> Optional[float]:
+    """Compute a 0-1 grade from a checklist verdict's PASS/FAIL marks.
+
+    The grade is COMPUTED from the marks, never taken from the model's own
+    arithmetic — a judge writing "40" as its final number would clamp to a
+    perfect 10/10 (observed live). Blend: 0.8 x fraction of requirements
+    passed + 0.2 x the judge's base-quality Q mark (default 5 when absent),
+    so requirement-equal candidates still order by answer quality.
+
+    Returns None when no marks are found (caller falls back to last-number
+    parsing).
+    """
+    marks = re.findall(r"\bR(\d+)\s*[:.]?\s*(PASS|FAIL)", verdict or "", re.IGNORECASE)
+    if not marks or n_requirements <= 0:
+        return None
+    seen_marks: Dict[str, bool] = {}
+    for num, mark in marks:
+        # First mark per requirement wins (models sometimes restate at the end).
+        seen_marks.setdefault(num, mark.upper() == "PASS")
+    passed = sum(1 for ok in seen_marks.values() if ok)
+    fraction = passed / max(n_requirements, len(seen_marks))
+    quality = 0.5
+    q_match = re.search(r"\bQ\s*[:.]?\s*(\d+(?:\.\d+)?)", verdict or "", re.IGNORECASE)
+    if q_match:
+        q_value = float(q_match.group(1))
+        quality = max(0.0, min(10.0, q_value)) / 10.0
+    return max(0.0, min(1.0, 0.8 * fraction + 0.2 * quality))
 
 
 def _job_name_score(outputs: Any) -> float:
@@ -1347,6 +1411,7 @@ class PromptOptimizationService:
             judge_rubric = rubric
             objective_for_training = objective
             train_expectations: Dict[str, str] = {}
+            human_requirements: List[str] = []
             if local_mode and crew_id:
                 try:
                     prior = mlflow.search_traces(
@@ -1358,7 +1423,7 @@ class PromptOptimizationService:
                     # the NEWEST notes (search order is not guaranteed).
                     prior.sort(key=lambda t: t.info.request_time or 0)
                     notes: List[str] = []
-                    expect_notes: List[str] = []
+                    req_texts: List[str] = []
                     for trace in prior:
                         for assessment in trace.search_assessments() or []:
                             name = getattr(assessment, "name", "") or ""
@@ -1371,50 +1436,96 @@ class PromptOptimizationService:
                                 None,
                             )
                             if exp_value is not None:
-                                expect_notes.append(str(exp_value))
+                                req_texts.append(str(exp_value))
                             if value is None:
                                 value = exp_value
                             rationale = getattr(assessment, "rationale", None) or ""
+                            if rationale:
+                                req_texts.append(rationale)
                             if value is not None or rationale:
                                 notes.append(
                                     f"- {name}: {value if value is not None else ''} {rationale}".strip()
                                 )
-                    if expect_notes:
-                        # Ground truth rides GEPA's expectations channel too —
-                        # the reflective dataset surfaces it to the mutator as
-                        # explicit targets, not just prose inside the request.
-                        train_expectations = {
-                            "human_requirements": "\n".join(
-                                dict.fromkeys(expect_notes)
-                            )[:2000]
-                        }
+                    # Deduplicated constraints, NOT the grade litany: repeating
+                    # "human_grade: 0.0 ..." thirteen times anchored the judge
+                    # to zero even for a compliant answer (verified live A/B).
+                    human_requirements = _distill_requirements(req_texts)
                     harvest_entry = _RUNS.get(cancel_run_id) if cancel_run_id else None
                     if harvest_entry is not None:
                         harvest_entry["human_feedback_count"] = len(notes)
-                    if notes:
-                        human_notes = "\n".join(notes[-12:])
-                        judge_rubric += (
-                            "\nHuman assessments on previous optimization answers "
-                            "(treat as authoritative grading guidance):\n" + human_notes
-                        )
-                        # CRITICAL: the requirements must ALSO reach GEPA's
-                        # reflection model, which only sees training inputs and
-                        # scorer feedback — a judge that grades 0 "because
-                        # wrong region" is useless to a mutator that never
-                        # learns the region requirement (observed live: flat
-                        # 0-scores with mutations blind to the human's why).
-                        objective_for_training = (
-                            objective
-                            + "\nHard requirements from human review of past answers:\n"
-                            + human_notes
-                        )
-                        logger.info(
-                            f"Crew optimization: folded {len(notes)} human assessments into the rubric"
-                        )
                 except Exception as assess_err:
                     logger.warning(
                         f"Could not harvest MLflow assessments: {assess_err}"
                     )
+
+            if human_requirements:
+                # LLM-refine the raw complaints into testable imperatives —
+                # verified live: a 30B judge fed the raw complaint sentences
+                # ("it is giving french side...") as checklist items failed
+                # EVERY mark by quoting the requirement itself as evidence;
+                # the same judge with cleanly phrased requirements graded a
+                # compliant answer 0.96 and a Geneva-containing one 0.60 with
+                # correct verbatim quotes. One cheap call per run.
+                try:
+                    refined_text = _sync_llm_completion(
+                        loop,
+                        messages=[
+                            {
+                                "role": "system",
+                                "content": (
+                                    "You convert raw human review notes about an "
+                                    "AI crew's answers into a clean requirements "
+                                    "checklist for FUTURE answers.\n"
+                                    "- Merge duplicate and overlapping notes into "
+                                    "one requirement.\n"
+                                    "- Phrase each as a positive, testable "
+                                    "requirement about the answer content.\n"
+                                    "- Notes describing one-off failures (e.g. "
+                                    "'nothing delivered') become a standing "
+                                    "requirement only if sensible.\n"
+                                    "- Output ONLY numbered lines 'R1. ...', "
+                                    "'R2. ...' — at most 5 requirements, nothing "
+                                    "else."
+                                ),
+                            },
+                            {
+                                "role": "user",
+                                "content": "\n".join(
+                                    f"- {r}" for r in human_requirements
+                                ),
+                            },
+                        ],
+                        model=judge_model,
+                        max_tokens=800,
+                        group_context=group_context,
+                        user_token=user_token,
+                    )
+                    refined = _parse_requirement_lines(refined_text)
+                    if refined:
+                        human_requirements = refined[:5]
+                except Exception as distill_err:
+                    logger.warning(
+                        f"Requirement distillation failed; using raw notes: {distill_err}"
+                    )
+                req_block = "\n".join(f"- {r}" for r in human_requirements)
+                # Ground truth rides GEPA's expectations channel too — the
+                # reflective dataset surfaces it to the mutator as explicit
+                # targets, not just prose inside the request.
+                train_expectations = {"human_requirements": req_block[:2000]}
+                # The requirements must ALSO reach GEPA's reflection model,
+                # which only sees training inputs and scorer feedback — a
+                # judge that grades 0 "because wrong region" is useless to a
+                # mutator that never learns the region requirement (observed
+                # live: flat 0-scores with mutations blind to the human's why).
+                objective_for_training = (
+                    objective
+                    + "\nHard requirements from human review of past answers:\n"
+                    + req_block
+                )
+                logger.info(
+                    "Crew optimization: using "
+                    f"{len(human_requirements)} distilled human requirements"
+                )
 
             # CUSTOM JUDGES: LLM judges registered on the local MLflow
             # experiment ("Create LLM judge" in the MLflow UI) participate in
@@ -1485,6 +1596,13 @@ class PromptOptimizationService:
             # against the baseline are stable within the run.
             deliverable_cache: Dict[str, str] = {}
             judge_cache: Dict[str, Any] = {}
+            # Serializes check-then-execute: mlflow's eval harness runs batch
+            # records through a thread pool, and concurrent calls for the SAME
+            # candidate all missed the cache and each ran the crew (observed
+            # live: two executions of one candidate finishing in the same
+            # second). GEPA itself steps sequentially, so the lock costs
+            # nothing in wall-clock.
+            execute_lock = threading.Lock()
 
             def predict_fn(**inputs) -> str:
                 run_entry = _RUNS.get(cancel_run_id, {}) if cancel_run_id else {}
@@ -1495,6 +1613,10 @@ class PromptOptimizationService:
                 doc_key = hashlib.sha256(
                     candidate.template.encode("utf-8")
                 ).hexdigest()
+                with execute_lock:
+                    return _predict_locked(doc_key, candidate, run_entry, inputs)
+
+            def _predict_locked(doc_key, candidate, run_entry, inputs) -> str:
                 # Cache lookup BEFORE the cap check: re-evaluations of an
                 # already-executed candidate (usually the baseline) stay
                 # truthful even after the budget is spent.
@@ -1548,7 +1670,10 @@ class PromptOptimizationService:
                             span.set_outputs({"deliverable": deliverable[:8000]})
                             mlflow.update_current_trace(tags={"kasal_crew_id": crew_id})
                     except Exception as trace_err:
-                        logger.debug(f"Eval trace logging failed: {trace_err}")
+                        # Warning, not debug: a lost trace means the user
+                        # cannot grade that answer (a baseline eval vanished
+                        # silently this way, observed live).
+                        logger.warning(f"Eval trace logging failed: {trace_err}")
                 return deliverable
 
             @scorer
@@ -1585,37 +1710,85 @@ class PromptOptimizationService:
                     return Feedback(
                         name="output_correct", value=cached[0], rationale=cached[1]
                     )
+                if human_requirements:
+                    # CHECKLIST mode: per-requirement PASS/FAIL gives GEPA a
+                    # gradient to climb — the all-or-nothing harsh grader
+                    # produced a flat 0.0 landscape where a fully compliant
+                    # candidate could only ever TIE the baseline. The verbatim
+                    # -quote rule counters judge hallucination (observed live:
+                    # a FAIL claiming Geneva rows in an answer containing
+                    # none), and the objective line is deliberately withheld —
+                    # the crew's own task text may contradict the human
+                    # requirements (it said "cities like Zurich, Geneva" while
+                    # the human demanded German-side only).
+                    req_lines = "\n".join(
+                        f"R{i + 1}. {r}" for i, r in enumerate(human_requirements)
+                    )
+                    judge_messages = [
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are grading an AI crew's final deliverable "
+                                "against a numbered requirements checklist distilled "
+                                "from human review of PREVIOUS answers.\n"
+                                "Rules:\n"
+                                "- Judge ONLY the answer shown below. Failures of "
+                                "previous answers are irrelevant.\n"
+                                "- Each requirement states what the human demanded "
+                                "(sometimes phrased as a complaint about an older "
+                                "answer); decide whether THIS answer satisfies it.\n"
+                                "- For EACH requirement output one line: "
+                                "'R<n>: PASS' or 'R<n>: FAIL — ' followed by a "
+                                "VERBATIM quote from the answer proving the "
+                                "violation.\n"
+                                "- If you cannot quote a violating passage from the "
+                                "answer, the mark is PASS.\n"
+                                "- Then output 'Q: <0-10>' rating base quality "
+                                "(completeness, specificity, format) of the answer "
+                                "against the task expectations. 10 is rare.\n"
+                                "- Output nothing else."
+                            ),
+                        },
+                        {
+                            "role": "user",
+                            "content": (
+                                f"Task expectations:\n{judge_rubric}\n\n"
+                                f"Requirements from human review:\n{req_lines}\n\n"
+                                f"Answer to grade:\n{text[:6000]}"
+                            ),
+                        },
+                    ]
+                else:
+                    judge_messages = [
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are a HARSH grader of an AI crew's final deliverable. "
+                                "Score 0-10 against the per-task expectations:\n"
+                                "- completeness: every expectation addressed, none skipped\n"
+                                "- specificity: concrete facts/sources/structure, no filler\n"
+                                "- fidelity: matches the requested format and scope exactly\n"
+                                "10 = flawless and exceptional (rare). 7 = solid with minor "
+                                "gaps. 5 = acceptable but generic. 3 = major omissions. "
+                                "0 = failed.\n"
+                                "First, in one or two sentences, name the SPECIFIC "
+                                "failures, quoting the exact expectation that was "
+                                "violated. Then write the final grade alone on the "
+                                "LAST line as a bare number."
+                            ),
+                        },
+                        {
+                            "role": "user",
+                            "content": (
+                                f"Objective: {inputs.get('request', objective)}\n"
+                                f"Expectations:\n{judge_rubric}\n\nFinal output:\n{text[:6000]}"
+                            ),
+                        },
+                    ]
                 try:
                     verdict = _sync_llm_completion(
                         loop,
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": (
-                                    "You are a HARSH grader of an AI crew's final deliverable. "
-                                    "Score 0-10 against the per-task expectations:\n"
-                                    "- completeness: every expectation addressed, none skipped\n"
-                                    "- specificity: concrete facts/sources/structure, no filler\n"
-                                    "- fidelity: matches the requested format and scope exactly\n"
-                                    "10 = flawless and exceptional (rare). 7 = solid with minor "
-                                    "gaps. 5 = acceptable but generic. 3 = major omissions. "
-                                    "0 = failed.\n"
-                                    "First, in one or two sentences, name the SPECIFIC "
-                                    "failures, quoting the exact expectation or human "
-                                    "requirement that was violated (e.g. wrong region, "
-                                    "rentals instead of sales, missing sources). Then "
-                                    "write the final grade alone on the LAST line as a "
-                                    "bare number."
-                                ),
-                            },
-                            {
-                                "role": "user",
-                                "content": (
-                                    f"Objective: {inputs.get('request', objective)}\n"
-                                    f"Expectations:\n{judge_rubric}\n\nFinal output:\n{text[:6000]}"
-                                ),
-                            },
-                        ],
+                        messages=judge_messages,
                         model=judge_model,
                         # Room for forced-thinking models (Kimi K2.x): even 300
                         # tokens were consumed entirely by reasoning, leaving
@@ -1635,15 +1808,28 @@ class PromptOptimizationService:
                 rationale_parts: List[str] = []
                 if verdict and str(verdict).strip():
                     rationale_parts.append(str(verdict).strip())
-                # LAST number wins: thinking models may reason (with incidental
-                # numbers) before stating the final grade.
-                matches = re.findall(r"\d+(?:\.\d+)?", verdict or "")
-                if matches:
-                    grades.append(max(0.0, min(10.0, float(matches[-1]))) / 10.0)
+                checklist_value = (
+                    _checklist_grade(verdict or "", len(human_requirements))
+                    if human_requirements
+                    else None
+                )
+                if checklist_value is not None:
+                    grades.append(checklist_value)
                 else:
-                    logger.warning(
-                        f"Crew optimization judge reply not numeric: {verdict!r}"
-                    )
+                    # LAST number wins: thinking models may reason (with
+                    # incidental numbers) before stating the final grade. A
+                    # number above 10 is treated as a percentage — clamping
+                    # alone turned a hallucinated "40" into a perfect 10/10.
+                    matches = re.findall(r"\d+(?:\.\d+)?", verdict or "")
+                    if matches:
+                        number = float(matches[-1])
+                        if 10.0 < number <= 100.0:
+                            number /= 10.0
+                        grades.append(max(0.0, min(10.0, number)) / 10.0)
+                    else:
+                        logger.warning(
+                            f"Crew optimization judge reply not numeric: {verdict!r}"
+                        )
                 # Registered judges grade the SAME deliverable here rather than
                 # running as separate MLflow scorers — trace-based scorers were
                 # each re-triggering their own crew execution (observed live as
@@ -1707,7 +1893,31 @@ class PromptOptimizationService:
                 prompt_uris=[prompt_uri],
                 optimizer=GepaPromptOptimizer(
                     reflection_model=reflection_uri,
-                    max_metric_calls=max_metric_calls,
+                    # METRIC calls are decoupled from crew EXECUTIONS: with
+                    # the caches (ours + gepa's) most metric calls are free
+                    # re-scores, so the user's number stays a hard cap on real
+                    # executions while GEPA gets iteration headroom. Observed
+                    # live without this: a 10-execution budget stopped after 4
+                    # executions because cached re-evaluations had consumed
+                    # the metric budget.
+                    max_metric_calls=max_metric_calls * 2 + 3,
+                    gepa_kwargs={
+                        # Default minibatch of 3 sampled our SINGLE training
+                        # example three times per step — every candidate cost
+                        # 3 crew executions racing the cache (two finished the
+                        # same second, observed live).
+                        "reflection_minibatch_size": 1,
+                        # Strict improvement rejected TIES: a candidate that
+                        # fully incorporated the human requirements scored
+                        # 0.9 vs 0.9 on the minibatch and was discarded
+                        # (proposals.json, observed live). Lateral moves must
+                        # survive so the search can leave a flat region.
+                        "acceptance_criterion": "improvement_or_equal",
+                        # gepa-side (candidate, example) result cache: skips
+                        # the metric call entirely on repeats, preserving the
+                        # metric budget for NEW candidates.
+                        "cache_evaluation": True,
+                    },
                 ),
                 scorers=[output_format, output_correct],
                 aggregation=aggregation,

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -1,0 +1,2043 @@
+"""
+Service for prompt optimization operations.
+
+Runs GEPA (via mlflow.genai.optimize_prompts) over a seeded meta-prompt:
+training examples are mined from the LLM interaction log (or supplied
+inline), the current effective template is registered in the MLflow
+Prompt Registry, GEPA searches for a better template against scorers,
+and the winner is stored on the run for explicit review-and-apply as a
+group-scoped template override (never the base row — the seeder
+overwrites base rows on startup).
+
+Run state lives in an in-process registry: the optimization itself is
+recorded durably in MLflow, but Kasal-side status is lost on backend
+restart. A `prompt_optimization_runs` table can replace the registry
+when this graduates from Phase 1.
+"""
+
+import asyncio
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from src.repositories.log_repository import LLMLogRepository
+from src.repositories.model_config_repository import ModelConfigRepository
+from src.schemas.prompt_optimization import PromptOptimizationRequest
+from src.schemas.template import PromptTemplateUpdate
+from src.services.template_service import TemplateService
+from src.utils.prompt_utils import robust_json_parser
+from src.utils.user_context import GroupContext
+
+logger = logging.getLogger(__name__)
+
+# Same fallback chain as the dispatcher: intent classification rides a fast model.
+DEFAULT_TARGET_MODEL = os.getenv(
+    "DEFAULT_DISPATCHER_MODEL", "databricks-llama-4-maverick"
+)
+
+MIN_EXAMPLES = 5
+
+
+def _extract_user_from_log(prompt: str) -> Optional[str]:
+    """Generation services log 'System: <template>\\nUser: <request>' — return
+    the user request part, or None when the marker is absent."""
+    if "\nUser: " not in prompt:
+        return None
+    return prompt.split("\nUser: ", 1)[1].strip() or None
+
+
+# ── Crew optimization: the crew's prompt fields travel through GEPA as ONE
+# labeled text document (GEPA mutates plain templates). Line-based parse so
+# multi-line field values survive the round trip.
+_CREW_DOC_FIELD_LABELS = {
+    "ROLE": "role",
+    "GOAL": "goal",
+    "BACKSTORY": "backstory",
+    "DESCRIPTION": "description",
+    "EXPECTED_OUTPUT": "expected_output",
+}
+
+
+def _serialize_crew_doc(agents: List[Any], tasks: List[Any]) -> tuple:
+    """Serialize crew prompt fields into a labeled document + the key set.
+
+    Returns (doc, field_keys) where keys look like 'agent.<id>.role'.
+    """
+    lines: List[str] = []
+    keys: List[str] = []
+    for agent in agents:
+        lines.append(f"[AGENT {agent.id}]")
+        for label, field in (
+            ("ROLE", "role"),
+            ("GOAL", "goal"),
+            ("BACKSTORY", "backstory"),
+        ):
+            lines.append(f"{label}: {str(getattr(agent, field, '') or '')}")
+            keys.append(f"agent.{agent.id}.{field}")
+        lines.append("")
+    for task in tasks:
+        lines.append(f"[TASK {task.id}]")
+        for label, field in (
+            ("DESCRIPTION", "description"),
+            ("EXPECTED_OUTPUT", "expected_output"),
+        ):
+            lines.append(f"{label}: {str(getattr(task, field, '') or '')}")
+            keys.append(f"task.{task.id}.{field}")
+        lines.append("")
+    return "\n".join(lines).strip(), keys
+
+
+def _parse_crew_doc(doc: str) -> Optional[Dict[str, str]]:
+    """Parse a (possibly GEPA-mutated) crew document back into field values.
+
+    Returns {key: text} or None when the document lost its structure —
+    callers score such candidates 0 WITHOUT executing the crew.
+    """
+    fields: Dict[str, str] = {}
+    entity_prefix: Optional[str] = None
+    current_key: Optional[str] = None
+    for raw_line in (doc or "").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[AGENT ") and line.endswith("]"):
+            entity_prefix = f"agent.{line[len('[AGENT '):-1].strip()}"
+            current_key = None
+            continue
+        if line.startswith("[TASK ") and line.endswith("]"):
+            entity_prefix = f"task.{line[len('[TASK '):-1].strip()}"
+            current_key = None
+            continue
+        matched = False
+        for label, field in _CREW_DOC_FIELD_LABELS.items():
+            if line.startswith(f"{label}:"):
+                if entity_prefix is None:
+                    return None
+                current_key = f"{entity_prefix}.{field}"
+                fields[current_key] = line[len(label) + 1 :].strip()
+                matched = True
+                break
+        if matched:
+            continue
+        if line and current_key:
+            fields[current_key] = f"{fields[current_key]}\n{line}".strip()
+    return fields or None
+
+
+# Categorical verdict scale for judges that answer in words rather than
+# numbers (MLflow's judge template often does: 'Satisfactory', 'Partial', …).
+_CATEGORICAL_GRADES = {
+    1.0: ("excellent", "perfect", "outstanding", "flawless", "exceptional"),
+    0.75: ("good", "great", "strong", "satisfactory", "yes", "true", "pass", "correct"),
+    0.5: (
+        "partial",
+        "partially correct",
+        "fair",
+        "moderate",
+        "average",
+        "mixed",
+        "acceptable",
+    ),
+    0.25: ("poor", "weak", "insufficient", "lacking"),
+    0.0: (
+        "bad",
+        "fail",
+        "failed",
+        "wrong",
+        "incorrect",
+        "no",
+        "false",
+        "unsatisfactory",
+    ),
+}
+
+
+def _judge_value_to_grade(value: Any) -> Optional[float]:
+    """Normalize a judge verdict (number, bool, or categorical word) to 0-1.
+
+    Returns None when the value carries no usable grade.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        number = float(value)
+        return max(0.0, min(1.0, number / 10.0 if number > 1.0 else number))
+    if isinstance(value, str):
+        text = value.strip().lower()
+        try:
+            number = float(text)
+            return max(0.0, min(1.0, number / 10.0 if number > 1.0 else number))
+        except ValueError:
+            pass
+        for grade, words in _CATEGORICAL_GRADES.items():
+            if text in words:
+                return grade
+    return None
+
+
+def _job_name_score(outputs: Any) -> float:
+    """Format scorer for generate_job_name: a short plain-text name (2-4 words,
+    no JSON/markdown artifacts)."""
+    text = str(outputs or "").strip().strip('"').strip()
+    if not text or "\n" in text or "{" in text or len(text) > 80:
+        return 0.0
+    words = len(text.split())
+    return 1.0 if 2 <= words <= 4 else 0.5 if 1 <= words <= 6 else 0.0
+
+
+# Per-template task wiring: where training inputs come from in the LLM log and
+# how outputs are scored. Adding an entry here (plus a schema/UI listing) is
+# all it takes to make another seeded template optimizable.
+TEMPLATE_TASKS: Dict[str, Dict[str, Any]] = {
+    "detect_intent": {
+        # dispatcher logs the raw user message as `prompt` under this endpoint
+        "log_endpoint": "detect-intent",
+        "input_key": "message",
+        "extract": None,
+    },
+    "generate_agent": {
+        "log_endpoint": "generate-agent",
+        "input_key": "request",
+        "extract": _extract_user_from_log,
+        "required_keys": ("name", "role", "goal", "backstory"),
+        "judge_system": (
+            "You judge an AI-agent generator. Given a user's request and the generated "
+            "agent JSON (name/role/goal/backstory), decide if the agent is a faithful, "
+            "specific, well-formed configuration for that request: the role matches the "
+            "domain, the goal is concrete with an action verb, and the backstory is "
+            "relevant professional expertise. Answer with EXACTLY one word: CORRECT or WRONG."
+        ),
+    },
+    "generate_task": {
+        "log_endpoint": "generate-task",
+        "input_key": "request",
+        "extract": _extract_user_from_log,
+        "required_keys": ("name", "description", "expected_output"),
+        "judge_system": (
+            "You judge an AI-task generator. Given a user's request and the generated "
+            "task JSON (name/description/expected_output), decide if the task is a "
+            "faithful, specific, well-formed configuration for that request: the "
+            "description covers context/objective/method and the expected output names "
+            "a checkable deliverable and its structure. Answer with EXACTLY one word: "
+            "CORRECT or WRONG."
+        ),
+    },
+    "generate_crew": {
+        "log_endpoint": "generate-crew",
+        "input_key": "request",
+        "extract": _extract_user_from_log,
+        "required_keys": ("agents", "tasks"),
+        "judge_system": (
+            "You judge an AI-crew generator. Given a user's goal and the generated crew "
+            "JSON (agents + tasks), decide if the crew is a faithful, minimal, "
+            "well-formed plan for that goal: agents have specific roles matching the "
+            "domain, every task is assigned to an existing agent, dependencies make "
+            "sense, and together the tasks accomplish the goal. Answer with EXACTLY "
+            "one word: CORRECT or WRONG."
+        ),
+    },
+    "generate_crew_plan": {
+        "log_endpoint": "generate-crew-plan",
+        "input_key": "request",
+        "extract": _extract_user_from_log,
+        "required_keys": ("complexity", "process_type", "agents", "tasks"),
+        "judge_system": (
+            "You judge an AI-crew PLANNER that outputs a skeleton only (complexity, "
+            "process_type, agent names/roles, task names with assignments). Given the "
+            "user's goal and the plan JSON, decide if the outline is faithful and "
+            "right-sized: the minimum agents needed, each task assigned to a listed "
+            "agent, and the tasks together covering the goal's distinct actions. "
+            "Answer with EXACTLY one word: CORRECT or WRONG."
+        ),
+    },
+    "generate_job_name": {
+        "log_endpoint": "generate-execution-name",
+        "input_key": "request",
+        "extract": _extract_user_from_log,
+        "format_fn": _job_name_score,
+        "judge_system": (
+            "You judge an AI job-run NAMER. Given a description of the agents/tasks "
+            "involved and the generated name, decide if the name is a concise (2-4 "
+            "word), descriptive title for that work — specific to the subject matter, "
+            "no generic filler like 'AI Job' or 'Crew Run'. Answer with EXACTLY one "
+            "word: CORRECT or WRONG."
+        ),
+    },
+}
+
+# The intent enum the detect_intent template contract allows.
+VALID_INTENTS = {
+    "generate_task",
+    "generate_agent",
+    "generate_crew",
+    "execute_crew",
+    "configure_crew",
+    "unknown",
+}
+
+# In-process run registry (see module docstring for the durability tradeoff).
+_RUNS: Dict[str, Dict[str, Any]] = {}
+_MAX_KEPT_RUNS = 50
+
+_PUBLIC_FIELDS = (
+    "run_id",
+    "template_name",
+    "status",
+    "dataset_size",
+    "model",
+    "initial_score",
+    "final_score",
+    "baseline_template",
+    "optimized_template",
+    "error",
+    "applied",
+    "created_at",
+    "kind",
+    "crew_id",
+    "baseline_fields",
+    "optimized_fields",
+    "executions_used",
+    "execution_cap",
+)
+
+
+def _intent_format_score(outputs: Any) -> float:
+    """Deterministic scorer: does the output honor the template's JSON contract?"""
+    try:
+        parsed = robust_json_parser(str(outputs))
+    except Exception:
+        return 0.0
+    if not isinstance(parsed, dict):
+        return 0.0
+    score = 0.0
+    if parsed.get("intent") in VALID_INTENTS:
+        score += 0.6
+    try:
+        confidence = float(parsed.get("confidence"))
+        if 0.0 <= confidence <= 1.0:
+            score += 0.2
+    except (TypeError, ValueError):
+        pass
+    if isinstance(parsed.get("extracted_info"), dict):
+        score += 0.1
+    if (
+        isinstance(parsed.get("suggested_prompt"), str)
+        and parsed["suggested_prompt"].strip()
+    ):
+        score += 0.1
+    return score
+
+
+def _json_keys_score(outputs: Any, required_keys: tuple) -> float:
+    """Generic format scorer: output parses as a JSON object and every required
+    key is present with a non-empty value (string, list, or object). Returns
+    the satisfied fraction."""
+    try:
+        parsed = robust_json_parser(str(outputs))
+    except Exception:
+        return 0.0
+    if not isinstance(parsed, dict):
+        return 0.0
+
+    def _ok(value: Any) -> bool:
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (list, dict)):
+            return len(value) > 0
+        return value is not None
+
+    satisfied = sum(1 for key in required_keys if _ok(parsed.get(key)))
+    return satisfied / len(required_keys) if required_keys else 0.0
+
+
+_JUDGE_SYSTEM = """You judge an intent classifier for a CrewAI workflow designer.
+Routing rules: the default intent is "generate_crew" (research, analysis, reporting,
+multi-step or goal-oriented requests, and any message with 2+ action verbs).
+"generate_agent" only when ONE agent/bot/assistant/chatbot is explicitly the entity
+created; "generate_task" only when a task is explicitly created; "execute_crew" for
+run/execute/start/launch; "configure_crew" for model/tools/settings changes.
+Given the user message and the predicted intent, answer with EXACTLY one word:
+CORRECT or WRONG."""
+
+
+def _preflight_reflection(reflection_uri: str, reflection_env: Dict[str, str]) -> None:
+    """One-token ping of GEPA's reflection model BEFORE any budget is spent.
+
+    A dead reflection model doesn't fail a run — GEPA just proposes zero
+    candidates and 'completes' at the baseline after burning the whole
+    execution budget (observed live with a retired provider model name).
+    """
+    import litellm
+
+    saved = {k: os.environ.get(k) for k in reflection_env}
+    try:
+        for k, v in reflection_env.items():
+            os.environ[k] = v
+        litellm_model = reflection_uri.replace(":/", "/", 1)
+        litellm.completion(
+            model=litellm_model,
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=1,
+        )
+    except Exception as e:
+        raise ValueError(
+            f"Reflection model '{reflection_uri}' failed a test call — the "
+            f"optimization cannot generate candidates with it. Pick a different "
+            f"reflection model. Provider error: {str(e)[:300]}"
+        )
+    finally:
+        for k, old in saved.items():
+            if old is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = old
+
+
+def _sync_llm_completion(
+    loop: asyncio.AbstractEventLoop,
+    messages: List[Dict[str, str]],
+    model: str,
+    max_tokens: int,
+    group_context: Optional[GroupContext] = None,
+    user_token: Optional[str] = None,
+) -> str:
+    """Run LLMManager.completion from a worker thread by submitting it to the
+    MAIN event loop. Never run it on a fresh loop (asyncio.run) — the app's
+    async DB engine is bound to the main loop, and cross-loop access deadlocks
+    holding the DB lock, wedging every request in the process.
+
+    The submitted Task does not inherit this thread's contextvars, so the
+    request's UserContext (group id + OBO token, which LLMManager needs for
+    API-key lookups) is re-established inside the coroutine.
+    """
+    from src.core.llm_manager import LLMManager
+    from src.utils.telemetry import KasalProduct, get_user_agent_header
+    from src.utils.user_context import UserContext
+
+    async def _with_context() -> str:
+        if group_context:
+            UserContext.set_group_context(group_context)
+        if user_token:
+            UserContext.set_user_token(user_token)
+        return await LLMManager.completion(
+            messages=messages,
+            model=model,
+            temperature=0.0,
+            max_tokens=max_tokens,
+            extra_headers=get_user_agent_header(KasalProduct.PROMPT_IMPROVEMENT),
+        )
+
+    future = asyncio.run_coroutine_threadsafe(_with_context(), loop)
+    return future.result(timeout=300)
+
+
+def _sync_run_crew(
+    loop: asyncio.AbstractEventLoop,
+    agents_yaml: Dict[str, Any],
+    tasks_yaml: Dict[str, Any],
+    model: str,
+    timeout: int,
+    group_context: Optional[GroupContext] = None,
+    user_token: Optional[str] = None,
+) -> str:
+    """Execute a crew (candidate prompt fields already applied) from a worker
+    thread by submitting to the MAIN loop, then poll to a terminal state.
+    Returns the final result text, or '' on failure/timeout (scored 0)."""
+
+    async def _run() -> str:
+        from src.schemas.execution import CrewConfig
+        from src.services.execution_service import ExecutionService
+        from src.utils.user_context import UserContext
+
+        if group_context:
+            UserContext.set_group_context(group_context)
+        if user_token:
+            UserContext.set_user_token(user_token)
+
+        service = ExecutionService()
+        created = await service.create_execution(
+            CrewConfig(
+                agents_yaml=agents_yaml,
+                tasks_yaml=tasks_yaml,
+                inputs={},
+                model=model,
+                execution_type="crew",
+            ),
+            None,
+            group_context,
+        )
+        execution_id = created.get("execution_id")
+        if not execution_id:
+            return ""
+        group_ids = group_context.group_ids if group_context else []
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(10)
+            # This coroutine runs as a background task with no request session —
+            # open a fresh one per poll (background work owns its sessions).
+            from src.db.session import async_session_factory
+
+            async with async_session_factory() as poll_session:
+                status = await ExecutionService(
+                    session=poll_session
+                ).get_execution_status(execution_id, group_ids)
+            if not status:
+                # Row may not be visible yet right after creation — keep polling.
+                continue
+            state = str(status.get("status", "")).upper()
+            if state in ("COMPLETED", "FAILED", "CANCELLED", "ERROR", "STOPPED"):
+                if state != "COMPLETED":
+                    return ""
+                result = status.get("result")
+                if isinstance(result, dict):
+                    return str(
+                        result.get("result")
+                        or result.get("output")
+                        or result.get("text")
+                        or result
+                    )
+                return str(result or "")
+        logger.warning(f"Crew optimization eval timed out for execution {execution_id}")
+        return ""
+
+    future = asyncio.run_coroutine_threadsafe(_run(), loop)
+    return future.result(timeout=timeout + 120)
+
+
+class PromptOptimizationService:
+    """Service for optimizing seeded prompt templates against logged usage."""
+
+    def __init__(self, session: Any):
+        self.session = session
+        self.log_repository = LLMLogRepository(session)
+        self.model_repository = ModelConfigRepository(session)
+
+    # ------------------------------------------------------------------ start
+
+    async def start_optimization(
+        self,
+        request: PromptOptimizationRequest,
+        group_context: Optional[GroupContext] = None,
+    ) -> Dict[str, Any]:
+        """Validate inputs, gather the training set, and launch the run in background."""
+        task_cfg = TEMPLATE_TASKS.get(request.template_name)
+        if not task_cfg:
+            raise ValueError(
+                f"Template '{request.template_name}' is not wired for optimization"
+            )
+
+        baseline = await TemplateService.get_effective_template_content(
+            request.template_name, group_context
+        )
+        if not baseline or not baseline.strip():
+            raise ValueError(
+                f"No effective template content found for '{request.template_name}'"
+            )
+
+        if request.examples:
+            examples = [e.strip() for e in request.examples if e and e.strip()]
+        else:
+            examples = await self._mine_examples(
+                endpoint=task_cfg["log_endpoint"],
+                group_context=group_context,
+                lookback_days=request.lookback_days,
+                max_examples=request.max_examples,
+                extract=task_cfg.get("extract"),
+            )
+        examples = examples[: request.max_examples]
+        if len(examples) < MIN_EXAMPLES:
+            raise ValueError(
+                f"Need at least {MIN_EXAMPLES} training examples, found {len(examples)}. "
+                f"Provide 'examples' explicitly or widen 'lookback_days'."
+            )
+
+        target_model = request.model or DEFAULT_TARGET_MODEL
+        judge_model = request.judge_model or target_model
+        reflection_uri, reflection_env = await self._resolve_reflection_model(
+            request.reflection_model or target_model, group_context
+        )
+        registry_uri, prompt_name = await self._resolve_registry(
+            request.template_name, group_context
+        )
+
+        run_id = uuid.uuid4().hex[:12]
+        group_id = group_context.primary_group_id if group_context else None
+        run: Dict[str, Any] = {
+            "run_id": run_id,
+            "template_name": request.template_name,
+            "status": "pending",
+            "dataset_size": len(examples),
+            "model": target_model,
+            "group_id": group_id,
+            "baseline_template": baseline,
+            "applied": False,
+            "created_at": datetime.utcnow(),
+        }
+        _RUNS[run_id] = run
+        self._prune_runs()
+
+        # Keep a strong reference on the run entry so the task isn't GC'd.
+        run["task"] = asyncio.create_task(
+            self._run_optimization(
+                run_id=run_id,
+                template_name=request.template_name,
+                baseline=baseline,
+                examples=examples,
+                input_key=task_cfg["input_key"],
+                target_model=target_model,
+                judge_model=judge_model,
+                reflection_uri=reflection_uri,
+                reflection_env=reflection_env,
+                max_metric_calls=request.max_metric_calls,
+                registry_uri=registry_uri,
+                prompt_name=prompt_name,
+                group_context=group_context,
+            )
+        )
+        return {"run_id": run_id, "status": "pending", "dataset_size": len(examples)}
+
+    async def _mine_examples(
+        self,
+        endpoint: str,
+        group_context: Optional[GroupContext],
+        lookback_days: int,
+        max_examples: int,
+        extract=None,
+    ) -> List[str]:
+        """Pull distinct, successful inputs for `endpoint` from the LLM log."""
+        group_ids = group_context.group_ids if group_context else []
+        if not group_ids:
+            return []
+        cutoff = datetime.utcnow() - timedelta(days=lookback_days)
+        seen, examples = set(), []
+        page = 0
+        # Over-fetch pages (dedup shrinks them) but bound total scanned rows.
+        while len(examples) < max_examples and page < 20:
+            rows = await self.log_repository.get_logs_paginated_by_group(
+                page=page, per_page=100, endpoint=endpoint, group_ids=group_ids
+            )
+            if not rows:
+                break
+            for row in rows:
+                if row.created_at and row.created_at < cutoff:
+                    continue
+                if row.status != "success" or not row.prompt:
+                    continue
+                text = extract(row.prompt) if extract else row.prompt.strip()
+                if not text:
+                    continue
+                # Data hygiene — the log contains rows that are not real user
+                # requests and would put an unfixable floor under the objective:
+                # slash commands (intercepted client-side, and outside the
+                # template's intent enum) and system error strings.
+                if text.startswith("/"):
+                    continue
+                if "failed:" in text[:80].lower() or len(text) > 4000:
+                    continue
+                key = text.lower()
+                if not text or key in seen:
+                    continue
+                seen.add(key)
+                examples.append(text)
+                if len(examples) >= max_examples:
+                    break
+            page += 1
+        return examples
+
+    # Providers whose GEPA reflection calls authenticate via a single API-key
+    # env var (litellm convention), with the key held in Kasal's key store.
+    _REFLECTION_KEY_ENV = {
+        "openai": "OPENAI_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "gemini": "GEMINI_API_KEY",
+        "groq": "GROQ_API_KEY",
+        "mistral": "MISTRAL_API_KEY",
+    }
+
+    async def _resolve_reflection_model(
+        self, model_key: str, group_context: Optional[GroupContext] = None
+    ) -> tuple:
+        """Map a Kasal model key to an MLflow/GEPA reflection-model URI.
+
+        GEPA invokes its reflection model itself (outside LLMManager), so the
+        key must become a provider URI plus any env vars the provider needs —
+        including the provider API key from Kasal's group-scoped key store.
+        """
+        config = await self.model_repository.find_by_key(model_key)
+        provider = (getattr(config, "provider", None) or "").lower() if config else ""
+        # The provider API expects the config's `name` (llm_manager does this
+        # translation too) — sending the Kasal KEY 400s when they differ
+        # (observed live: key deepseek-v3.1-non-thinking vs API name).
+        api_model = (
+            (getattr(config, "name", None) or model_key) if config else model_key
+        )
+        if provider == "databricks":
+            return f"databricks:/{api_model}", {}
+        if provider == "vllm":
+            # OpenAI-compatible endpoint — same env resolution as llm_manager.
+            return f"openai:/{api_model}", {
+                "OPENAI_API_BASE": os.getenv(
+                    "VLLM_BASE_URL", "http://localhost:8081/v1"
+                ),
+                "OPENAI_API_KEY": os.getenv("VLLM_API_KEY", "vllm"),
+            }
+        if provider == "kimi":
+            # Kimi (Moonshot AI) — OpenAI-compatible endpoint with the key from
+            # Kasal's key store, mirroring llm_manager's kimi routing.
+            from src.services.api_keys_service import ApiKeysService
+
+            group_id = group_context.primary_group_id if group_context else None
+            api_key = await ApiKeysService.get_provider_api_key(
+                "kimi", group_id=group_id
+            )
+            if not api_key:
+                raise ValueError(
+                    "Reflection model needs a Kimi API key — add KIMI_API_KEY "
+                    "under Configuration -> API Keys."
+                )
+            return f"openai:/{api_model}", {
+                "OPENAI_API_BASE": os.getenv(
+                    "KIMI_ENDPOINT", "https://api.moonshot.ai/v1"
+                ),
+                "OPENAI_API_KEY": api_key,
+            }
+        if provider in self._REFLECTION_KEY_ENV:
+            env: Dict[str, str] = {}
+            env_name = self._REFLECTION_KEY_ENV[provider]
+            try:
+                from src.services.api_keys_service import ApiKeysService
+
+                group_id = group_context.primary_group_id if group_context else None
+                api_key = await ApiKeysService.get_provider_api_key(
+                    provider, group_id=group_id
+                )
+                if api_key:
+                    env[env_name] = api_key
+            except Exception as key_err:
+                logger.warning(
+                    f"Could not fetch {provider} API key for reflection model: {key_err}"
+                )
+            # Fall back to a pre-set env var when the store has no key.
+            if env_name not in env and not os.getenv(env_name):
+                raise ValueError(
+                    f"Reflection model '{model_key}' needs a {provider} API key "
+                    f"(configure it under API Keys) or pass 'reflection_model' "
+                    f"with a different provider."
+                )
+            return f"{provider}:/{api_model}", env
+        raise ValueError(
+            f"Reflection model '{model_key}' has unsupported provider '{provider or 'unknown'}' "
+            f"(supported: databricks, vllm, kimi, {', '.join(sorted(self._REFLECTION_KEY_ENV))}). "
+            f"Pass 'reflection_model' explicitly."
+        )
+
+    async def _resolve_registry(
+        self, template_name: str, group_context: Optional[GroupContext]
+    ) -> tuple:
+        """Resolve the MLflow prompt-registry destination and prompt name.
+
+        Policy: managed MLflow (Databricks Unity Catalog prompt registry) is
+        the default. A LOCAL MLflow server is used only when explicitly
+        enabled for development: MCP_SERVER_ENABLED=true plus
+        MLFLOW_TRACKING_URI (e.g. http://127.0.0.1:5555).
+        """
+        group_id = group_context.primary_group_id if group_context else None
+        safe_group = "".join(
+            c if c.isalnum() or c in "-_" else "_" for c in (group_id or "base")
+        )
+        base_name = f"kasal_{template_name}_{safe_group}"
+
+        local_enabled = os.getenv("MCP_SERVER_ENABLED", "").lower() == "true"
+        # main.py force-overwrites MLFLOW_TRACKING_URI to "databricks" at
+        # startup; the value the process was LAUNCHED with is preserved in
+        # KASAL_LAUNCH_MLFLOW_TRACKING_URI. Guard against databricks-schemed
+        # values either way — local mode means a local/OSS server.
+        local_uri = os.getenv("KASAL_LAUNCH_MLFLOW_TRACKING_URI") or os.getenv(
+            "MLFLOW_TRACKING_URI"
+        )
+        if local_enabled and local_uri and not local_uri.startswith("databricks"):
+            return local_uri, base_name
+
+        # Managed MLflow: UC prompt registry needs a three-level name from the
+        # workspace's configured catalog + schema.
+        from src.services.databricks_service import DatabricksService
+
+        db_config = await DatabricksService(
+            self.session, group_id=group_id
+        ).get_databricks_config()
+        catalog = getattr(db_config, "catalog", None) if db_config else None
+        # schema field is `db_schema` (aliased "schema"); reading "schema"
+        # returns BaseModel.schema (a method) — same trap as mlflow_parent_setup.
+        schema = getattr(db_config, "db_schema", None) if db_config else None
+        if not (catalog and schema):
+            raise ValueError(
+                "Prompt optimization uses the managed MLflow (Unity Catalog) prompt "
+                "registry, which requires a catalog and schema in the Databricks "
+                "configuration. For local development set MCP_SERVER_ENABLED=true and "
+                "MLFLOW_TRACKING_URI (e.g. http://127.0.0.1:5555) to use a local "
+                "MLflow server instead."
+            )
+        return "databricks-uc", f"{catalog}.{schema}.{base_name}"
+
+    # ------------------------------------------------------------ background
+
+    async def _run_optimization(self, run_id: str, sync_fn=None, **kwargs) -> None:
+        run = _RUNS.get(run_id)
+        if run is None:
+            return
+        run["status"] = "running"
+        try:
+            result = await asyncio.to_thread(
+                sync_fn or self._execute_optimization_sync,
+                loop=asyncio.get_running_loop(),
+                **kwargs,
+            )
+            run.update(result)
+            run["status"] = "completed"
+            logger.info(
+                f"Prompt optimization {run_id} completed: "
+                f"{result.get('initial_score')} -> {result.get('final_score')}"
+            )
+        except Exception as e:
+            import traceback as _tb
+
+            if run.get("cancel_requested"):
+                logger.info(f"Prompt optimization {run_id} cancelled by user")
+                run["status"] = "cancelled"
+                run["error"] = None
+                return
+            logger.error(f"Prompt optimization {run_id} failed: {e}", exc_info=True)
+            run["status"] = "failed"
+            # Keep the deepest frames — the surface message alone has proven
+            # insufficient to locate failures inside optimizer internals.
+            run["error"] = (
+                f"{e}\n\n{''.join(_tb.format_exc().splitlines(keepends=True)[-30:])}"
+            )
+
+    @staticmethod
+    def _execute_optimization_sync(
+        loop: asyncio.AbstractEventLoop,
+        template_name: str,
+        baseline: str,
+        examples: List[str],
+        input_key: str,
+        target_model: str,
+        judge_model: str,
+        reflection_uri: str,
+        reflection_env: Dict[str, str],
+        max_metric_calls: int,
+        registry_uri: str,
+        prompt_name: str,
+        group_context: Optional[GroupContext] = None,
+    ) -> Dict[str, Any]:
+        """The blocking optimization body — runs in a worker thread."""
+        user_token = (
+            getattr(group_context, "access_token", None) if group_context else None
+        )
+        # Quiet MLflow's background telemetry consumer — it resolves the
+        # tracking scheme over HTTP with lazy imports, one of the threads in
+        # the import-lock deadlock below. Must be set before mlflow import.
+        os.environ.setdefault("MLFLOW_DISABLE_TELEMETRY", "true")
+
+        import mlflow
+        from mlflow.genai import optimize_prompts
+        from mlflow.genai.optimize import GepaPromptOptimizer
+        from mlflow.genai.scorers import scorer
+
+        # Pre-import every module that MLflow imports LAZILY from background
+        # threads during this flow: register_prompt spawns an async
+        # link-prompt-to-experiment thread and optimize_prompts enables openai
+        # autologging via import hooks — concurrent lazy imports across those
+        # threads deadlock on importlib module locks (observed live via
+        # py-spy). With the modules already in sys.modules, nothing imports.
+        # The openai submodules matter most: mlflow/openai/autolog.py imports
+        # them lazily inside its import-hook critical section, and the openai
+        # package itself lazy-loads submodules (so importing the parent is NOT
+        # enough — py-spy showed successive deadlocks marching through beta,
+        # then responses). This list mirrors autolog's actual imports; with
+        # everything already in sys.modules our thread takes no import locks
+        # while MLflow's background threads run their own lazy imports.
+        for _mod in (
+            "openai",
+            "openai.resources",
+            "openai.resources.chat.completions",
+            "openai.resources.completions",
+            "openai.resources.embeddings",
+            "openai.resources.images",
+            "openai.resources.beta.chat.completions",
+            "openai.resources.responses",
+            "litellm",
+            "databricks.sdk",
+            "mlflow.openai",
+        ):
+            try:
+                __import__(_mod)
+            except ImportError:
+                pass
+
+        # Prompt-registry destination (resolved by _resolve_registry: managed
+        # UC by default, local server only when explicitly enabled). Only the
+        # REGISTRY is pointed there — the app's global tracking config for
+        # tracing is left untouched. Belt and braces: set the module global
+        # AND the env var (for optimize_prompts internals), and additionally
+        # pin an explicit client for our own calls — in-process something can
+        # reset the global between our set and the call (observed live), and a
+        # client carries its registry_uri immutably.
+        os.environ["MLFLOW_REGISTRY_URI"] = registry_uri
+        mlflow.set_registry_uri(registry_uri)
+        logger.info(
+            f"Prompt optimization registry: requested={registry_uri} "
+            f"effective={mlflow.get_registry_uri()}"
+        )
+        client = mlflow.MlflowClient(registry_uri=registry_uri)
+
+        # In LOCAL mode, redirect TRACKING to the local server for the whole
+        # register→optimize span and restore after. This is not just for the
+        # optimizer: register_prompt itself resolves the default experiment
+        # (MLFLOW_EXPERIMENT_NAME) against the TRACKING store, which is
+        # globally "databricks" (main.py) and unauthenticated in local dev.
+        # Side benefit: the optimization is visible in the local MLflow UI.
+        local_mode = not registry_uri.startswith("databricks")
+        prev_tracking = mlflow.get_tracking_uri()
+        if local_mode:
+            mlflow.set_tracking_uri(registry_uri)
+
+        # Suppress experiment resolution for the whole span: register_prompt
+        # spawns an async link-prompt-to-experiment thread when
+        # MLFLOW_EXPERIMENT_NAME/_ID resolve, and that thread deadlocks with
+        # autologging's import hooks on importlib module locks (py-spy
+        # verified twice). Prompt↔experiment linking isn't needed here.
+        saved_exp_env = {
+            k: os.environ.pop(k, None)
+            for k in ("MLFLOW_EXPERIMENT_NAME", "MLFLOW_EXPERIMENT_ID")
+        }
+
+        def _restore_span_env() -> None:
+            if local_mode:
+                mlflow.set_tracking_uri(prev_tracking)
+            for k, old in saved_exp_env.items():
+                if old is not None:
+                    os.environ[k] = old
+
+        logger.info(f"Prompt optimization stage=register registry={registry_uri}")
+        try:
+            prompt_version = client.register_prompt(
+                name=prompt_name,
+                template=baseline,
+                commit_message="baseline registered by Kasal prompt optimization",
+            )
+        except Exception:
+            _restore_span_env()
+            raise
+        prompt_uri = prompt_version.uri
+        logger.info(f"Prompt optimization stage=optimize prompt_uri={prompt_uri}")
+
+        def predict_fn(**inputs) -> str:
+            # Loading via the registry URI is what lets the optimizer inject
+            # candidate templates without knowing our LLM stack.
+            candidate = client.load_prompt(prompt_uri)
+            return _sync_llm_completion(
+                loop,
+                messages=[
+                    {"role": "system", "content": candidate.template},
+                    {"role": "user", "content": str(inputs[input_key])},
+                ],
+                model=target_model,
+                max_tokens=1000,
+                group_context=group_context,
+                user_token=user_token,
+            )
+
+        task_cfg = TEMPLATE_TASKS[template_name]
+
+        @scorer
+        def output_format(outputs) -> float:
+            if template_name == "detect_intent":
+                return _intent_format_score(outputs)
+            if task_cfg.get("format_fn"):
+                return task_cfg["format_fn"](outputs)
+            return _json_keys_score(outputs, task_cfg["required_keys"])
+
+        @scorer
+        def output_correct(inputs, outputs) -> float:
+            if template_name == "detect_intent":
+                try:
+                    parsed = robust_json_parser(str(outputs))
+                    predicted = (
+                        parsed.get("intent") if isinstance(parsed, dict) else None
+                    )
+                except Exception:
+                    predicted = None
+                if predicted not in VALID_INTENTS:
+                    return 0.0
+                judge_system = _JUDGE_SYSTEM
+                judge_user = (
+                    f"User message: {inputs[input_key]}\nPredicted intent: {predicted}"
+                )
+            else:
+                judge_system = task_cfg["judge_system"]
+                judge_user = (
+                    f"User request: {inputs[input_key]}\nGenerated output: {outputs}"
+                )
+            verdict = _sync_llm_completion(
+                loop,
+                messages=[
+                    {"role": "system", "content": judge_system},
+                    {"role": "user", "content": judge_user},
+                ],
+                model=judge_model,
+                # Room for forced-thinking judges (Kimi K2.x): 300 tokens of
+                # allowance was consumed entirely by reasoning, leaving empty
+                # visible content (observed live).
+                max_tokens=1500,
+                group_context=group_context,
+                user_token=user_token,
+            )
+            # Check the verdict's TAIL so reasoning text mentioning "correct"
+            # doesn't count — the instructed final word is what matters.
+            tail = (verdict or "").strip().upper()[-40:]
+            negative = "WRONG" in tail or "INCORRECT" in tail
+            return 1.0 if "CORRECT" in tail and not negative else 0.0
+
+        def aggregation(scores: Dict[str, Any]) -> float:
+            fmt = float(scores.get("output_format") or 0.0)
+            correct = float(scores.get("output_correct") or 0.0)
+            return 0.4 * fmt + 0.6 * correct
+
+        train_data = [
+            {"inputs": {input_key: ex}, "expectations": {}} for ex in examples
+        ]
+
+        saved_env = {k: os.environ.get(k) for k in reflection_env}
+        # Mark every autolog flavor disabled for the span: optimize_prompts'
+        # evaluation wrapper otherwise registers import hooks that lazily
+        # import each installed flavor module (openai, crewai, ...) inside a
+        # lock-guarded critical section — which deadlocks against MLflow's own
+        # background threads on importlib locks (py-spy verified across five
+        # runs, each stuck one flavor further). With disable=True the wrapper
+        # skips the flavor entirely: no hooks, no imports, nothing to deadlock.
+        from mlflow.models.evaluation.utils.trace import FLAVOR_TO_MODULE_NAME
+        from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
+
+        saved_autolog_flags: Dict[str, Any] = {}
+        for _flavor in FLAVOR_TO_MODULE_NAME:
+            cfg = AUTOLOGGING_INTEGRATIONS.setdefault(_flavor, {})
+            saved_autolog_flags[_flavor] = cfg.get("disable")
+            cfg["disable"] = True
+
+        # Quiet the JSON-recovery parser for the span: candidate templates that
+        # break the output contract are EXPECTED here (that's what the format
+        # scorer is for) and each one otherwise emits a burst of parse-recovery
+        # ERROR logs.
+        _parser_logger = logging.getLogger("src.utils.prompt_utils")
+        _prev_parser_level = _parser_logger.level
+        _parser_logger.setLevel(logging.CRITICAL)
+
+        # Tracking is already redirected in local mode (see above); this
+        # try/finally owns restoring it once the optimization ends.
+        try:
+            for k, v in reflection_env.items():
+                os.environ[k] = v
+            result = optimize_prompts(
+                predict_fn=predict_fn,
+                train_data=train_data,
+                prompt_uris=[prompt_uri],
+                optimizer=GepaPromptOptimizer(
+                    reflection_model=reflection_uri,
+                    max_metric_calls=max_metric_calls,
+                ),
+                scorers=[output_format, output_correct],
+                aggregation=aggregation,
+                # Local mode: track into the local server (visible in its UI).
+                # Managed mode: registry artifacts suffice; skip tracking writes.
+                enable_tracking=local_mode,
+            )
+        finally:
+            _parser_logger.setLevel(_prev_parser_level)
+            _restore_span_env()
+            for _flavor, old_flag in saved_autolog_flags.items():
+                if old_flag is None:
+                    AUTOLOGGING_INTEGRATIONS.get(_flavor, {}).pop("disable", None)
+                else:
+                    AUTOLOGGING_INTEGRATIONS[_flavor]["disable"] = old_flag
+            for k, old in saved_env.items():
+                if old is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = old
+
+        optimized = result.optimized_prompts[0]
+        return {
+            "optimized_template": optimized.template,
+            "initial_score": _to_float(getattr(result, "initial_eval_score", None)),
+            "final_score": _to_float(getattr(result, "final_eval_score", None)),
+            "prompt_uri": getattr(optimized, "uri", None),
+        }
+
+    # ----------------------------------------------------------- crew (GEPA)
+
+    async def start_crew_optimization(
+        self, request: Any, group_context: Optional[GroupContext] = None
+    ) -> Dict[str, Any]:
+        """GEPA over a saved crew's prompt fields, with REAL crew executions as
+        the evaluation: every metric call runs the crew (tools included) and a
+        judge scores the final deliverable. Expensive by design — the budget is
+        the number of crew executions."""
+        from src.repositories.agent_repository import AgentRepository
+        from src.repositories.crew_repository import CrewRepository
+        from src.repositories.task_repository import TaskRepository
+
+        group_ids = group_context.group_ids if group_context else []
+        # The crews PK is a UUID column — normalize the string id and treat any
+        # malformed value the same as not-found (clean 400, not a 500).
+        try:
+            crew_key = uuid.UUID(str(request.crew_id))
+        except (ValueError, AttributeError):
+            raise ValueError(f"Crew '{request.crew_id}' not found")
+        crew = await CrewRepository(self.session).get_by_group(crew_key, group_ids)
+        if crew is None:
+            raise ValueError(f"Crew '{request.crew_id}' not found")
+
+        agent_repo = AgentRepository(self.session)
+        task_repo = TaskRepository(self.session)
+        agents = [
+            a for a in [await agent_repo.get(i) for i in (crew.agent_ids or [])] if a
+        ]
+        tasks = [
+            t for t in [await task_repo.get(i) for i in (crew.task_ids or [])] if t
+        ]
+        if not agents or not tasks:
+            raise ValueError("Crew has no agent/task records to optimize")
+
+        baseline_doc, field_keys = _serialize_crew_doc(agents, tasks)
+        baseline_fields = _parse_crew_doc(baseline_doc) or {}
+
+        # Execution payload bases (candidate fields are overlaid per eval).
+        agent_name_by_id = {str(a.id): a.name for a in agents}
+        agents_yaml = {
+            str(a.name): {
+                "name": a.name,
+                "role": a.role,
+                "goal": a.goal,
+                "backstory": a.backstory,
+                "tools": a.tools or [],
+                "llm": a.llm,
+            }
+            for a in agents
+        }
+        tasks_yaml = {
+            str(t.name): {
+                "name": t.name,
+                "description": t.description,
+                "expected_output": t.expected_output,
+                "tools": t.tools or [],
+                "agent": agent_name_by_id.get(str(t.agent_id), ""),
+                "async_execution": False,
+                "context": [],
+                "_field_prefix": f"task.{t.id}",
+            }
+            for t in tasks
+        }
+        for a in agents:
+            agents_yaml[str(a.name)]["_field_prefix"] = f"agent.{a.id}"
+
+        objective = f"Crew '{crew.name}': " + "; ".join(
+            (t.description or "")[:120] for t in tasks
+        )
+        rubric = "\n".join(f"- {t.name}: {t.expected_output}" for t in tasks)
+        if request.guidance:
+            rubric += f"\nAdditional guidance: {request.guidance}"
+
+        # HUMAN JUDGMENT: fold this crew's real user feedback (chat 👍/👎 with
+        # comments) into the judge's rubric so the automated grade reflects what
+        # actual users praised or flagged, not just the task contracts.
+        try:
+            from src.repositories.crew_feedback_repository import CrewFeedbackRepository
+
+            feedback = await CrewFeedbackRepository(
+                self.session
+            ).list_by_crew_and_group(str(crew.id), group_ids)
+            complaints = [
+                f.comment.strip()
+                for f in feedback
+                if f.rating == "down" and f.comment and f.comment.strip()
+            ][:8]
+            praise = [
+                f.comment.strip()
+                for f in feedback
+                if f.rating == "up" and f.comment and f.comment.strip()
+            ][:4]
+            if complaints:
+                rubric += (
+                    "\nUsers flagged these problems in past runs (penalize any recurrence):\n"
+                    + "\n".join(f"- {c}" for c in complaints)
+                )
+            if praise:
+                rubric += "\nUsers praised (preserve these qualities):\n" + "\n".join(
+                    f"- {p}" for p in praise
+                )
+        except Exception as feedback_err:
+            logger.warning(f"Could not load crew feedback for rubric: {feedback_err}")
+
+        target_model = request.model or DEFAULT_TARGET_MODEL
+        judge_model = request.judge_model or target_model
+        reflection_uri, reflection_env = await self._resolve_reflection_model(
+            request.reflection_model or target_model, group_context
+        )
+        registry_uri, _ = await self._resolve_registry("crew", group_context)
+        safe_group = "".join(
+            c if c.isalnum() or c in "-_" else "_"
+            for c in (group_context.primary_group_id if group_context else "base")
+            or "base"
+        )
+        prompt_name = f"kasal_crew_{str(crew.id).replace('-', '')[:12]}_{safe_group}"
+        if registry_uri == "databricks-uc":
+            # UC needs the catalog.schema prefix _resolve_registry computed for
+            # its own name; recompute with the crew-specific leaf.
+            _, uc_name = await self._resolve_registry("crew", group_context)
+            prompt_name = uc_name.rsplit(".", 1)[0] + "." + prompt_name
+
+        run_id = uuid.uuid4().hex[:12]
+        group_id = group_context.primary_group_id if group_context else None
+        run: Dict[str, Any] = {
+            "run_id": run_id,
+            "template_name": f"crew:{crew.name}",
+            "kind": "crew",
+            "crew_id": str(crew.id),
+            "status": "pending",
+            "executions_used": 0,
+            "execution_cap": request.max_metric_calls,
+            "dataset_size": 1,
+            "model": target_model,
+            "group_id": group_id,
+            "baseline_template": baseline_doc,
+            "baseline_fields": baseline_fields,
+            "applied": False,
+            "created_at": datetime.utcnow(),
+        }
+        _RUNS[run_id] = run
+        self._prune_runs()
+
+        run["task"] = asyncio.create_task(
+            self._run_optimization(
+                run_id=run_id,
+                sync_fn=self._execute_crew_optimization_sync,
+                baseline_doc=baseline_doc,
+                field_keys=field_keys,
+                objective=objective,
+                rubric=rubric,
+                agents_yaml=agents_yaml,
+                tasks_yaml=tasks_yaml,
+                target_model=target_model,
+                judge_model=judge_model,
+                reflection_uri=reflection_uri,
+                reflection_env=reflection_env,
+                max_metric_calls=request.max_metric_calls,
+                execution_timeout=request.execution_timeout_seconds,
+                registry_uri=registry_uri,
+                prompt_name=prompt_name,
+                crew_id=str(crew.id),
+                cancel_run_id=run_id,
+                group_context=group_context,
+            )
+        )
+        return {"run_id": run_id, "status": "pending", "dataset_size": 1}
+
+    @staticmethod
+    def _execute_crew_optimization_sync(
+        loop: asyncio.AbstractEventLoop,
+        baseline_doc: str,
+        field_keys: List[str],
+        objective: str,
+        rubric: str,
+        agents_yaml: Dict[str, Any],
+        tasks_yaml: Dict[str, Any],
+        target_model: str,
+        judge_model: str,
+        reflection_uri: str,
+        reflection_env: Dict[str, str],
+        max_metric_calls: int,
+        execution_timeout: int,
+        registry_uri: str,
+        prompt_name: str,
+        crew_id: str = "",
+        cancel_run_id: str = "",
+        group_context: Optional[GroupContext] = None,
+    ) -> Dict[str, Any]:
+        """Blocking crew-optimization body (worker thread). Mirrors the
+        template body's MLflow span setup; predict = execute the crew."""
+        import copy
+
+        user_token = (
+            getattr(group_context, "access_token", None) if group_context else None
+        )
+        os.environ.setdefault("MLFLOW_DISABLE_TELEMETRY", "true")
+        import mlflow
+        from mlflow.genai import optimize_prompts
+        from mlflow.genai.optimize import GepaPromptOptimizer
+        from mlflow.genai.scorers import scorer
+        from mlflow.models.evaluation.utils.trace import FLAVOR_TO_MODULE_NAME
+        from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
+
+        os.environ["MLFLOW_REGISTRY_URI"] = registry_uri
+        mlflow.set_registry_uri(registry_uri)
+        client = mlflow.MlflowClient(registry_uri=registry_uri)
+
+        local_mode = not registry_uri.startswith("databricks")
+        prev_tracking = mlflow.get_tracking_uri()
+        if local_mode:
+            mlflow.set_tracking_uri(registry_uri)
+        saved_exp_env = {
+            k: os.environ.pop(k, None)
+            for k in ("MLFLOW_EXPERIMENT_NAME", "MLFLOW_EXPERIMENT_ID")
+        }
+        saved_autolog_flags: Dict[str, Any] = {}
+        for _flavor in FLAVOR_TO_MODULE_NAME:
+            cfg = AUTOLOGGING_INTEGRATIONS.setdefault(_flavor, {})
+            saved_autolog_flags[_flavor] = cfg.get("disable")
+            cfg["disable"] = True
+        saved_env = {k: os.environ.get(k) for k in reflection_env}
+
+        try:
+            for k, v in reflection_env.items():
+                os.environ[k] = v
+
+            # Fail fast on a dead reflection model — before ANY crew execution.
+            _preflight_reflection(reflection_uri, reflection_env)
+
+            prompt_version = client.register_prompt(
+                name=prompt_name,
+                template=baseline_doc,
+                commit_message="crew baseline registered by Kasal prompt optimization",
+            )
+            prompt_uri = prompt_version.uri
+            logger.info(f"Crew optimization stage=optimize prompt_uri={prompt_uri}")
+
+            # Pin the experiment AFTER register_prompt (the experiment lookup
+            # before registration is what spawned the deadlocking link thread).
+            # Traces, registered judges, and assessments are all per-experiment,
+            # and the request-context endpoints resolve MLFLOW_EXPERIMENT_NAME —
+            # the run must land on the SAME experiment or judges/evals become
+            # invisible to each other (observed: scorers registered on 'kasal',
+            # run searching the default experiment).
+            if local_mode:
+                exp_name = saved_exp_env.get("MLFLOW_EXPERIMENT_NAME") or "kasal"
+                try:
+                    mlflow.set_experiment(exp_name)
+                except Exception as exp_err:
+                    logger.warning(f"Could not pin experiment '{exp_name}': {exp_err}")
+
+            # HUMAN JUDGMENT via MLflow Assessments: every evaluation logs its
+            # deliverable as a trace (tagged kasal_crew_id); Feedback and
+            # Expectations the user adds on those traces in the MLflow UI are
+            # harvested here and folded into the judge's rubric on the NEXT run.
+            judge_rubric = rubric
+            objective_for_training = objective
+            if local_mode and crew_id:
+                try:
+                    prior = mlflow.search_traces(
+                        filter_string=f"tags.kasal_crew_id = '{crew_id}'",
+                        max_results=50,
+                        return_type="list",
+                    )
+                    notes: List[str] = []
+                    for trace in prior:
+                        for assessment in trace.search_assessments() or []:
+                            name = getattr(assessment, "name", "") or ""
+                            value = getattr(
+                                getattr(assessment, "feedback", None), "value", None
+                            )
+                            if value is None:
+                                value = getattr(
+                                    getattr(assessment, "expectation", None),
+                                    "value",
+                                    None,
+                                )
+                            rationale = getattr(assessment, "rationale", None) or ""
+                            if value is not None or rationale:
+                                notes.append(
+                                    f"- {name}: {value if value is not None else ''} {rationale}".strip()
+                                )
+                    if notes:
+                        human_notes = "\n".join(notes[-12:])
+                        judge_rubric += (
+                            "\nHuman assessments on previous optimization answers "
+                            "(treat as authoritative grading guidance):\n" + human_notes
+                        )
+                        # CRITICAL: the requirements must ALSO reach GEPA's
+                        # reflection model, which only sees training inputs and
+                        # scorer feedback — a judge that grades 0 "because
+                        # wrong region" is useless to a mutator that never
+                        # learns the region requirement (observed live: flat
+                        # 0-scores with mutations blind to the human's why).
+                        objective_for_training = (
+                            objective
+                            + "\nHard requirements from human review of past answers:\n"
+                            + human_notes
+                        )
+                        logger.info(
+                            f"Crew optimization: folded {len(notes)} human assessments into the rubric"
+                        )
+                except Exception as assess_err:
+                    logger.warning(
+                        f"Could not harvest MLflow assessments: {assess_err}"
+                    )
+
+            # CUSTOM JUDGES: LLM judges registered on the local MLflow
+            # experiment ("Create LLM judge" in the MLflow UI) participate in
+            # scoring alongside the built-in judge — users author evaluation
+            # criteria there and optimization honors them automatically.
+            registered_scorers: List[Any] = []
+            if local_mode:
+                try:
+                    from mlflow.genai.scorers import list_scorers
+
+                    # Only judges ASSIGNED to this crew (scoped by name prefix)
+                    # participate — the shared library is inert until assigned.
+                    crew_prefix = (
+                        PromptOptimizationService._crew_judge_prefix(crew_id)
+                        if crew_id
+                        else None
+                    )
+                    registered_scorers = [
+                        s
+                        for s in (list_scorers() or [])
+                        if crew_prefix
+                        and str(getattr(s, "name", "")).startswith(crew_prefix)
+                    ]
+                    if registered_scorers:
+                        logger.info(
+                            "Crew optimization: using registered MLflow judges: "
+                            + ", ".join(
+                                getattr(s, "name", "?") for s in registered_scorers
+                            )
+                        )
+                except Exception as scorer_err:
+                    logger.warning(
+                        f"Could not load registered MLflow judges: {scorer_err}"
+                    )
+
+            expected_keys = set(field_keys)
+
+            def _apply_fields(fields: Dict[str, str]):
+                agents_over = copy.deepcopy(agents_yaml)
+                tasks_over = copy.deepcopy(tasks_yaml)
+                for cfg_map in (agents_over, tasks_over):
+                    for entity in cfg_map.values():
+                        prefix = entity.pop("_field_prefix", None)
+                        if not prefix:
+                            continue
+                        for field in (
+                            "role",
+                            "goal",
+                            "backstory",
+                            "description",
+                            "expected_output",
+                        ):
+                            key = f"{prefix}.{field}"
+                            if key in fields and fields[key].strip():
+                                entity[field] = fields[key].strip()
+                return agents_over, tasks_over
+
+            def predict_fn(**inputs) -> str:
+                run_entry = _RUNS.get(cancel_run_id, {}) if cancel_run_id else {}
+                # User-requested stop: abort BEFORE spending a crew execution.
+                if run_entry.get("cancel_requested"):
+                    raise RuntimeError("Cancelled by user")
+                # HARD execution cap: the user's budget is a promise about crew
+                # executions, but GEPA overshoots (parallel batches are only
+                # budget-checked between iterations, plus the upfront smoke
+                # test). Once the cap is spent, further candidates get a free
+                # empty result — they score 0, never win, and GEPA wraps up
+                # returning the best already-evaluated candidate.
+                if run_entry.get("executions_used", 0) >= max_metric_calls:
+                    logger.info(
+                        "Crew optimization execution cap reached "
+                        f"({max_metric_calls}); skipping further executions"
+                    )
+                    return ""
+                candidate = client.load_prompt(prompt_uri)
+                fields = _parse_crew_doc(candidate.template)
+                # Malformed candidates never execute — free rejection.
+                if fields is None or set(fields) != expected_keys:
+                    return ""
+                if run_entry:
+                    run_entry["executions_used"] = (
+                        run_entry.get("executions_used", 0) + 1
+                    )
+                agents_over, tasks_over = _apply_fields(fields)
+                deliverable = _sync_run_crew(
+                    loop,
+                    agents_yaml=agents_over,
+                    tasks_yaml=tasks_over,
+                    model=target_model,
+                    timeout=execution_timeout,
+                    group_context=group_context,
+                    user_token=user_token,
+                )
+                # Log this evaluation as an MLflow trace so the user can attach
+                # Feedback/Expectations (Assessments panel) that steer the judge
+                # on the next run. Advisory only — never fail the eval over it.
+                if local_mode and crew_id:
+                    try:
+                        with mlflow.start_span(name="crew_optimization_eval") as span:
+                            span.set_inputs(
+                                {
+                                    "objective": inputs.get("request", objective),
+                                    "candidate_prompts": candidate.template[:4000],
+                                }
+                            )
+                            span.set_outputs({"deliverable": deliverable[:8000]})
+                            mlflow.update_current_trace(tags={"kasal_crew_id": crew_id})
+                    except Exception as trace_err:
+                        logger.debug(f"Eval trace logging failed: {trace_err}")
+                return deliverable
+
+            @scorer
+            def output_format(outputs) -> float:
+                text = str(outputs or "").strip()
+                return 1.0 if len(text) > 50 else 0.0
+
+            @scorer
+            def output_correct(inputs, outputs) -> float:
+                # GRADED, not binary: a pass/fail judge saturates at 1.0 for any
+                # acceptable baseline, leaving GEPA no gradient to climb (observed
+                # live: 1.00 -> 1.00 with zero exploration payoff). A harsh 0-10
+                # rubric keeps ordinary output around 6-7 so better prompts can
+                # actually outscore the baseline.
+                text = str(outputs or "").strip()
+                if not text:
+                    return 0.0
+                try:
+                    verdict = _sync_llm_completion(
+                        loop,
+                        messages=[
+                            {
+                                "role": "system",
+                                "content": (
+                                    "You are a HARSH grader of an AI crew's final deliverable. "
+                                    "Score 0-10 against the per-task expectations:\n"
+                                    "- completeness: every expectation addressed, none skipped\n"
+                                    "- specificity: concrete facts/sources/structure, no filler\n"
+                                    "- fidelity: matches the requested format and scope exactly\n"
+                                    "10 = flawless and exceptional (rare). 7 = solid with minor "
+                                    "gaps. 5 = acceptable but generic. 3 = major omissions. "
+                                    "0 = failed. Reply with ONLY the number."
+                                ),
+                            },
+                            {
+                                "role": "user",
+                                "content": (
+                                    f"Objective: {inputs.get('request', objective)}\n"
+                                    f"Expectations:\n{judge_rubric}\n\nFinal output:\n{text[:6000]}"
+                                ),
+                            },
+                        ],
+                        model=judge_model,
+                        # Room for forced-thinking models (Kimi K2.x): even 300
+                        # tokens were consumed entirely by reasoning, leaving
+                        # empty visible content (observed live at 300/300).
+                        max_tokens=1500,
+                        group_context=group_context,
+                        user_token=user_token,
+                    )
+                except Exception as judge_err:
+                    # A broken judge must be LOUD: silent zeros flatten the
+                    # whole score landscape and make runs look like "no
+                    # improvement possible" (observed live with an unsupported
+                    # judge provider — every grade was an exception).
+                    logger.error(f"Crew optimization judge call failed: {judge_err}")
+                    raise
+                grades: List[float] = []
+                # LAST number wins: thinking models may reason (with incidental
+                # numbers) before stating the final grade.
+                matches = re.findall(r"\d+(?:\.\d+)?", verdict or "")
+                if matches:
+                    grades.append(max(0.0, min(10.0, float(matches[-1]))) / 10.0)
+                else:
+                    logger.warning(
+                        f"Crew optimization judge reply not numeric: {verdict!r}"
+                    )
+                # Registered judges grade the SAME deliverable here rather than
+                # running as separate MLflow scorers — trace-based scorers were
+                # each re-triggering their own crew execution (observed live as
+                # bursts of one execution per judge), multiplying the budget.
+                for judge in registered_scorers:
+                    try:
+                        feedback = judge(
+                            inputs={"request": inputs.get("request", objective)},
+                            outputs=text,
+                        )
+                        grade = _judge_value_to_grade(getattr(feedback, "value", None))
+                        if grade is None:
+                            logger.warning(
+                                f"Registered judge '{getattr(judge, 'name', '?')}' "
+                                f"returned unusable value "
+                                f"{getattr(feedback, 'value', None)!r}; skipping"
+                            )
+                        else:
+                            grades.append(grade)
+                    except Exception as judge_err:
+                        logger.warning(
+                            f"Registered judge '{getattr(judge, 'name', '?')}' "
+                            f"failed: {judge_err}"
+                        )
+                return sum(grades) / len(grades) if grades else 0.0
+
+            def aggregation(scores: Dict[str, Any]) -> float:
+                # Registered judges are already averaged INSIDE output_correct.
+                fmt = float(scores.get("output_format") or 0.0)
+                correct = float(scores.get("output_correct") or 0.0)
+                return 0.3 * fmt + 0.7 * correct
+
+            result = optimize_prompts(
+                predict_fn=predict_fn,
+                train_data=[
+                    {"inputs": {"request": objective_for_training}, "expectations": {}}
+                ],
+                prompt_uris=[prompt_uri],
+                optimizer=GepaPromptOptimizer(
+                    reflection_model=reflection_uri,
+                    max_metric_calls=max_metric_calls,
+                ),
+                scorers=[output_format, output_correct],
+                aggregation=aggregation,
+                enable_tracking=local_mode,
+            )
+        finally:
+            if local_mode:
+                mlflow.set_tracking_uri(prev_tracking)
+            for k, old in saved_exp_env.items():
+                if old is not None:
+                    os.environ[k] = old
+            for _flavor, old_flag in saved_autolog_flags.items():
+                if old_flag is None:
+                    AUTOLOGGING_INTEGRATIONS.get(_flavor, {}).pop("disable", None)
+                else:
+                    AUTOLOGGING_INTEGRATIONS[_flavor]["disable"] = old_flag
+            for k, old in saved_env.items():
+                if old is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = old
+
+        optimized = result.optimized_prompts[0]
+        optimized_fields = _parse_crew_doc(optimized.template) or {}
+        return {
+            "optimized_template": optimized.template,
+            "optimized_fields": optimized_fields,
+            "initial_score": _to_float(getattr(result, "initial_eval_score", None)),
+            "final_score": _to_float(getattr(result, "final_eval_score", None)),
+            "prompt_uri": getattr(optimized, "uri", None),
+        }
+
+    # -------------------------------------------------- crew eval feedback
+
+    @staticmethod
+    def _local_mlflow_uri() -> Optional[str]:
+        """The local MLflow server URI when local mode is enabled, else None."""
+        if os.getenv("MCP_SERVER_ENABLED", "").lower() != "true":
+            return None
+        uri = os.getenv("KASAL_LAUNCH_MLFLOW_TRACKING_URI") or os.getenv(
+            "MLFLOW_TRACKING_URI"
+        )
+        if uri and not uri.startswith("databricks"):
+            return uri
+        return None
+
+    async def list_crew_evals(self, crew_id: str) -> List[Dict[str, Any]]:
+        """List this crew's optimization-evaluation traces (for in-app grading)."""
+        local_uri = self._local_mlflow_uri()
+        if not local_uri:
+            return []
+
+        def _list() -> List[Dict[str, Any]]:
+            import mlflow
+
+            prev = mlflow.get_tracking_uri()
+            mlflow.set_tracking_uri(local_uri)
+            try:
+                # Generous window: eval traces accumulate across runs, and a
+                # too-small page silently hides previously GRADED answers
+                # (observed live — graded traces fell out of a 25-trace page).
+                traces = mlflow.search_traces(
+                    filter_string=f"tags.kasal_crew_id = '{crew_id}'",
+                    max_results=200,
+                    return_type="list",
+                )
+                out: List[Dict[str, Any]] = []
+                for trace in traces:
+                    deliverable = ""
+                    try:
+                        for span in trace.search_spans(name="crew_optimization_eval"):
+                            outputs = span.outputs or {}
+                            deliverable = str(outputs.get("deliverable", ""))
+                            break
+                    except Exception:
+                        pass
+                    assessments = []
+                    try:
+                        assessments = trace.search_assessments() or []
+                    except Exception:
+                        pass
+                    info = trace.info
+                    out.append(
+                        {
+                            "trace_id": getattr(info, "trace_id", None)
+                            or getattr(info, "request_id", ""),
+                            "timestamp_ms": getattr(info, "timestamp_ms", None)
+                            or getattr(info, "request_time", None),
+                            "deliverable": deliverable[:4000],
+                            "assessment_count": len(assessments),
+                        }
+                    )
+                return out
+            finally:
+                mlflow.set_tracking_uri(prev)
+
+        return await asyncio.to_thread(_list)
+
+    async def add_eval_feedback(
+        self,
+        trace_id: str,
+        value: Optional[float] = None,
+        comment: Optional[str] = None,
+        expectation: Optional[str] = None,
+    ) -> bool:
+        """Attach human assessments to an eval trace — a grade (Feedback:
+        judgment of what WAS produced) and/or an expectation (ground truth of
+        what SHOULD have been produced). Both are harvested into the judge's
+        rubric on the next optimization run."""
+        if value is None and not (expectation or "").strip():
+            raise ValueError("Provide a grade, an expectation, or both")
+        local_uri = self._local_mlflow_uri()
+        if not local_uri:
+            raise ValueError(
+                "In-app eval feedback requires the local MLflow server "
+                "(MCP_SERVER_ENABLED=true + MLFLOW_TRACKING_URI)."
+            )
+
+        def _log() -> bool:
+            import mlflow
+
+            prev = mlflow.get_tracking_uri()
+            mlflow.set_tracking_uri(local_uri)
+            try:
+                if value is not None:
+                    mlflow.log_feedback(
+                        trace_id=trace_id,
+                        name="human_grade",
+                        value=max(0.0, min(10.0, float(value))),
+                        rationale=(comment or "").strip() or None,
+                    )
+                if (expectation or "").strip():
+                    mlflow.log_expectation(
+                        trace_id=trace_id,
+                        name="human_expectation",
+                        value=expectation.strip(),
+                    )
+                return True
+            finally:
+                mlflow.set_tracking_uri(prev)
+
+        return await asyncio.to_thread(_log)
+
+    # ----------------------------------------------------------- LLM judges
+
+    @staticmethod
+    def _crew_judge_prefix(crew_id: str) -> str:
+        """Registry-name prefix that scopes a judge to one crew (assignment is
+        encoded in the name — no schema change, survives restarts)."""
+        return f"crew_{str(crew_id).replace('-', '')[:12]}__"
+
+    async def list_judges(self) -> List[Dict[str, Any]]:
+        """List LLM judges registered on the local MLflow experiment.
+
+        Names starting with a crew prefix ('crew_<id>__') are ASSIGNED to that
+        crew; others are shared library judges. `name` is the display name,
+        `full_name` the registry name.
+        """
+        local_uri = self._local_mlflow_uri()
+        if not local_uri:
+            return []
+
+        def _list() -> List[Dict[str, Any]]:
+            import mlflow
+
+            prev = mlflow.get_tracking_uri()
+            mlflow.set_tracking_uri(local_uri)
+            try:
+                from mlflow.genai.scorers import list_scorers
+
+                out = []
+                for s in list_scorers() or []:
+                    full_name = getattr(s, "name", "?")
+                    crew_id = None
+                    display = full_name
+                    match = re.match(r"^crew_([0-9a-f]{1,12})__(.+)$", full_name)
+                    if match:
+                        crew_id = match.group(1)
+                        display = match.group(2)
+                    out.append(
+                        {
+                            "name": display,
+                            "full_name": full_name,
+                            "crew_id": crew_id,
+                            "model": getattr(s, "model", None),
+                            "instructions": (getattr(s, "instructions", "") or "")[
+                                :500
+                            ],
+                        }
+                    )
+                return out
+            finally:
+                mlflow.set_tracking_uri(prev)
+
+        return await asyncio.to_thread(_list)
+
+    async def create_judge(
+        self,
+        name: str,
+        instructions: str,
+        model: Optional[str] = None,
+        crew_id: Optional[str] = None,
+        group_context: Optional[GroupContext] = None,
+    ) -> Dict[str, Any]:
+        """Create + register an MLflow LLM judge from Kasal (no MLflow UI needed).
+
+        `instructions` is plain-language criteria; it must reference the answer
+        via the {{ outputs }} template variable (added automatically when
+        missing). `model` is a Kasal model key, resolved to a judge model URI.
+        """
+        local_uri = self._local_mlflow_uri()
+        if not local_uri:
+            raise ValueError(
+                "Judge creation requires the local MLflow server "
+                "(MCP_SERVER_ENABLED=true + MLFLOW_TRACKING_URI)."
+            )
+        safe_name = "".join(c if c.isalnum() or c == "_" else "_" for c in name.strip())
+        if not safe_name:
+            raise ValueError("Judge name is required")
+        if crew_id:
+            # Crew-assigned judge: scope via the registry name.
+            safe_name = f"{self._crew_judge_prefix(crew_id)}{safe_name}"
+        text = instructions.strip()
+        if not text:
+            raise ValueError("Judge instructions are required")
+        if "{{ outputs }}" not in text and "{{outputs}}" not in text:
+            text += "\n\nThe answer to evaluate:\n{{ outputs }}"
+        model_uri, _env = await self._resolve_reflection_model(
+            model or DEFAULT_TARGET_MODEL, group_context
+        )
+
+        def _create() -> Dict[str, Any]:
+            import mlflow
+
+            prev = mlflow.get_tracking_uri()
+            mlflow.set_tracking_uri(local_uri)
+            try:
+                from mlflow.genai.judges import make_judge
+
+                judge = make_judge(
+                    name=safe_name,
+                    instructions=text,
+                    model=model_uri,
+                    # Numeric verdicts — categorical words ('Satisfactory') are
+                    # lossier to fold into an aggregate score.
+                    feedback_value_type=float,
+                )
+                judge.register()
+                return {"name": safe_name, "model": model_uri}
+            finally:
+                mlflow.set_tracking_uri(prev)
+
+        return await asyncio.to_thread(_create)
+
+    async def assign_judge(
+        self, name: str, crew_id: str, group_context: Optional[GroupContext] = None
+    ) -> Dict[str, Any]:
+        """Assign a shared library judge to a crew by registering a crew-scoped
+        copy (same instructions/model) under the crew's name prefix."""
+        local_uri = self._local_mlflow_uri()
+        if not local_uri:
+            raise ValueError("Judge assignment requires the local MLflow server.")
+
+        def _assign() -> Dict[str, Any]:
+            import mlflow
+
+            prev = mlflow.get_tracking_uri()
+            mlflow.set_tracking_uri(local_uri)
+            try:
+                from mlflow.genai.judges import make_judge
+                from mlflow.genai.scorers import get_scorer
+
+                source = get_scorer(name=name)
+                scoped_name = f"{self._crew_judge_prefix(crew_id)}{name}"
+                judge = make_judge(
+                    name=scoped_name,
+                    instructions=getattr(source, "instructions", "") or "",
+                    model=getattr(source, "model", None),
+                    feedback_value_type=float,
+                )
+                judge.register()
+                return {"name": name, "full_name": scoped_name, "crew_id": crew_id}
+            finally:
+                mlflow.set_tracking_uri(prev)
+
+        return await asyncio.to_thread(_assign)
+
+    async def delete_judge(self, name: str) -> bool:
+        """Delete a registered judge by name."""
+        local_uri = self._local_mlflow_uri()
+        if not local_uri:
+            raise ValueError("Judge deletion requires the local MLflow server.")
+
+        def _delete() -> bool:
+            import mlflow
+
+            prev = mlflow.get_tracking_uri()
+            mlflow.set_tracking_uri(local_uri)
+            try:
+                from mlflow.genai.scorers import delete_scorer
+
+                delete_scorer(name=name, version="all")
+                return True
+            finally:
+                mlflow.set_tracking_uri(prev)
+
+        return await asyncio.to_thread(_delete)
+
+    # ---------------------------------------------------------------- reads
+
+    def get_run(
+        self, run_id: str, group_context: Optional[GroupContext] = None
+    ) -> Optional[Dict[str, Any]]:
+        run = _RUNS.get(run_id)
+        if run is None or not self._visible(run, group_context):
+            return None
+        return {k: run.get(k) for k in _PUBLIC_FIELDS}
+
+    def list_runs(
+        self, group_context: Optional[GroupContext] = None
+    ) -> List[Dict[str, Any]]:
+        runs = [r for r in _RUNS.values() if self._visible(r, group_context)]
+        runs.sort(key=lambda r: r.get("created_at") or datetime.min, reverse=True)
+        return [{k: r.get(k) for k in _PUBLIC_FIELDS} for r in runs]
+
+    @staticmethod
+    def _visible(run: Dict[str, Any], group_context: Optional[GroupContext]) -> bool:
+        group_id = group_context.primary_group_id if group_context else None
+        return run.get("group_id") == group_id
+
+    @staticmethod
+    def _prune_runs() -> None:
+        if len(_RUNS) <= _MAX_KEPT_RUNS:
+            return
+        # Drop the oldest finished runs first; never prune active ones.
+        finished = [
+            r for r in _RUNS.values() if r.get("status") in ("completed", "failed")
+        ]
+        finished.sort(key=lambda r: r.get("created_at") or datetime.min)
+        for run in finished[: len(_RUNS) - _MAX_KEPT_RUNS]:
+            _RUNS.pop(run["run_id"], None)
+
+    # ---------------------------------------------------------------- cancel
+
+    def cancel_run(
+        self, run_id: str, group_context: Optional[GroupContext] = None
+    ) -> Dict[str, Any]:
+        """Request a running optimization to stop. The flag is honored before
+        the NEXT crew execution — an in-flight execution finishes first."""
+        run = _RUNS.get(run_id)
+        if run is None or not self._visible(run, group_context):
+            raise ValueError(f"Optimization run '{run_id}' not found")
+        if run.get("status") not in ("pending", "running"):
+            raise ValueError(f"Optimization run '{run_id}' is not active")
+        run["cancel_requested"] = True
+        logger.info(f"Prompt optimization {run_id}: cancellation requested")
+        return {"run_id": run_id, "cancelling": True}
+
+    # ---------------------------------------------------------------- apply
+
+    async def apply_run(
+        self, run_id: str, group_context: Optional[GroupContext] = None
+    ) -> Dict[str, Any]:
+        """Write a completed run's proposal as a group-scoped template override."""
+        run = _RUNS.get(run_id)
+        if run is None or not self._visible(run, group_context):
+            raise ValueError(f"Optimization run '{run_id}' not found")
+        if run.get("status") != "completed" or not run.get("optimized_template"):
+            raise ValueError(
+                f"Optimization run '{run_id}' has no completed proposal to apply"
+            )
+
+        if run.get("kind") == "crew":
+            return await self._apply_crew_run(run)
+
+        template_service = TemplateService(self.session)
+        row = await template_service.find_by_name_with_group_check(
+            run["template_name"], group_context
+        )
+        if row is None:
+            raise ValueError(f"Template '{run['template_name']}' not found")
+        updated = await template_service.update_with_group_check(
+            row.id,
+            PromptTemplateUpdate(template=run["optimized_template"]),
+            group_context,
+        )
+        if updated is None:
+            raise ValueError(f"Failed to update template '{run['template_name']}'")
+        run["applied"] = True
+        return {
+            "run_id": run_id,
+            "template_name": run["template_name"],
+            "applied": True,
+        }
+
+    async def _apply_crew_run(self, run: Dict[str, Any]) -> Dict[str, Any]:
+        """Write a crew run's optimized fields back onto the agent/task rows."""
+        from src.repositories.agent_repository import AgentRepository
+        from src.repositories.task_repository import TaskRepository
+
+        optimized: Dict[str, str] = run.get("optimized_fields") or {}
+        baseline: Dict[str, str] = run.get("baseline_fields") or {}
+        agent_repo = AgentRepository(self.session)
+        task_repo = TaskRepository(self.session)
+
+        # Group per entity, skipping unchanged fields.
+        changes: Dict[tuple, Dict[str, str]] = {}
+        for key, value in optimized.items():
+            if not value or value == baseline.get(key):
+                continue
+            try:
+                entity_kind, entity_id, field = key.split(".", 2)
+            except ValueError:
+                continue
+            changes.setdefault((entity_kind, entity_id), {})[field] = value
+
+        applied = 0
+        for (entity_kind, entity_id), patch in changes.items():
+            if entity_kind == "agent":
+                if await agent_repo.update(entity_id, patch):
+                    applied += 1
+            elif entity_kind == "task":
+                if await task_repo.update(entity_id, patch):
+                    applied += 1
+        run["applied"] = True
+        logger.info(f"Crew optimization {run['run_id']} applied to {applied} entities")
+        return {
+            "run_id": run["run_id"],
+            "template_name": run["template_name"],
+            "applied": True,
+        }
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -98,6 +98,14 @@ def _parse_crew_doc(doc: str) -> Optional[Dict[str, str]]:
     Returns {key: text} or None when the document lost its structure —
     callers score such candidates 0 WITHOUT executing the crew.
     """
+    doc = (doc or "").strip()
+    # Fence rescue: reflection models sometimes wrap the document in markdown
+    # code fences that survive gepa's extraction. The content inside is a
+    # perfectly good document — losing the candidate over the wrapper wastes
+    # the proposal.
+    if doc.startswith("```"):
+        doc = re.sub(r"^```\S*\n?", "", doc)
+        doc = re.sub(r"\n?```\s*$", "", doc)
     fields: Dict[str, str] = {}
     entity_prefix: Optional[str] = None
     current_key: Optional[str] = None
@@ -1924,8 +1932,59 @@ class PromptOptimizationService:
                         # every iteration a free cache-hit rejection, budget
                         # drained, zero exploration (observed live in
                         # proposals.json). Explicit sampling temperature is
-                        # the only diversity source this setup has.
-                        "reflection_lm_kwargs": {"temperature": 1.0},
+                        # the only diversity source this setup has — and
+                        # no-cache is MANDATORY: llm_manager enables a
+                        # process-global litellm disk cache at import, and
+                        # gepa's LM rides the same litellm, so identical
+                        # reflection prompts were served the SAME cached
+                        # response forever (observed live: duration=0.00s,
+                        # byte-identical proposals at temperature 1.0).
+                        # 0.8, not 1.0: at 1.0 the reflection model emitted a
+                        # bare "```" and stopped in 2 of 3 samples; at 0.8
+                        # with the no-fence contract below, 4 of 4 samples
+                        # parsed, were distinct, and carried the requirements
+                        # (validated offline against the live endpoint).
+                        "reflection_lm_kwargs": {
+                            "temperature": 0.8,
+                            "cache": {"no-cache": True},
+                        },
+                        # gepa's default template says "write a new
+                        # instruction ... within ``` blocks" — an open
+                        # invitation to restructure: the reflection model
+                        # returned {"instruction": "..."} JSON blobs that
+                        # lost the [AGENT]/[TASK] document structure and
+                        # free-rejected every proposal (observed live, 11/11
+                        # malformed). Pin the output contract to the crew-doc
+                        # format instead.
+                        "reflection_prompt_template": (
+                            "I provided an assistant with the following "
+                            "DOCUMENT of prompt fields that configures an AI "
+                            "crew (agents and tasks):\n"
+                            "```\n<curr_param>\n```\n\n"
+                            "The following are examples of task inputs, the "
+                            "crew's final answer, and feedback (score and "
+                            "judge rationale) on how the answer could be "
+                            "better:\n"
+                            "```\n<side_info>\n```\n\n"
+                            "Your task is to write an IMPROVED VERSION of the "
+                            "document above so that a future answer satisfies "
+                            "the feedback and every hard requirement stated "
+                            "in the task input.\n\n"
+                            "STRICT FORMAT RULES:\n"
+                            "- Keep EXACTLY the same structure: the same "
+                            "[AGENT <id>] and [TASK <id>] section headers "
+                            "with the same ids, and the same field labels "
+                            "(ROLE:, GOAL:, BACKSTORY:, DESCRIPTION:, "
+                            "EXPECTED_OUTPUT:).\n"
+                            "- Each field label starts its line, followed by "
+                            "the improved text for that field on the same "
+                            "line.\n"
+                            "- Do NOT output JSON, commentary, or anything "
+                            "except the document.\n"
+                            "- Output ONLY the improved document, nothing "
+                            "before or after it. Start your reply directly "
+                            "with the first [AGENT line."
+                        ),
                     },
                 ),
                 scorers=[output_format, output_correct],

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -1917,6 +1917,15 @@ class PromptOptimizationService:
                         # the metric call entirely on repeats, preserving the
                         # metric budget for NEW candidates.
                         "cache_evaluation": True,
+                        # The reflection prompt is IDENTICAL every iteration
+                        # (same parent, same single example, cached rationale),
+                        # so a deterministic reflection endpoint re-proposed
+                        # the byte-identical candidate 11 times in one run —
+                        # every iteration a free cache-hit rejection, budget
+                        # drained, zero exploration (observed live in
+                        # proposals.json). Explicit sampling temperature is
+                        # the only diversity source this setup has.
+                        "reflection_lm_kwargs": {"temperature": 1.0},
                     },
                 ),
                 scorers=[output_format, output_correct],

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -649,8 +649,10 @@ class PromptOptimizationService:
 
         target_model = request.model or DEFAULT_TARGET_MODEL
         judge_model = request.judge_model or target_model
-        reflection_uri, reflection_env = await self._resolve_reflection_model(
-            request.reflection_model or target_model, group_context
+        reflection_uri, reflection_env, reflection_provider = (
+            await self._resolve_reflection_model(
+                request.reflection_model or target_model, group_context
+            )
         )
         registry_uri, prompt_name = await self._resolve_registry(
             request.template_name, group_context
@@ -762,6 +764,9 @@ class PromptOptimizationService:
         GEPA invokes its reflection model itself (outside LLMManager), so the
         key must become a provider URI plus any env vars the provider needs —
         including the provider API key from Kasal's group-scoped key store.
+
+        Returns (uri, env, provider) — the provider string lets callers apply
+        provider-specific request quirks (e.g. Kimi rejects any temperature).
         """
         config = await self.model_repository.find_by_key(model_key)
         provider = (getattr(config, "provider", None) or "").lower() if config else ""
@@ -772,15 +777,19 @@ class PromptOptimizationService:
             (getattr(config, "name", None) or model_key) if config else model_key
         )
         if provider == "databricks":
-            return f"databricks:/{api_model}", {}
+            return f"databricks:/{api_model}", {}, provider
         if provider == "vllm":
             # OpenAI-compatible endpoint — same env resolution as llm_manager.
-            return f"openai:/{api_model}", {
-                "OPENAI_API_BASE": os.getenv(
-                    "VLLM_BASE_URL", "http://localhost:8081/v1"
-                ),
-                "OPENAI_API_KEY": os.getenv("VLLM_API_KEY", "vllm"),
-            }
+            return (
+                f"openai:/{api_model}",
+                {
+                    "OPENAI_API_BASE": os.getenv(
+                        "VLLM_BASE_URL", "http://localhost:8081/v1"
+                    ),
+                    "OPENAI_API_KEY": os.getenv("VLLM_API_KEY", "vllm"),
+                },
+                provider,
+            )
         if provider == "kimi":
             # Kimi (Moonshot AI) — OpenAI-compatible endpoint with the key from
             # Kasal's key store, mirroring llm_manager's kimi routing.
@@ -795,12 +804,16 @@ class PromptOptimizationService:
                     "Reflection model needs a Kimi API key — add KIMI_API_KEY "
                     "under Configuration -> API Keys."
                 )
-            return f"openai:/{api_model}", {
-                "OPENAI_API_BASE": os.getenv(
-                    "KIMI_ENDPOINT", "https://api.moonshot.ai/v1"
-                ),
-                "OPENAI_API_KEY": api_key,
-            }
+            return (
+                f"openai:/{api_model}",
+                {
+                    "OPENAI_API_BASE": os.getenv(
+                        "KIMI_ENDPOINT", "https://api.moonshot.ai/v1"
+                    ),
+                    "OPENAI_API_KEY": api_key,
+                },
+                provider,
+            )
         if provider in self._REFLECTION_KEY_ENV:
             env: Dict[str, str] = {}
             env_name = self._REFLECTION_KEY_ENV[provider]
@@ -824,7 +837,7 @@ class PromptOptimizationService:
                     f"(configure it under API Keys) or pass 'reflection_model' "
                     f"with a different provider."
                 )
-            return f"{provider}:/{api_model}", env
+            return f"{provider}:/{api_model}", env, provider
         raise ValueError(
             f"Reflection model '{model_key}' has unsupported provider '{provider or 'unknown'}' "
             f"(supported: databricks, vllm, kimi, {', '.join(sorted(self._REFLECTION_KEY_ENV))}). "
@@ -1145,6 +1158,11 @@ class PromptOptimizationService:
                 optimizer=GepaPromptOptimizer(
                     reflection_model=reflection_uri,
                     max_metric_calls=max_metric_calls,
+                    # llm_manager enables a process-global litellm cache;
+                    # without a per-request bypass, identical reflection
+                    # prompts are served the same cached proposal forever
+                    # (observed live in crew mode).
+                    gepa_kwargs={"reflection_lm_kwargs": {"cache": {"no-cache": True}}},
                 ),
                 scorers=[output_format, output_correct],
                 aggregation=aggregation,
@@ -1281,8 +1299,10 @@ class PromptOptimizationService:
 
         target_model = request.model or DEFAULT_TARGET_MODEL
         judge_model = request.judge_model or target_model
-        reflection_uri, reflection_env = await self._resolve_reflection_model(
-            request.reflection_model or target_model, group_context
+        reflection_uri, reflection_env, reflection_provider = (
+            await self._resolve_reflection_model(
+                request.reflection_model or target_model, group_context
+            )
         )
         registry_uri, _ = await self._resolve_registry("crew", group_context)
         safe_group = "".join(
@@ -1334,6 +1354,7 @@ class PromptOptimizationService:
                 judge_model=judge_model,
                 reflection_uri=reflection_uri,
                 reflection_env=reflection_env,
+                reflection_provider=reflection_provider,
                 max_metric_calls=request.max_metric_calls,
                 execution_timeout=request.execution_timeout_seconds,
                 registry_uri=registry_uri,
@@ -1364,6 +1385,7 @@ class PromptOptimizationService:
         prompt_name: str,
         crew_id: str = "",
         cancel_run_id: str = "",
+        reflection_provider: str = "",
         group_context: Optional[GroupContext] = None,
     ) -> Dict[str, Any]:
         """Blocking crew-optimization body (worker thread). Mirrors the
@@ -1960,10 +1982,23 @@ class PromptOptimizationService:
                         # with the no-fence contract below, 4 of 4 samples
                         # parsed, were distinct, and carried the requirements
                         # (validated offline against the live endpoint).
-                        "reflection_lm_kwargs": {
-                            "temperature": 0.8,
-                            "cache": {"no-cache": True},
-                        },
+                        # PROVIDER QUIRK — Kimi K-series accepts ONLY its
+                        # default temperature: sending 0.8 made Moonshot 400
+                        # every reflection call ("invalid temperature: only 1
+                        # is allowed"), gepa skipped 10 proposals in a row and
+                        # the run 'completed' after the baseline's single
+                        # execution (observed live; verified by direct repro —
+                        # the same call without temperature returns a clean,
+                        # parseable crew doc). Kimi's forced default sampling
+                        # is itself diverse, so dropping the knob is safe.
+                        "reflection_lm_kwargs": (
+                            {"cache": {"no-cache": True}}
+                            if reflection_provider == "kimi"
+                            else {
+                                "temperature": 0.8,
+                                "cache": {"no-cache": True},
+                            }
+                        ),
                         # gepa's default template says "write a new
                         # instruction ... within ``` blocks" — an open
                         # invitation to restructure: the reflection model
@@ -2230,7 +2265,7 @@ class PromptOptimizationService:
             raise ValueError("Judge instructions are required")
         if "{{ outputs }}" not in text and "{{outputs}}" not in text:
             text += "\n\nThe answer to evaluate:\n{{ outputs }}"
-        model_uri, _env = await self._resolve_reflection_model(
+        model_uri, _env, _provider = await self._resolve_reflection_model(
             model or DEFAULT_TARGET_MODEL, group_context
         )
         scoped_name = (
@@ -2330,7 +2365,9 @@ class PromptOptimizationService:
             raise ValueError("Nothing to update: provide instructions and/or a model")
         model_uri: Optional[str] = None
         if model:
-            model_uri, _env = await self._resolve_reflection_model(model, group_context)
+            model_uri, _env, _provider = await self._resolve_reflection_model(
+                model, group_context
+            )
 
         def _update() -> Dict[str, Any]:
             import mlflow

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -16,11 +16,12 @@ when this graduates from Phase 1.
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from src.repositories.log_repository import LLMLogRepository
@@ -301,6 +302,8 @@ _PUBLIC_FIELDS = (
     "optimized_fields",
     "executions_used",
     "execution_cap",
+    "human_feedback_count",
+    "candidates_tried",
 )
 
 
@@ -574,7 +577,10 @@ class PromptOptimizationService:
             "group_id": group_id,
             "baseline_template": baseline,
             "applied": False,
-            "created_at": datetime.utcnow(),
+            # Timezone-AWARE so the ISO string carries +00:00 and browsers
+            # render local time (a naive UTC stamp displayed as-is showed a
+            # 01:20 local run as "11:20 PM" — observed live).
+            "created_at": datetime.now(timezone.utc),
         }
         _RUNS[run_id] = run
         self._prune_runs()
@@ -1217,7 +1223,9 @@ class PromptOptimizationService:
             "baseline_template": baseline_doc,
             "baseline_fields": baseline_fields,
             "applied": False,
-            "created_at": datetime.utcnow(),
+            "human_feedback_count": 0,
+            "candidates_tried": 0,
+            "created_at": datetime.now(timezone.utc),
         }
         _RUNS[run_id] = run
         self._prune_runs()
@@ -1277,6 +1285,7 @@ class PromptOptimizationService:
         )
         os.environ.setdefault("MLFLOW_DISABLE_TELEMETRY", "true")
         import mlflow
+        from mlflow.entities import Feedback
         from mlflow.genai import optimize_prompts
         from mlflow.genai.optimize import GepaPromptOptimizer
         from mlflow.genai.scorers import scorer
@@ -1337,6 +1346,7 @@ class PromptOptimizationService:
             # harvested here and folded into the judge's rubric on the NEXT run.
             judge_rubric = rubric
             objective_for_training = objective
+            train_expectations: Dict[str, str] = {}
             if local_mode and crew_id:
                 try:
                     prior = mlflow.search_traces(
@@ -1344,24 +1354,43 @@ class PromptOptimizationService:
                         max_results=50,
                         return_type="list",
                     )
+                    # Oldest-first so the "keep the last 12" slice below keeps
+                    # the NEWEST notes (search order is not guaranteed).
+                    prior.sort(key=lambda t: t.info.request_time or 0)
                     notes: List[str] = []
+                    expect_notes: List[str] = []
                     for trace in prior:
                         for assessment in trace.search_assessments() or []:
                             name = getattr(assessment, "name", "") or ""
                             value = getattr(
                                 getattr(assessment, "feedback", None), "value", None
                             )
+                            exp_value = getattr(
+                                getattr(assessment, "expectation", None),
+                                "value",
+                                None,
+                            )
+                            if exp_value is not None:
+                                expect_notes.append(str(exp_value))
                             if value is None:
-                                value = getattr(
-                                    getattr(assessment, "expectation", None),
-                                    "value",
-                                    None,
-                                )
+                                value = exp_value
                             rationale = getattr(assessment, "rationale", None) or ""
                             if value is not None or rationale:
                                 notes.append(
                                     f"- {name}: {value if value is not None else ''} {rationale}".strip()
                                 )
+                    if expect_notes:
+                        # Ground truth rides GEPA's expectations channel too —
+                        # the reflective dataset surfaces it to the mutator as
+                        # explicit targets, not just prose inside the request.
+                        train_expectations = {
+                            "human_requirements": "\n".join(
+                                dict.fromkeys(expect_notes)
+                            )[:2000]
+                        }
+                    harvest_entry = _RUNS.get(cancel_run_id) if cancel_run_id else None
+                    if harvest_entry is not None:
+                        harvest_entry["human_feedback_count"] = len(notes)
                     if notes:
                         human_notes = "\n".join(notes[-12:])
                         judge_rubric += (
@@ -1443,24 +1472,46 @@ class PromptOptimizationService:
                                 entity[field] = fields[key].strip()
                 return agents_over, tasks_over
 
+            # Result caches, keyed by content. GEPA re-evaluates the SAME
+            # candidate doc many times (upfront smoke test, baseline valset
+            # pass, and a fresh reflective-minibatch pass EVERY iteration).
+            # Uncached, those re-runs burned most of a small execution budget
+            # re-measuring the baseline — a 4-execution run bought exactly ONE
+            # distinct candidate (observed live: total_metric_calls=7,
+            # candidates=1). Worse, the stochastic judge re-grading identical
+            # prompts drew 0.0 and then 4/10 two minutes apart, so accept/
+            # reject was a coin flip. With caching, each DISTINCT candidate
+            # costs exactly one execution and one judgment, and comparisons
+            # against the baseline are stable within the run.
+            deliverable_cache: Dict[str, str] = {}
+            judge_cache: Dict[str, Any] = {}
+
             def predict_fn(**inputs) -> str:
                 run_entry = _RUNS.get(cancel_run_id, {}) if cancel_run_id else {}
                 # User-requested stop: abort BEFORE spending a crew execution.
                 if run_entry.get("cancel_requested"):
                     raise RuntimeError("Cancelled by user")
+                candidate = client.load_prompt(prompt_uri)
+                doc_key = hashlib.sha256(
+                    candidate.template.encode("utf-8")
+                ).hexdigest()
+                # Cache lookup BEFORE the cap check: re-evaluations of an
+                # already-executed candidate (usually the baseline) stay
+                # truthful even after the budget is spent.
+                if doc_key in deliverable_cache:
+                    return deliverable_cache[doc_key]
                 # HARD execution cap: the user's budget is a promise about crew
                 # executions, but GEPA overshoots (parallel batches are only
                 # budget-checked between iterations, plus the upfront smoke
-                # test). Once the cap is spent, further candidates get a free
-                # empty result — they score 0, never win, and GEPA wraps up
-                # returning the best already-evaluated candidate.
+                # test). Once the cap is spent, further NEW candidates get a
+                # free empty result — they score 0, never win, and GEPA wraps
+                # up returning the best already-evaluated candidate.
                 if run_entry.get("executions_used", 0) >= max_metric_calls:
                     logger.info(
                         "Crew optimization execution cap reached "
                         f"({max_metric_calls}); skipping further executions"
                     )
                     return ""
-                candidate = client.load_prompt(prompt_uri)
                 fields = _parse_crew_doc(candidate.template)
                 # Malformed candidates never execute — free rejection.
                 if fields is None or set(fields) != expected_keys:
@@ -1479,6 +1530,9 @@ class PromptOptimizationService:
                     group_context=group_context,
                     user_token=user_token,
                 )
+                deliverable_cache[doc_key] = deliverable
+                if run_entry:
+                    run_entry["candidates_tried"] = len(deliverable_cache)
                 # Log this evaluation as an MLflow trace so the user can attach
                 # Feedback/Expectations (Assessments panel) that steer the judge
                 # on the next run. Advisory only — never fail the eval over it.
@@ -1503,15 +1557,34 @@ class PromptOptimizationService:
                 return 1.0 if len(text) > 50 else 0.0
 
             @scorer
-            def output_correct(inputs, outputs) -> float:
+            def output_correct(inputs, outputs):
                 # GRADED, not binary: a pass/fail judge saturates at 1.0 for any
                 # acceptable baseline, leaving GEPA no gradient to climb (observed
                 # live: 1.00 -> 1.00 with zero exploration payoff). A harsh 0-10
                 # rubric keeps ordinary output around 6-7 so better prompts can
                 # actually outscore the baseline.
+                #
+                # Returns an mlflow Feedback (value + rationale), NOT a bare
+                # float: rationales are the ONLY textual signal the GEPA
+                # reflection model receives about WHY a candidate scored low
+                # (mlflow folds Feedback.rationale into the reflective
+                # dataset). With floats, mutations were blind guesses — the
+                # judge knew "wrong region, rentals not sales" but the mutator
+                # never heard it (observed live: 1 requirement-aware candidate
+                # in ~10 runs).
                 text = str(outputs or "").strip()
                 if not text:
-                    return 0.0
+                    return Feedback(
+                        name="output_correct",
+                        value=0.0,
+                        rationale="Empty deliverable — the crew produced no output.",
+                    )
+                text_key = hashlib.sha256(text.encode("utf-8")).hexdigest()
+                cached = judge_cache.get(text_key)
+                if cached is not None:
+                    return Feedback(
+                        name="output_correct", value=cached[0], rationale=cached[1]
+                    )
                 try:
                     verdict = _sync_llm_completion(
                         loop,
@@ -1526,7 +1599,13 @@ class PromptOptimizationService:
                                     "- fidelity: matches the requested format and scope exactly\n"
                                     "10 = flawless and exceptional (rare). 7 = solid with minor "
                                     "gaps. 5 = acceptable but generic. 3 = major omissions. "
-                                    "0 = failed. Reply with ONLY the number."
+                                    "0 = failed.\n"
+                                    "First, in one or two sentences, name the SPECIFIC "
+                                    "failures, quoting the exact expectation or human "
+                                    "requirement that was violated (e.g. wrong region, "
+                                    "rentals instead of sales, missing sources). Then "
+                                    "write the final grade alone on the LAST line as a "
+                                    "bare number."
                                 ),
                             },
                             {
@@ -1553,6 +1632,9 @@ class PromptOptimizationService:
                     logger.error(f"Crew optimization judge call failed: {judge_err}")
                     raise
                 grades: List[float] = []
+                rationale_parts: List[str] = []
+                if verdict and str(verdict).strip():
+                    rationale_parts.append(str(verdict).strip())
                 # LAST number wins: thinking models may reason (with incidental
                 # numbers) before stating the final grade.
                 matches = re.findall(r"\d+(?:\.\d+)?", verdict or "")
@@ -1581,23 +1663,46 @@ class PromptOptimizationService:
                             )
                         else:
                             grades.append(grade)
+                            judge_rationale = getattr(feedback, "rationale", None)
+                            if judge_rationale:
+                                rationale_parts.append(
+                                    f"[{getattr(judge, 'name', 'judge')}] "
+                                    f"{judge_rationale}"
+                                )
                     except Exception as judge_err:
                         logger.warning(
                             f"Registered judge '{getattr(judge, 'name', '?')}' "
                             f"failed: {judge_err}"
                         )
-                return sum(grades) / len(grades) if grades else 0.0
+                grade_value = sum(grades) / len(grades) if grades else 0.0
+                rationale = "\n".join(rationale_parts)[:4000]
+                judge_cache[text_key] = (grade_value, rationale)
+                return Feedback(
+                    name="output_correct", value=grade_value, rationale=rationale
+                )
 
             def aggregation(scores: Dict[str, Any]) -> float:
                 # Registered judges are already averaged INSIDE output_correct.
-                fmt = float(scores.get("output_format") or 0.0)
-                correct = float(scores.get("output_correct") or 0.0)
+                # Scores arrive RAW: a scorer that returned a Feedback shows up
+                # here as the Feedback object, not its numeric value.
+                def _num(value: Any) -> float:
+                    value = getattr(value, "value", value)
+                    try:
+                        return float(value or 0.0)
+                    except (TypeError, ValueError):
+                        return 0.0
+
+                fmt = _num(scores.get("output_format"))
+                correct = _num(scores.get("output_correct"))
                 return 0.3 * fmt + 0.7 * correct
 
             result = optimize_prompts(
                 predict_fn=predict_fn,
                 train_data=[
-                    {"inputs": {"request": objective_for_training}, "expectations": {}}
+                    {
+                        "inputs": {"request": objective_for_training},
+                        "expectations": train_expectations,
+                    }
                 ],
                 prompt_uris=[prompt_uri],
                 optimizer=GepaPromptOptimizer(
@@ -1925,7 +2030,8 @@ class PromptOptimizationService:
         self, group_context: Optional[GroupContext] = None
     ) -> List[Dict[str, Any]]:
         runs = [r for r in _RUNS.values() if self._visible(r, group_context)]
-        runs.sort(key=lambda r: r.get("created_at") or datetime.min, reverse=True)
+        _epoch = datetime.min.replace(tzinfo=timezone.utc)
+        runs.sort(key=lambda r: r.get("created_at") or _epoch, reverse=True)
         return [{k: r.get(k) for k in _PUBLIC_FIELDS} for r in runs]
 
     @staticmethod
@@ -1941,7 +2047,8 @@ class PromptOptimizationService:
         finished = [
             r for r in _RUNS.values() if r.get("status") in ("completed", "failed")
         ]
-        finished.sort(key=lambda r: r.get("created_at") or datetime.min)
+        _epoch = datetime.min.replace(tzinfo=timezone.utc)
+        finished.sort(key=lambda r: r.get("created_at") or _epoch)
         for run in finished[: len(_RUNS) - _MAX_KEPT_RUNS]:
             _RUNS.pop(run["run_id"], None)
 

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -213,6 +213,24 @@ def _distill_requirements(raw_notes: List[str], limit: int = 8) -> List[str]:
     return requirements[:limit]
 
 
+def _pin_local_experiment() -> None:
+    """Pin the MLflow experiment for judge/scorer operations.
+
+    Scorers are PER-EXPERIMENT. The optimization runs pin the launch
+    experiment ('kasal' by default), but a fresh worker's active experiment
+    is Default/0 — a judge registered or listed there silently diverges from
+    everything else (risk observed live while chasing a judge that never
+    appeared). Every judge CRUD body must call this after set_tracking_uri.
+    """
+    import mlflow
+
+    exp_name = os.environ.get("MLFLOW_EXPERIMENT_NAME") or "kasal"
+    try:
+        mlflow.set_experiment(exp_name)
+    except Exception as exp_err:
+        logger.warning(f"Could not pin experiment '{exp_name}': {exp_err}")
+
+
 def _parse_requirement_lines(text: str) -> List[str]:
     """Parse 'R1. ...' numbered requirement lines from a distillation reply."""
     return [
@@ -1618,9 +1636,7 @@ class PromptOptimizationService:
                 if run_entry.get("cancel_requested"):
                     raise RuntimeError("Cancelled by user")
                 candidate = client.load_prompt(prompt_uri)
-                doc_key = hashlib.sha256(
-                    candidate.template.encode("utf-8")
-                ).hexdigest()
+                doc_key = hashlib.sha256(candidate.template.encode("utf-8")).hexdigest()
                 with execute_lock:
                     return _predict_locked(doc_key, candidate, run_entry, inputs)
 
@@ -2154,6 +2170,7 @@ class PromptOptimizationService:
             prev = mlflow.get_tracking_uri()
             mlflow.set_tracking_uri(local_uri)
             try:
+                _pin_local_experiment()
                 from mlflow.genai.scorers import list_scorers
 
                 out = []
@@ -2171,8 +2188,11 @@ class PromptOptimizationService:
                             "full_name": full_name,
                             "crew_id": crew_id,
                             "model": getattr(s, "model", None),
+                            # Full text (bounded): the edit dialog round-trips
+                            # this — a truncated copy would corrupt the judge
+                            # on save.
                             "instructions": (getattr(s, "instructions", "") or "")[
-                                :500
+                                :4000
                             ],
                         }
                     )
@@ -2205,9 +2225,6 @@ class PromptOptimizationService:
         safe_name = "".join(c if c.isalnum() or c == "_" else "_" for c in name.strip())
         if not safe_name:
             raise ValueError("Judge name is required")
-        if crew_id:
-            # Crew-assigned judge: scope via the registry name.
-            safe_name = f"{self._crew_judge_prefix(crew_id)}{safe_name}"
         text = instructions.strip()
         if not text:
             raise ValueError("Judge instructions are required")
@@ -2216,6 +2233,9 @@ class PromptOptimizationService:
         model_uri, _env = await self._resolve_reflection_model(
             model or DEFAULT_TARGET_MODEL, group_context
         )
+        scoped_name = (
+            f"{self._crew_judge_prefix(crew_id)}{safe_name}" if crew_id else None
+        )
 
         def _create() -> Dict[str, Any]:
             import mlflow
@@ -2223,18 +2243,29 @@ class PromptOptimizationService:
             prev = mlflow.get_tracking_uri()
             mlflow.set_tracking_uri(local_uri)
             try:
+                _pin_local_experiment()
                 from mlflow.genai.judges import make_judge
 
-                judge = make_judge(
-                    name=safe_name,
-                    instructions=text,
-                    model=model_uri,
-                    # Numeric verdicts — categorical words ('Satisfactory') are
-                    # lossier to fold into an aggregate score.
-                    feedback_value_type=float,
-                )
-                judge.register()
-                return {"name": safe_name, "model": model_uri}
+                # ALWAYS register the shared library original; when created
+                # from a crew's dialog, ALSO register the crew-scoped copy
+                # (auto-assign). Registering only the scoped copy made the
+                # judge invisible in every other crew's Assign menu — there
+                # was no library original to assign (observed live).
+                for reg_name in filter(None, [safe_name, scoped_name]):
+                    judge = make_judge(
+                        name=reg_name,
+                        instructions=text,
+                        model=model_uri,
+                        # Numeric verdicts — categorical words ('Satisfactory')
+                        # are lossier to fold into an aggregate score.
+                        feedback_value_type=float,
+                    )
+                    judge.register()
+                return {
+                    "name": safe_name,
+                    "full_name": scoped_name or safe_name,
+                    "model": model_uri,
+                }
             finally:
                 mlflow.set_tracking_uri(prev)
 
@@ -2255,6 +2286,7 @@ class PromptOptimizationService:
             prev = mlflow.get_tracking_uri()
             mlflow.set_tracking_uri(local_uri)
             try:
+                _pin_local_experiment()
                 from mlflow.genai.judges import make_judge
                 from mlflow.genai.scorers import get_scorer
 
@@ -2273,6 +2305,63 @@ class PromptOptimizationService:
 
         return await asyncio.to_thread(_assign)
 
+    async def update_judge(
+        self,
+        name: str,
+        instructions: Optional[str] = None,
+        model: Optional[str] = None,
+        group_context: Optional[GroupContext] = None,
+    ) -> Dict[str, Any]:
+        """Update a judge's instructions and/or model.
+
+        `name` is the FULL registry name (library judge, or a crew-scoped
+        'crew_<id>__name' copy — editing an assigned copy changes what that
+        crew's runs use). MLflow scorers are versioned: registering under the
+        same name creates a new version and get_scorer/list_scorers return the
+        latest (verified live against the local registry). Omitted fields keep
+        their current values. Editing a library judge does NOT touch copies
+        already assigned to crews — those are snapshots taken at assign time.
+        """
+        local_uri = self._local_mlflow_uri()
+        if not local_uri:
+            raise ValueError("Judge update requires the local MLflow server.")
+        new_text = (instructions or "").strip()
+        if not new_text and not model:
+            raise ValueError("Nothing to update: provide instructions and/or a model")
+        model_uri: Optional[str] = None
+        if model:
+            model_uri, _env = await self._resolve_reflection_model(model, group_context)
+
+        def _update() -> Dict[str, Any]:
+            import mlflow
+
+            prev = mlflow.get_tracking_uri()
+            mlflow.set_tracking_uri(local_uri)
+            try:
+                _pin_local_experiment()
+                from mlflow.genai.judges import make_judge
+                from mlflow.genai.scorers import get_scorer
+
+                current = get_scorer(name=name)
+                text = new_text or (getattr(current, "instructions", "") or "").strip()
+                if not text:
+                    raise ValueError("Judge instructions are required")
+                if "{{ outputs }}" not in text and "{{outputs}}" not in text:
+                    text += "\n\nThe answer to evaluate:\n{{ outputs }}"
+                final_model = model_uri or getattr(current, "model", None)
+                judge = make_judge(
+                    name=name,
+                    instructions=text,
+                    model=final_model,
+                    feedback_value_type=float,
+                )
+                judge.register()
+                return {"name": name, "model": final_model}
+            finally:
+                mlflow.set_tracking_uri(prev)
+
+        return await asyncio.to_thread(_update)
+
     async def delete_judge(self, name: str) -> bool:
         """Delete a registered judge by name."""
         local_uri = self._local_mlflow_uri()
@@ -2285,6 +2374,7 @@ class PromptOptimizationService:
             prev = mlflow.get_tracking_uri()
             mlflow.set_tracking_uri(local_uri)
             try:
+                _pin_local_experiment()
                 from mlflow.genai.scorers import delete_scorer
 
                 delete_scorer(name=name, version="all")

--- a/src/backend/src/services/prompt_optimization_service.py
+++ b/src/backend/src/services/prompt_optimization_service.py
@@ -456,37 +456,148 @@ Given the user message and the predicted intent, answer with EXACTLY one word:
 CORRECT or WRONG."""
 
 
-def _preflight_reflection(reflection_uri: str, reflection_env: Dict[str, str]) -> None:
-    """One-token ping of GEPA's reflection model BEFORE any budget is spent.
+# ---------------------------------------------------------------------------
+# ALL LLM calls in this service go through LLMManager (judge, distillation,
+# preflight, AND GEPA's reflection model via the bridge below). LLMManager
+# owns provider routing, group-scoped API keys, and per-provider request
+# quirks (e.g. Kimi rejecting any explicit temperature) — re-implementing
+# those here produced a string of provider-specific failures (retired
+# DeepSeek names, Kimi temperature 400s, per-tenant keys written into the
+# shared process env). None of that belongs outside the manager.
+# ---------------------------------------------------------------------------
+
+# Per-worker-thread override consumed by the patched gepa.optimize below.
+_GEPA_REFLECTION_STATE = threading.local()
+
+
+def _install_gepa_reflection_bridge() -> None:
+    """Route GEPA's reflection LM through LLMManager (idempotent).
+
+    MLflow's GepaPromptOptimizer pins `reflection_lm` to a litellm model
+    STRING in the kwargs it builds last, so a callable cannot be injected via
+    gepa_kwargs. gepa itself accepts any callable conforming to its
+    LanguageModel protocol; this one-time patch swaps in the callable armed on
+    the current worker thread (each optimization run owns one thread, so
+    concurrent runs cannot cross wires).
+    """
+    import gepa
+
+    if getattr(gepa.optimize, "_kasal_reflection_bridge", False):
+        return
+    original = gepa.optimize
+
+    def bridged(*args, **kwargs):
+        override = getattr(_GEPA_REFLECTION_STATE, "reflection_fn", None)
+        if override is not None:
+            kwargs["reflection_lm"] = override
+        return original(*args, **kwargs)
+
+    bridged._kasal_reflection_bridge = True
+    gepa.optimize = bridged
+
+
+def _make_reflection_fn(
+    loop: asyncio.AbstractEventLoop,
+    model: str,
+    group_context: Optional[GroupContext],
+    user_token: Optional[str],
+):
+    """Build GEPA's reflection callable, backed by LLMManager.
+
+    `model` is a plain Kasal model key — LLMManager resolves provider,
+    endpoint, group-scoped API key, and request quirks (it drops temperature
+    for Kimi, which 400s on any explicit value)."""
+
+    def reflection_fn(prompt: Any) -> str:
+        if isinstance(prompt, list):
+            messages = list(prompt)
+        else:
+            messages = [{"role": "user", "content": str(prompt)}]
+        # Cache-buster: the reflection prompt is byte-identical every
+        # iteration in the 1-example regime, and the process-global litellm
+        # cache would replay one cached proposal forever (observed live:
+        # duration=0.00s, identical candidates). A unique system line keeps
+        # each request distinct without touching the task content.
+        messages = [
+            {
+                "role": "system",
+                "content": f"reflection request {uuid.uuid4().hex}",
+            }
+        ] + messages
+        return _sync_llm_completion(
+            loop,
+            messages=messages,
+            model=model,
+            # Forced-thinking models (Kimi K2.x) spend heavily on reasoning
+            # before the visible document; starving them returns empty text.
+            max_tokens=6000,
+            group_context=group_context,
+            user_token=user_token,
+            # Proposal diversity. LLMManager drops the param for providers
+            # that reject it — no per-provider branching here.
+            temperature=0.8,
+        )
+
+    return reflection_fn
+
+
+def _stored_judge_model_to_key(stored: Any) -> Optional[str]:
+    """Kasal model key from a judge's stored model field.
+
+    New judges store the Kasal key wrapped as 'openai:/<key>' purely to
+    satisfy make_judge's URI shape (the judge is INVOKED via LLMManager, the
+    URI is inert). Legacy judges stored real provider URIs — the remainder
+    after '<scheme>:/' is the best available key for those too.
+    """
+    if not stored:
+        return None
+    text = str(stored)
+    if ":/" in text:
+        return text.split(":/", 1)[1] or None
+    return text
+
+
+def _parse_grade_from_text(text: str) -> Optional[float]:
+    """0-1 grade from a judge reply: LAST number wins (thinking models emit
+    incidental numbers first); values in (10, 100] are read as percentages —
+    clamping alone turned a hallucinated '40' into a perfect 10/10."""
+    matches = re.findall(r"\d+(?:\.\d+)?", text or "")
+    if not matches:
+        return None
+    number = float(matches[-1])
+    if 10.0 < number <= 100.0:
+        number /= 10.0
+    return max(0.0, min(10.0, number)) / 10.0
+
+
+def _preflight_reflection(
+    loop: asyncio.AbstractEventLoop,
+    model: str,
+    group_context: Optional[GroupContext],
+    user_token: Optional[str],
+) -> None:
+    """Tiny ping of GEPA's reflection model BEFORE any budget is spent.
 
     A dead reflection model doesn't fail a run — GEPA just proposes zero
     candidates and 'completes' at the baseline after burning the whole
     execution budget (observed live with a retired provider model name).
+    Runs through LLMManager like every other call.
     """
-    import litellm
-
-    saved = {k: os.environ.get(k) for k in reflection_env}
     try:
-        for k, v in reflection_env.items():
-            os.environ[k] = v
-        litellm_model = reflection_uri.replace(":/", "/", 1)
-        litellm.completion(
-            model=litellm_model,
-            messages=[{"role": "user", "content": "ping"}],
-            max_tokens=1,
+        _sync_llm_completion(
+            loop,
+            messages=[{"role": "user", "content": "ping — reply with OK"}],
+            model=model,
+            max_tokens=5,
+            group_context=group_context,
+            user_token=user_token,
         )
     except Exception as e:
         raise ValueError(
-            f"Reflection model '{reflection_uri}' failed a test call — the "
+            f"Reflection model '{model}' failed a test call — the "
             f"optimization cannot generate candidates with it. Pick a different "
             f"reflection model. Provider error: {str(e)[:300]}"
         )
-    finally:
-        for k, old in saved.items():
-            if old is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = old
 
 
 def _sync_llm_completion(
@@ -496,6 +607,7 @@ def _sync_llm_completion(
     max_tokens: int,
     group_context: Optional[GroupContext] = None,
     user_token: Optional[str] = None,
+    temperature: float = 0.0,
 ) -> str:
     """Run LLMManager.completion from a worker thread by submitting it to the
     MAIN event loop. Never run it on a fresh loop (asyncio.run) — the app's
@@ -518,7 +630,10 @@ def _sync_llm_completion(
         return await LLMManager.completion(
             messages=messages,
             model=model,
-            temperature=0.0,
+            # 0.0 for deterministic judging/distillation; reflection passes
+            # 0.8 for proposal diversity. LLMManager owns per-provider quirks
+            # (it drops the param entirely for models that reject it).
+            temperature=temperature,
             max_tokens=max_tokens,
             extra_headers=get_user_agent_header(KasalProduct.PROMPT_IMPROVEMENT),
         )
@@ -649,11 +764,10 @@ class PromptOptimizationService:
 
         target_model = request.model or DEFAULT_TARGET_MODEL
         judge_model = request.judge_model or target_model
-        reflection_uri, reflection_env, reflection_provider = (
-            await self._resolve_reflection_model(
-                request.reflection_model or target_model, group_context
-            )
-        )
+        # Reflection is a Kasal model key like every other model here —
+        # invocation goes through LLMManager (keys, endpoints, provider quirks
+        # all owned there), so no URI/env resolution happens in this service.
+        reflection_model = request.reflection_model or target_model
         registry_uri, prompt_name = await self._resolve_registry(
             request.template_name, group_context
         )
@@ -687,8 +801,7 @@ class PromptOptimizationService:
                 input_key=task_cfg["input_key"],
                 target_model=target_model,
                 judge_model=judge_model,
-                reflection_uri=reflection_uri,
-                reflection_env=reflection_env,
+                reflection_model=reflection_model,
                 max_metric_calls=request.max_metric_calls,
                 registry_uri=registry_uri,
                 prompt_name=prompt_name,
@@ -744,105 +857,6 @@ class PromptOptimizationService:
                     break
             page += 1
         return examples
-
-    # Providers whose GEPA reflection calls authenticate via a single API-key
-    # env var (litellm convention), with the key held in Kasal's key store.
-    _REFLECTION_KEY_ENV = {
-        "openai": "OPENAI_API_KEY",
-        "deepseek": "DEEPSEEK_API_KEY",
-        "anthropic": "ANTHROPIC_API_KEY",
-        "gemini": "GEMINI_API_KEY",
-        "groq": "GROQ_API_KEY",
-        "mistral": "MISTRAL_API_KEY",
-    }
-
-    async def _resolve_reflection_model(
-        self, model_key: str, group_context: Optional[GroupContext] = None
-    ) -> tuple:
-        """Map a Kasal model key to an MLflow/GEPA reflection-model URI.
-
-        GEPA invokes its reflection model itself (outside LLMManager), so the
-        key must become a provider URI plus any env vars the provider needs —
-        including the provider API key from Kasal's group-scoped key store.
-
-        Returns (uri, env, provider) — the provider string lets callers apply
-        provider-specific request quirks (e.g. Kimi rejects any temperature).
-        """
-        config = await self.model_repository.find_by_key(model_key)
-        provider = (getattr(config, "provider", None) or "").lower() if config else ""
-        # The provider API expects the config's `name` (llm_manager does this
-        # translation too) — sending the Kasal KEY 400s when they differ
-        # (observed live: key deepseek-v3.1-non-thinking vs API name).
-        api_model = (
-            (getattr(config, "name", None) or model_key) if config else model_key
-        )
-        if provider == "databricks":
-            return f"databricks:/{api_model}", {}, provider
-        if provider == "vllm":
-            # OpenAI-compatible endpoint — same env resolution as llm_manager.
-            return (
-                f"openai:/{api_model}",
-                {
-                    "OPENAI_API_BASE": os.getenv(
-                        "VLLM_BASE_URL", "http://localhost:8081/v1"
-                    ),
-                    "OPENAI_API_KEY": os.getenv("VLLM_API_KEY", "vllm"),
-                },
-                provider,
-            )
-        if provider == "kimi":
-            # Kimi (Moonshot AI) — OpenAI-compatible endpoint with the key from
-            # Kasal's key store, mirroring llm_manager's kimi routing.
-            from src.services.api_keys_service import ApiKeysService
-
-            group_id = group_context.primary_group_id if group_context else None
-            api_key = await ApiKeysService.get_provider_api_key(
-                "kimi", group_id=group_id
-            )
-            if not api_key:
-                raise ValueError(
-                    "Reflection model needs a Kimi API key — add KIMI_API_KEY "
-                    "under Configuration -> API Keys."
-                )
-            return (
-                f"openai:/{api_model}",
-                {
-                    "OPENAI_API_BASE": os.getenv(
-                        "KIMI_ENDPOINT", "https://api.moonshot.ai/v1"
-                    ),
-                    "OPENAI_API_KEY": api_key,
-                },
-                provider,
-            )
-        if provider in self._REFLECTION_KEY_ENV:
-            env: Dict[str, str] = {}
-            env_name = self._REFLECTION_KEY_ENV[provider]
-            try:
-                from src.services.api_keys_service import ApiKeysService
-
-                group_id = group_context.primary_group_id if group_context else None
-                api_key = await ApiKeysService.get_provider_api_key(
-                    provider, group_id=group_id
-                )
-                if api_key:
-                    env[env_name] = api_key
-            except Exception as key_err:
-                logger.warning(
-                    f"Could not fetch {provider} API key for reflection model: {key_err}"
-                )
-            # Fall back to a pre-set env var when the store has no key.
-            if env_name not in env and not os.getenv(env_name):
-                raise ValueError(
-                    f"Reflection model '{model_key}' needs a {provider} API key "
-                    f"(configure it under API Keys) or pass 'reflection_model' "
-                    f"with a different provider."
-                )
-            return f"{provider}:/{api_model}", env, provider
-        raise ValueError(
-            f"Reflection model '{model_key}' has unsupported provider '{provider or 'unknown'}' "
-            f"(supported: databricks, vllm, kimi, {', '.join(sorted(self._REFLECTION_KEY_ENV))}). "
-            f"Pass 'reflection_model' explicitly."
-        )
 
     async def _resolve_registry(
         self, template_name: str, group_context: Optional[GroupContext]
@@ -936,8 +950,7 @@ class PromptOptimizationService:
         input_key: str,
         target_model: str,
         judge_model: str,
-        reflection_uri: str,
-        reflection_env: Dict[str, str],
+        reflection_model: str,
         max_metric_calls: int,
         registry_uri: str,
         prompt_name: str,
@@ -1121,7 +1134,6 @@ class PromptOptimizationService:
             {"inputs": {input_key: ex}, "expectations": {}} for ex in examples
         ]
 
-        saved_env = {k: os.environ.get(k) for k in reflection_env}
         # Mark every autolog flavor disabled for the span: optimize_prompts'
         # evaluation wrapper otherwise registers import hooks that lazily
         # import each installed flavor module (openai, crewai, ...) inside a
@@ -1146,23 +1158,24 @@ class PromptOptimizationService:
         _prev_parser_level = _parser_logger.level
         _parser_logger.setLevel(logging.CRITICAL)
 
+        reflection_fn = _make_reflection_fn(
+            loop, reflection_model, group_context, user_token
+        )
+        _install_gepa_reflection_bridge()
+
         # Tracking is already redirected in local mode (see above); this
         # try/finally owns restoring it once the optimization ends.
         try:
-            for k, v in reflection_env.items():
-                os.environ[k] = v
+            _GEPA_REFLECTION_STATE.reflection_fn = reflection_fn
             result = optimize_prompts(
                 predict_fn=predict_fn,
                 train_data=train_data,
                 prompt_uris=[prompt_uri],
                 optimizer=GepaPromptOptimizer(
-                    reflection_model=reflection_uri,
+                    # Inert placeholder — the bridge swaps in the LLMManager
+                    # -backed callable; this string is parsed but never called.
+                    reflection_model="openai:/kasal-llm-manager",
                     max_metric_calls=max_metric_calls,
-                    # llm_manager enables a process-global litellm cache;
-                    # without a per-request bypass, identical reflection
-                    # prompts are served the same cached proposal forever
-                    # (observed live in crew mode).
-                    gepa_kwargs={"reflection_lm_kwargs": {"cache": {"no-cache": True}}},
                 ),
                 scorers=[output_format, output_correct],
                 aggregation=aggregation,
@@ -1171,6 +1184,7 @@ class PromptOptimizationService:
                 enable_tracking=local_mode,
             )
         finally:
+            _GEPA_REFLECTION_STATE.reflection_fn = None
             _parser_logger.setLevel(_prev_parser_level)
             _restore_span_env()
             for _flavor, old_flag in saved_autolog_flags.items():
@@ -1178,11 +1192,6 @@ class PromptOptimizationService:
                     AUTOLOGGING_INTEGRATIONS.get(_flavor, {}).pop("disable", None)
                 else:
                     AUTOLOGGING_INTEGRATIONS[_flavor]["disable"] = old_flag
-            for k, old in saved_env.items():
-                if old is None:
-                    os.environ.pop(k, None)
-                else:
-                    os.environ[k] = old
 
         optimized = result.optimized_prompts[0]
         return {
@@ -1299,11 +1308,8 @@ class PromptOptimizationService:
 
         target_model = request.model or DEFAULT_TARGET_MODEL
         judge_model = request.judge_model or target_model
-        reflection_uri, reflection_env, reflection_provider = (
-            await self._resolve_reflection_model(
-                request.reflection_model or target_model, group_context
-            )
-        )
+        # A Kasal model key; invoked through LLMManager (no URI/env plumbing).
+        reflection_model = request.reflection_model or target_model
         registry_uri, _ = await self._resolve_registry("crew", group_context)
         safe_group = "".join(
             c if c.isalnum() or c in "-_" else "_"
@@ -1352,9 +1358,7 @@ class PromptOptimizationService:
                 tasks_yaml=tasks_yaml,
                 target_model=target_model,
                 judge_model=judge_model,
-                reflection_uri=reflection_uri,
-                reflection_env=reflection_env,
-                reflection_provider=reflection_provider,
+                reflection_model=reflection_model,
                 max_metric_calls=request.max_metric_calls,
                 execution_timeout=request.execution_timeout_seconds,
                 registry_uri=registry_uri,
@@ -1377,15 +1381,13 @@ class PromptOptimizationService:
         tasks_yaml: Dict[str, Any],
         target_model: str,
         judge_model: str,
-        reflection_uri: str,
-        reflection_env: Dict[str, str],
+        reflection_model: str,
         max_metric_calls: int,
         execution_timeout: int,
         registry_uri: str,
         prompt_name: str,
         crew_id: str = "",
         cancel_run_id: str = "",
-        reflection_provider: str = "",
         group_context: Optional[GroupContext] = None,
     ) -> Dict[str, Any]:
         """Blocking crew-optimization body (worker thread). Mirrors the
@@ -1421,14 +1423,10 @@ class PromptOptimizationService:
             cfg = AUTOLOGGING_INTEGRATIONS.setdefault(_flavor, {})
             saved_autolog_flags[_flavor] = cfg.get("disable")
             cfg["disable"] = True
-        saved_env = {k: os.environ.get(k) for k in reflection_env}
 
         try:
-            for k, v in reflection_env.items():
-                os.environ[k] = v
-
             # Fail fast on a dead reflection model — before ANY crew execution.
-            _preflight_reflection(reflection_uri, reflection_env)
+            _preflight_reflection(loop, reflection_model, group_context, user_token)
 
             prompt_version = client.register_prompt(
                 name=prompt_name,
@@ -1880,31 +1878,60 @@ class PromptOptimizationService:
                 # running as separate MLflow scorers — trace-based scorers were
                 # each re-triggering their own crew execution (observed live as
                 # bursts of one execution per judge), multiplying the budget.
+                # Registered judges are RENDERED AND INVOKED HERE through
+                # LLMManager — never via mlflow's own model client. The judge
+                # entity contributes only its instructions and model key;
+                # provider routing, keys and request quirks stay centralized
+                # in the manager (invoking judges through mlflow's client is
+                # what produced the retired-DeepSeek and Kimi failures).
                 for judge in registered_scorers:
+                    judge_name = getattr(judge, "name", "judge")
                     try:
-                        feedback = judge(
-                            inputs={"request": inputs.get("request", objective)},
-                            outputs=text,
+                        instructions = getattr(judge, "instructions", "") or ""
+                        rendered = (
+                            instructions.replace("{{ outputs }}", text)
+                            .replace("{{outputs}}", text)
+                            .replace(
+                                "{{ inputs }}", str(inputs.get("request", objective))
+                            )
+                            .replace(
+                                "{{inputs}}", str(inputs.get("request", objective))
+                            )
                         )
-                        grade = _judge_value_to_grade(getattr(feedback, "value", None))
+                        judge_reply = _sync_llm_completion(
+                            loop,
+                            messages=[
+                                {
+                                    "role": "user",
+                                    "content": (
+                                        f"{rendered}\n\nEnd your reply with the "
+                                        "numeric grade 0-10 alone on the LAST line."
+                                    ),
+                                }
+                            ],
+                            model=_stored_judge_model_to_key(
+                                getattr(judge, "model", None)
+                            )
+                            or judge_model,
+                            max_tokens=1500,
+                            group_context=group_context,
+                            user_token=user_token,
+                        )
+                        grade = _parse_grade_from_text(judge_reply)
                         if grade is None:
                             logger.warning(
-                                f"Registered judge '{getattr(judge, 'name', '?')}' "
-                                f"returned unusable value "
-                                f"{getattr(feedback, 'value', None)!r}; skipping"
+                                f"Registered judge '{judge_name}' reply not "
+                                f"numeric; skipping: {judge_reply!r:.200}"
                             )
                         else:
                             grades.append(grade)
-                            judge_rationale = getattr(feedback, "rationale", None)
-                            if judge_rationale:
+                            if judge_reply and judge_reply.strip():
                                 rationale_parts.append(
-                                    f"[{getattr(judge, 'name', 'judge')}] "
-                                    f"{judge_rationale}"
+                                    f"[{judge_name}] {judge_reply.strip()}"
                                 )
                     except Exception as judge_err:
                         logger.warning(
-                            f"Registered judge '{getattr(judge, 'name', '?')}' "
-                            f"failed: {judge_err}"
+                            f"Registered judge '{judge_name}' failed: {judge_err}"
                         )
                 grade_value = sum(grades) / len(grades) if grades else 0.0
                 rationale = "\n".join(rationale_parts)[:4000]
@@ -1928,6 +1955,11 @@ class PromptOptimizationService:
                 correct = _num(scores.get("output_correct"))
                 return 0.3 * fmt + 0.7 * correct
 
+            reflection_fn = _make_reflection_fn(
+                loop, reflection_model, group_context, user_token
+            )
+            _install_gepa_reflection_bridge()
+            _GEPA_REFLECTION_STATE.reflection_fn = reflection_fn
             result = optimize_prompts(
                 predict_fn=predict_fn,
                 train_data=[
@@ -1938,7 +1970,9 @@ class PromptOptimizationService:
                 ],
                 prompt_uris=[prompt_uri],
                 optimizer=GepaPromptOptimizer(
-                    reflection_model=reflection_uri,
+                    # Inert placeholder — the bridge swaps in the LLMManager
+                    # -backed callable; this string is parsed, never called.
+                    reflection_model="openai:/kasal-llm-manager",
                     # METRIC calls are decoupled from crew EXECUTIONS: with
                     # the caches (ours + gepa's) most metric calls are free
                     # re-scores, so the user's number stays a hard cap on real
@@ -1963,42 +1997,6 @@ class PromptOptimizationService:
                         # the metric call entirely on repeats, preserving the
                         # metric budget for NEW candidates.
                         "cache_evaluation": True,
-                        # The reflection prompt is IDENTICAL every iteration
-                        # (same parent, same single example, cached rationale),
-                        # so a deterministic reflection endpoint re-proposed
-                        # the byte-identical candidate 11 times in one run —
-                        # every iteration a free cache-hit rejection, budget
-                        # drained, zero exploration (observed live in
-                        # proposals.json). Explicit sampling temperature is
-                        # the only diversity source this setup has — and
-                        # no-cache is MANDATORY: llm_manager enables a
-                        # process-global litellm disk cache at import, and
-                        # gepa's LM rides the same litellm, so identical
-                        # reflection prompts were served the SAME cached
-                        # response forever (observed live: duration=0.00s,
-                        # byte-identical proposals at temperature 1.0).
-                        # 0.8, not 1.0: at 1.0 the reflection model emitted a
-                        # bare "```" and stopped in 2 of 3 samples; at 0.8
-                        # with the no-fence contract below, 4 of 4 samples
-                        # parsed, were distinct, and carried the requirements
-                        # (validated offline against the live endpoint).
-                        # PROVIDER QUIRK — Kimi K-series accepts ONLY its
-                        # default temperature: sending 0.8 made Moonshot 400
-                        # every reflection call ("invalid temperature: only 1
-                        # is allowed"), gepa skipped 10 proposals in a row and
-                        # the run 'completed' after the baseline's single
-                        # execution (observed live; verified by direct repro —
-                        # the same call without temperature returns a clean,
-                        # parseable crew doc). Kimi's forced default sampling
-                        # is itself diverse, so dropping the knob is safe.
-                        "reflection_lm_kwargs": (
-                            {"cache": {"no-cache": True}}
-                            if reflection_provider == "kimi"
-                            else {
-                                "temperature": 0.8,
-                                "cache": {"no-cache": True},
-                            }
-                        ),
                         # gepa's default template says "write a new
                         # instruction ... within ``` blocks" — an open
                         # invitation to restructure: the reflection model
@@ -2043,6 +2041,7 @@ class PromptOptimizationService:
                 enable_tracking=local_mode,
             )
         finally:
+            _GEPA_REFLECTION_STATE.reflection_fn = None
             if local_mode:
                 mlflow.set_tracking_uri(prev_tracking)
             for k, old in saved_exp_env.items():
@@ -2053,11 +2052,6 @@ class PromptOptimizationService:
                     AUTOLOGGING_INTEGRATIONS.get(_flavor, {}).pop("disable", None)
                 else:
                     AUTOLOGGING_INTEGRATIONS[_flavor]["disable"] = old_flag
-            for k, old in saved_env.items():
-                if old is None:
-                    os.environ.pop(k, None)
-                else:
-                    os.environ[k] = old
 
         optimized = result.optimized_prompts[0]
         optimized_fields = _parse_crew_doc(optimized.template) or {}
@@ -2265,9 +2259,10 @@ class PromptOptimizationService:
             raise ValueError("Judge instructions are required")
         if "{{ outputs }}" not in text and "{{outputs}}" not in text:
             text += "\n\nThe answer to evaluate:\n{{ outputs }}"
-        model_uri, _env, _provider = await self._resolve_reflection_model(
-            model or DEFAULT_TARGET_MODEL, group_context
-        )
+        # The judge is INVOKED through LLMManager with the plain Kasal model
+        # key; the 'openai:/' wrapper exists only to satisfy make_judge's URI
+        # shape and is stripped back on invocation. No provider resolution.
+        model_uri = f"openai:/{model or DEFAULT_TARGET_MODEL}"
         scoped_name = (
             f"{self._crew_judge_prefix(crew_id)}{safe_name}" if crew_id else None
         )
@@ -2363,11 +2358,9 @@ class PromptOptimizationService:
         new_text = (instructions or "").strip()
         if not new_text and not model:
             raise ValueError("Nothing to update: provide instructions and/or a model")
-        model_uri: Optional[str] = None
-        if model:
-            model_uri, _env, _provider = await self._resolve_reflection_model(
-                model, group_context
-            )
+        # Plain Kasal model key, wrapped only for make_judge's URI shape —
+        # invocation goes through LLMManager (see _stored_judge_model_to_key).
+        model_uri: Optional[str] = f"openai:/{model}" if model else None
 
         def _update() -> Dict[str, Any]:
             import mlflow

--- a/src/backend/tests/unit/api/test_prompt_optimization_router.py
+++ b/src/backend/tests/unit/api/test_prompt_optimization_router.py
@@ -1,0 +1,312 @@
+"""
+Unit tests for the prompt-optimization API router.
+
+The router is a thin boundary: every handler builds the service, translates
+ValueError → BadRequestError (client input) or NotFoundError (missing runs),
+and wraps results in response schemas. Handlers are invoked directly with a
+patched service, mirroring the other router unit tests.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# NOTE: both `from src.api import prompt_optimization_router` and
+# `import src.api.prompt_optimization_router as m` yield the APIRouter object —
+# the package __init__ rebinds the module name to the router, and the `as m`
+# form resolves through that shadowed package attribute. importlib returns the
+# actual module from sys.modules.
+import importlib
+
+router_module = importlib.import_module("src.api.prompt_optimization_router")
+from src.api.prompt_optimization_router import (
+    add_eval_feedback,
+    apply_run,
+    assign_judge,
+    cancel_run,
+    create_judge,
+    delete_judge,
+    get_run,
+    list_crew_evals,
+    list_judges,
+    list_runs,
+    router,
+    start_crew_optimization,
+    start_optimization,
+    update_judge,
+)
+from src.core.exceptions import BadRequestError, NotFoundError
+from src.schemas.prompt_optimization import (
+    CrewOptimizationRequest,
+    PromptOptimizationRequest,
+)
+
+
+def _group(token=None):
+    context = MagicMock()
+    context.access_token = token
+    context.primary_group_id = "grp1"
+    return context
+
+
+RUN = {
+    "run_id": "abc123",
+    "template_name": "detect_intent",
+    "status": "completed",
+    "dataset_size": 5,
+    "initial_score": 0.5,
+    "final_score": 0.9,
+    "applied": False,
+    "created_at": datetime.now(timezone.utc),
+    "human_feedback_count": 3,
+    "candidates_tried": 4,
+}
+
+
+@pytest.fixture()
+def service():
+    svc = MagicMock()
+    with patch.object(
+        router_module, "PromptOptimizationService", return_value=svc
+    ):
+        yield svc
+
+
+class TestRouterConfiguration:
+    def test_prefix_and_tags(self):
+        assert router.prefix == "/prompt-optimization"
+        assert "prompt optimization" in router.tags
+
+
+class TestStartEndpoints:
+    @pytest.mark.asyncio
+    async def test_start_optimization_success(self, service):
+        service.start_optimization = AsyncMock(
+            return_value={"run_id": "r1", "status": "pending", "dataset_size": 5}
+        )
+        request = PromptOptimizationRequest(
+            template_name="detect_intent", examples=["a", "b", "c", "d", "e"]
+        )
+        response = await start_optimization(request, _group(), MagicMock())
+        assert response.run_id == "r1"
+        assert response.dataset_size == 5
+
+    @pytest.mark.asyncio
+    async def test_start_optimization_value_error_becomes_400(self, service):
+        service.start_optimization = AsyncMock(
+            side_effect=ValueError("need at least 4 examples")
+        )
+        request = PromptOptimizationRequest(
+            template_name="detect_intent", examples=["a"] * 5
+        )
+        with pytest.raises(BadRequestError, match="at least 4"):
+            await start_optimization(request, _group(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_start_crew_optimization_success(self, service):
+        service.start_crew_optimization = AsyncMock(
+            return_value={"run_id": "r2", "status": "pending", "dataset_size": 1}
+        )
+        request = CrewOptimizationRequest(crew_id="c1")
+        response = await start_crew_optimization(request, _group(), MagicMock())
+        assert response.run_id == "r2"
+        assert response.dataset_size == 1
+
+    @pytest.mark.asyncio
+    async def test_start_crew_optimization_value_error_becomes_400(self, service):
+        service.start_crew_optimization = AsyncMock(
+            side_effect=ValueError("crew not found")
+        )
+        with pytest.raises(BadRequestError, match="crew not found"):
+            await start_crew_optimization(
+                CrewOptimizationRequest(crew_id="c1"), _group(), MagicMock()
+            )
+
+    @pytest.mark.asyncio
+    async def test_start_publishes_user_context(self, service):
+        service.start_optimization = AsyncMock(
+            return_value={"run_id": "r1", "status": "pending", "dataset_size": 5}
+        )
+        request = PromptOptimizationRequest(
+            template_name="detect_intent", examples=["a"] * 5
+        )
+        with patch("src.utils.user_context.UserContext") as user_context:
+            await start_optimization(request, _group(token="tok"), MagicMock())
+            user_context.set_group_context.assert_called_once()
+            user_context.set_user_token.assert_called_once_with("tok")
+
+
+class TestCrewOptimizationRequestBounds:
+    def test_budget_defaults_and_bounds(self):
+        assert CrewOptimizationRequest(crew_id="c").max_metric_calls == 10
+        assert (
+            CrewOptimizationRequest(crew_id="c", max_metric_calls=4).max_metric_calls
+            == 4
+        )
+        with pytest.raises(ValueError):
+            CrewOptimizationRequest(crew_id="c", max_metric_calls=3)
+        with pytest.raises(ValueError):
+            CrewOptimizationRequest(crew_id="c", max_metric_calls=41)
+
+    def test_template_name_is_a_closed_set(self):
+        with pytest.raises(ValueError):
+            PromptOptimizationRequest(template_name="not_a_template")
+
+
+class TestEvalEndpoints:
+    @pytest.mark.asyncio
+    async def test_list_crew_evals(self, service):
+        service.list_crew_evals = AsyncMock(return_value=[{"trace_id": "t1"}])
+        result = await list_crew_evals("crew1", _group(), MagicMock())
+        assert result == {"evals": [{"trace_id": "t1"}]}
+        service.list_crew_evals.assert_awaited_once_with("crew1")
+
+    @pytest.mark.asyncio
+    async def test_add_eval_feedback_coerces_numeric_value(self, service):
+        service.add_eval_feedback = AsyncMock(return_value=True)
+        result = await add_eval_feedback(
+            "t1",
+            {"value": "7", "comment": "good", "expectation": "german side"},
+            _group(),
+            MagicMock(),
+        )
+        assert result == {"ok": True}
+        service.add_eval_feedback.assert_awaited_once_with(
+            "t1", 7.0, "good", "german side"
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_eval_feedback_rejects_non_numeric_value(self, service):
+        with pytest.raises(BadRequestError, match="number"):
+            await add_eval_feedback(
+                "t1", {"value": "not-a-number"}, _group(), MagicMock()
+            )
+
+    @pytest.mark.asyncio
+    async def test_add_eval_feedback_service_error_becomes_400(self, service):
+        service.add_eval_feedback = AsyncMock(
+            side_effect=ValueError("local MLflow required")
+        )
+        with pytest.raises(BadRequestError, match="local MLflow"):
+            await add_eval_feedback("t1", {"value": 5}, _group(), MagicMock())
+
+
+class TestJudgeEndpoints:
+    @pytest.mark.asyncio
+    async def test_list_judges(self, service):
+        service.list_judges = AsyncMock(return_value=[{"name": "acc"}])
+        result = await list_judges(_group(), MagicMock())
+        assert result == {"judges": [{"name": "acc"}]}
+
+    @pytest.mark.asyncio
+    async def test_create_judge_passes_fields(self, service):
+        service.create_judge = AsyncMock(return_value={"name": "acc"})
+        body = {
+            "name": "acc",
+            "instructions": "criteria",
+            "model": "qwen",
+            "crew_id": "c1",
+        }
+        result = await create_judge(body, _group(), MagicMock())
+        assert result == {"name": "acc"}
+        kwargs = service.create_judge.await_args.kwargs
+        assert kwargs["name"] == "acc"
+        assert kwargs["instructions"] == "criteria"
+        assert kwargs["model"] == "qwen"
+        assert kwargs["crew_id"] == "c1"
+
+    @pytest.mark.asyncio
+    async def test_create_judge_error_becomes_400(self, service):
+        service.create_judge = AsyncMock(side_effect=ValueError("name required"))
+        with pytest.raises(BadRequestError, match="name required"):
+            await create_judge({"name": ""}, _group(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_assign_judge_requires_crew_id(self, service):
+        with pytest.raises(BadRequestError, match="crew_id"):
+            await assign_judge("acc", {}, _group(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_assign_judge_passes_through(self, service):
+        service.assign_judge = AsyncMock(return_value={"full_name": "crew_x__acc"})
+        result = await assign_judge("acc", {"crew_id": "c1"}, _group(), MagicMock())
+        assert result["full_name"] == "crew_x__acc"
+
+    @pytest.mark.asyncio
+    async def test_update_judge_passes_changes(self, service):
+        service.update_judge = AsyncMock(return_value={"name": "acc"})
+        result = await update_judge(
+            "acc", {"instructions": "new", "model": "qwen"}, _group(), MagicMock()
+        )
+        assert result == {"name": "acc"}
+        kwargs = service.update_judge.await_args.kwargs
+        assert kwargs["name"] == "acc"
+        assert kwargs["instructions"] == "new"
+        assert kwargs["model"] == "qwen"
+
+    @pytest.mark.asyncio
+    async def test_update_judge_error_becomes_400(self, service):
+        service.update_judge = AsyncMock(side_effect=ValueError("Nothing to update"))
+        with pytest.raises(BadRequestError, match="Nothing to update"):
+            await update_judge("acc", {}, _group(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_delete_judge(self, service):
+        service.delete_judge = AsyncMock(return_value=True)
+        assert await delete_judge("acc", _group(), MagicMock()) == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_delete_judge_error_becomes_400(self, service):
+        service.delete_judge = AsyncMock(side_effect=ValueError("local MLflow"))
+        with pytest.raises(BadRequestError):
+            await delete_judge("acc", _group(), MagicMock())
+
+
+class TestRunEndpoints:
+    @pytest.mark.asyncio
+    async def test_list_runs_wraps_status_models(self, service):
+        service.list_runs = MagicMock(return_value=[RUN])
+        response = await list_runs(_group(), MagicMock())
+        assert len(response.runs) == 1
+        status = response.runs[0]
+        assert status.run_id == "abc123"
+        assert status.human_feedback_count == 3
+        assert status.candidates_tried == 4
+
+    @pytest.mark.asyncio
+    async def test_get_run_found(self, service):
+        service.get_run = MagicMock(return_value=RUN)
+        status = await get_run("abc123", _group(), MagicMock())
+        assert status.final_score == 0.9
+
+    @pytest.mark.asyncio
+    async def test_get_run_missing_is_404(self, service):
+        service.get_run = MagicMock(return_value=None)
+        with pytest.raises(NotFoundError, match="abc123"):
+            await get_run("abc123", _group(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_cancel_run_passthrough_and_404(self, service):
+        service.cancel_run = MagicMock(
+            return_value={"run_id": "abc123", "cancelling": True}
+        )
+        assert (await cancel_run("abc123", _group(), MagicMock()))["cancelling"]
+        service.cancel_run = MagicMock(side_effect=ValueError("not found"))
+        with pytest.raises(NotFoundError):
+            await cancel_run("abc123", _group(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_apply_run_success_and_404(self, service):
+        service.apply_run = AsyncMock(
+            return_value={
+                "run_id": "abc123",
+                "template_name": "detect_intent",
+                "applied": True,
+            }
+        )
+        response = await apply_run("abc123", _group(), MagicMock())
+        assert response.applied is True
+        service.apply_run = AsyncMock(side_effect=ValueError("no completed proposal"))
+        with pytest.raises(NotFoundError):
+            await apply_run("abc123", _group(), MagicMock())

--- a/src/backend/tests/unit/engines/crewai/config/test_embedder_fail_open.py
+++ b/src/backend/tests/unit/engines/crewai/config/test_embedder_fail_open.py
@@ -1,0 +1,68 @@
+"""Tests for the crew-memory embedder fail-open policy (_embed_with_fail_open).
+
+Crew memory is an enhancement, not part of producing the metric view — a
+transient embedding failure (SSL/EOF, connection reset, 429/5xx) must never
+propagate and fail a flow whose generation already succeeded. Regression for a
+production `SSLEOFError` on the embedding endpoint that flipped a completed UCMV
+run to FAILED.
+
+Imports only the module-level helper (not EmbedderConfigBuilder), so it avoids
+the heavy engine import chain.
+"""
+import os
+
+os.environ.setdefault("DATABASE_TYPE", "sqlite")
+os.environ.setdefault("SQLITE_DB_PATH", ":memory:")
+
+import requests  # noqa: E402
+from src.engines.crewai.config.embedder_config_builder import _embed_with_fail_open  # noqa: E402
+
+
+def _no_sleep(_seconds):
+    return None
+
+
+class TestEmbedFailOpen:
+    def test_retries_transient_then_succeeds(self):
+        calls = {"n": 0}
+
+        def flaky(docs):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise requests.exceptions.SSLError("EOF occurred in violation of protocol")
+            return [[1.0, 2.0]]
+
+        out = _embed_with_fail_open(flaky, ["x"], dimension=2, max_attempts=3, sleep_fn=_no_sleep)
+        assert out == [[1.0, 2.0]]
+        assert calls["n"] == 2  # retried once, then succeeded
+
+    def test_fails_open_to_zero_vectors_on_persistent_transport_error(self):
+        def always(docs):
+            raise requests.exceptions.ConnectionError("connection reset")
+
+        out = _embed_with_fail_open(always, ["a", "b"], dimension=4, max_attempts=3, sleep_fn=_no_sleep)
+        assert out == [[0.0] * 4, [0.0] * 4]  # one zero-vector per doc; never raises
+
+    def test_non_retryable_stops_immediately_and_fails_open(self):
+        calls = {"n": 0}
+
+        def authfail(docs):
+            calls["n"] += 1
+            raise Exception("No authentication method available")  # no .retryable flag
+
+        out = _embed_with_fail_open(authfail, ["a"], dimension=3, max_attempts=3, sleep_fn=_no_sleep)
+        assert calls["n"] == 1  # not retried (non-transient)
+        assert out == [[0.0, 0.0, 0.0]]
+
+    def test_retryable_5xx_is_retried_then_fails_open(self):
+        calls = {"n": 0}
+
+        def server_err(docs):
+            calls["n"] += 1
+            e = Exception("Embedding API error 503: unavailable")
+            e.retryable = True  # transient server error
+            raise e
+
+        out = _embed_with_fail_open(server_err, ["a"], dimension=2, max_attempts=3, sleep_fn=_no_sleep)
+        assert calls["n"] == 3  # retried up to max
+        assert out == [[0.0, 0.0]]

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_dax_llm_fallback.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_dax_llm_fallback.py
@@ -1,5 +1,6 @@
 """Tests for DAX LLM fallback module."""
 import json
+import re
 import pytest
 from collections import OrderedDict
 from unittest.mock import AsyncMock, patch, MagicMock
@@ -12,6 +13,19 @@ from src.engines.crewai.tools.custom.metric_view_utils.dax_llm_fallback import (
     translate_batch_with_llm,
 )
 from src.engines.crewai.tools.custom.metric_view_utils.data_classes import TranslationResult
+
+
+def _batch_reply(prompt, sql="SUM(source.c)", **fields):
+    """Build a fake batch LLM reply that echoes every measure in the batch prompt.
+
+    The batch path sends all measures in one call and expects a JSON ARRAY back,
+    one object per measure keyed by ``measure_name``. This parses the numbered
+    ``N. name: <original_name>`` lines from the batch user prompt and returns a
+    success object for each, so a single mock works for any batch composition.
+    """
+    names = re.findall(r"(?m)^\s*\d+\. name: (.+)$", prompt)
+    arr = [{"measure_name": n.strip(), "success": True, "sql_expr": sql, **fields} for n in names]
+    return {"content": json.dumps(arr), "usage": {}}
 
 
 class TestHelpers:
@@ -209,27 +223,29 @@ class TestTranslateBatchWithLLM:
         ]
         seen = []
 
-        async def fake_call(prompt, sysp, model):
+        async def fake_call(prompt, sysp, model, max_tokens=None):
             seen.append(prompt)
-            return {"content": json.dumps({"success": True, "sql_expr": "SUM(source.amount)",
-                                           "confidence": "medium"}), "usage": {}}
+            return _batch_reply(prompt, sql="SUM(source.amount)", confidence="medium")
 
         with patch("src.engines.crewai.tools.custom.metric_view_utils.dax_llm_fallback._call_llm",
                    new=fake_call):
             result = await translate_batch_with_llm(measures, "fact_test", set(), {})
 
-        # Both SELECTEDVALUE measures were sent to the LLM (not artifact-filtered)
-        # and got translated.
-        assert len(seen) == 2
+        # Both SELECTEDVALUE measures reached the LLM (not artifact-filtered) — now
+        # in a single batch call — and got translated.
+        assert len(seen) == 1
+        assert "F_Start_date" in seen[0] and "Guarded" in seen[0]
         assert all(m.is_translatable for m in result)
 
 
 class TestBatchConcurrency:
-    """translate_batch_with_llm runs in bounded-concurrency chunks (not one-at-a-time).
+    """translate_batch_with_llm sends many measures per LLM call (batching).
 
-    Regression: the old sequential loop could exceed the flow's crew timeout on
-    models with hundreds of measures. Chunked concurrency cuts wall-time while
-    preserving cross-measure MEASURE() reference resolution between chunks.
+    Regression: per-measure calls re-sent the ~14k-token skill corpus every time
+    (Databricks drops prompt caching), blowing the workspace tokens-per-minute
+    limit. Batching amortises the corpus across the batch; batches run
+    sequentially, merging translations between them so cross-measure MEASURE()
+    references still resolve.
     """
 
     def _mk(self, i):
@@ -239,14 +255,16 @@ class TestBatchConcurrency:
             skip_reason="", confidence="", category="",
         )
 
-    def test_all_translated_and_runs_concurrently(self):
+    def test_all_translated_in_batches(self):
         import asyncio, time
         from src.engines.crewai.tools.custom.metric_view_utils import dax_llm_fallback as d
-        measures = [self._mk(i) for i in range(14)]  # 3 chunks at concurrency=6
+        measures = [self._mk(i) for i in range(14)]  # 2 batches at batch_size=12
+        calls = []
 
-        async def fake_call(prompt, sys, model):
+        async def fake_call(prompt, sys, model, max_tokens=None):
+            calls.append(prompt)
             await asyncio.sleep(0.05)
-            return {'content': json.dumps({"success": True, "sql_expr": "SUM(source.c)", "confidence": "high"})}
+            return _batch_reply(prompt, sql="SUM(source.c)", confidence="high")
 
         async def go():
             with patch.object(d, "_call_llm", new=fake_call):
@@ -256,8 +274,10 @@ class TestBatchConcurrency:
 
         out, dur = asyncio.run(go())
         assert sum(1 for m in out if m.is_translatable) == 14
-        # Sequential would be ~14*0.05=0.70s; chunked(6) is ~3*0.05=0.15s.
-        assert dur < 0.45, f"expected concurrent execution, got {dur:.2f}s"
+        # 14 measures at batch_size=12 → 2 LLM calls, not 14 (the token-burn win).
+        assert len(calls) == 2
+        # 2 sequential batch calls ≈ 2*0.05=0.10s — well under the crew timeout.
+        assert dur < 0.45, f"expected batched execution, got {dur:.2f}s"
 
     def test_artifacts_skipped(self):
         import asyncio
@@ -266,7 +286,7 @@ class TestBatchConcurrency:
         m.skip_reason = "FORMAT string artifact"
         called = False
 
-        async def fake_call(*a):
+        async def fake_call(*a, **kw):
             nonlocal called; called = True
             return {'content': '{"success": true, "sql_expr": "x"}'}
 
@@ -276,6 +296,57 @@ class TestBatchConcurrency:
 
         asyncio.run(go())
         assert called is False  # artifact never sent to the LLM
+
+
+class TestBatchRobustness:
+    """A malformed/incomplete batch response must never silently drop measures."""
+
+    def _mk(self, i):
+        return TranslationResult(
+            original_name=f"M{i}", measure_name=f"m{i}",
+            dax_expression=f"SUM(t[c{i}])", sql_expr="", is_translatable=False,
+            skip_reason="", confidence="", category="",
+        )
+
+    def test_unparseable_batch_falls_back_to_per_measure(self):
+        import asyncio
+        from src.engines.crewai.tools.custom.metric_view_utils import dax_llm_fallback as d
+        measures = [self._mk(i) for i in range(3)]
+
+        async def fake_call(prompt, sysp, model, max_tokens=None):
+            if "Translate the following" in prompt:      # the batch call
+                return {"content": "sorry, not JSON", "usage": {}}
+            # per-measure fallback call
+            return {"content": json.dumps({"success": True, "sql_expr": "SUM(source.c)"}), "usage": {}}
+
+        async def go():
+            with patch.object(d, "_call_llm", new=fake_call):
+                return await d.translate_batch_with_llm(measures, "tbl", set(), {}, model="m")
+
+        out = asyncio.run(go())
+        # Batch parse failed, but every measure still translated via the fallback.
+        assert all(m.is_translatable for m in out)
+
+    def test_measure_missing_from_batch_gets_per_measure_retry(self):
+        import asyncio
+        from src.engines.crewai.tools.custom.metric_view_utils import dax_llm_fallback as d
+        measures = [self._mk(0), self._mk(1)]
+
+        async def fake_call(prompt, sysp, model, max_tokens=None):
+            if "Translate the following" in prompt:      # batch: only answer M0
+                return {"content": json.dumps([
+                    {"measure_name": "M0", "success": True, "sql_expr": "SUM(source.c0)"}
+                ]), "usage": {}}
+            # per-measure fallback for the dropped M1
+            return {"content": json.dumps({"success": True, "sql_expr": "SUM(source.c1)"}), "usage": {}}
+
+        async def go():
+            with patch.object(d, "_call_llm", new=fake_call):
+                return await d.translate_batch_with_llm(measures, "tbl", set(), {}, model="m")
+
+        out = asyncio.run(go())
+        # M0 from the batch, M1 recovered by the per-measure retry.
+        assert all(m.is_translatable for m in out)
 
 
 class TestLLMFirstCorpus:
@@ -320,12 +391,12 @@ class TestLLMFirstCorpus:
                                    sql_expr='', is_translatable=False, skip_reason='', confidence='', category='')
         child = TranslationResult(original_name='Child', measure_name='child', dax_expression='[Parent]*2',
                                   sql_expr='', is_translatable=False, skip_reason='', confidence='', category='')
-        seen_order = []
+        captured = {}
 
-        async def fake_call(prompt, sysp, model):
-            # record which measure ran (prompt carries the name)
-            seen_order.append('Parent' if 'Parent' in prompt and 'Child' not in prompt else 'Child')
-            return {"content": json.dumps({"success": True, "sql_expr": "SUM(source.a)", "dax_class": "translatable_direct"}), "usage": {}}
+        async def fake_call(prompt, sysp, model, max_tokens=None):
+            # parent + child land in one batch; capture the prompt to check order.
+            captured['prompt'] = prompt
+            return _batch_reply(prompt, sql="SUM(source.a)", dax_class="translatable_direct")
 
         async def go():
             with patch.object(d, "_call_llm", new=fake_call):
@@ -333,8 +404,10 @@ class TestLLMFirstCorpus:
                 await d.translate_batch_with_llm([child, parent], "t", set(), {}, model="x",
                                                  topo_priority={'Parent': 0, 'Child': 1})
         asyncio.run(go())
-        # parent must be attempted before child
-        assert seen_order.index('Parent') < seen_order.index('Child')
+        # topo_priority orders parent before child WITHIN the batch prompt, so the
+        # child's MEASURE(parent) reference resolves against an earlier line.
+        p = captured['prompt']
+        assert p.index('Parent') < p.index('Child')
 
 
 class TestTableContext:

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_dax_llm_fallback.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_dax_llm_fallback.py
@@ -376,3 +376,40 @@ class TestTableContext:
         asyncio.run(go())
         # different table context → two distinct cache keys → two LLM calls
         assert calls["n"] == 2
+
+
+class TestLLMDeclinedSkipReason:
+    """REGRESSION: when the fast path routes a measure to the LLM and the LLM ALSO
+    declines, skip_reason must report the TERMINAL verdict — not the routing step.
+
+    The fast path sets "routed to LLM (fast-path dropped a DAX component)" to mean
+    "hand this to the LLM". Leaving that text once the LLM has declined reported an
+    intermediate state as final: the Not-transpiled panel and the re-evaluation sweep
+    both claimed the LLM never got a turn, for measures it had already rejected.
+    """
+
+    def test_reason_names_the_llm_and_the_class(self):
+        from src.engines.crewai.tools.custom.metric_view_utils.dax_llm_fallback import (
+            _llm_declined_reason,
+        )
+        out = _llm_declined_reason('unsupported', 'no metric-view equivalent exists')
+        assert 'LLM declined' in out
+        assert 'unsupported' in out
+        # routing text must be gone
+        assert 'routed to LLM' not in out
+
+    def test_known_classes_get_a_human_label(self):
+        from src.engines.crewai.tools.custom.metric_view_utils.dax_llm_fallback import (
+            _llm_declined_reason,
+        )
+        assert 'display/formatting only' in _llm_declined_reason('display_layer', '')
+        assert 'out of scope' in _llm_declined_reason('out_of_scope', '')
+        assert 'source-model change' in _llm_declined_reason('architecture_change', '')
+
+    def test_unknown_class_still_produces_a_sane_reason(self):
+        from src.engines.crewai.tools.custom.metric_view_utils.dax_llm_fallback import (
+            _llm_declined_reason,
+        )
+        out = _llm_declined_reason(None, 'something odd')
+        assert out.startswith('LLM declined')
+        assert 'something odd' in out

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_function_ref_retriever.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_function_ref_retriever.py
@@ -1,0 +1,75 @@
+"""Unit tests for the DAX function-reference retriever."""
+from src.engines.crewai.tools.custom.metric_view_utils import function_ref_retriever as R
+
+
+class TestDetection:
+    def test_detects_known_function_calls(self):
+        found = R.detect_functions(["GEOMEAN(Sales[margin])", "DATEDIFF(a, b, DAY)"])
+        assert "GEOMEAN" in found
+        assert "DATEDIFF" in found
+
+    def test_ignores_unknown_and_columns(self):
+        # bracketed column refs and unknown tokens must not match
+        found = R.detect_functions(["[Some Measure] + NOTAFUNC(x) + 'C_Dim'"])
+        assert "NOTAFUNC" not in found
+
+    def test_dotted_function_names(self):
+        found = R.detect_functions(["PERCENTILE.INC(Sales[amt], 0.9)"])
+        assert "PERCENTILE.INC" in found
+
+    def test_empty_and_none_safe(self):
+        assert R.detect_functions([]) == []
+        assert R.detect_functions([None, ""]) == []
+
+
+class TestRender:
+    def test_skips_prefix_covered_head_functions(self):
+        # CALCULATE/SUM/DIVIDE are taught deeply in the static prefix → not injected
+        block = R.render_function_refs(["CALCULATE(SUM(t[x]), t[y]=1)", "DIVIDE(a, b)"])
+        assert block == ""
+
+    def test_injects_tail_trap_with_curated_form(self):
+        block = R.render_function_refs(["FIND(\"@\", Cust[email])"])
+        assert "FIND" in block
+        assert "INSTR(source.hay, 'needle')" in block
+        assert "ARG ORDER SWAPS" in block
+
+    def test_uncurated_tail_renders_generic_with_caveat(self):
+        block = R.render_function_refs(["ACOSH(Metrics[x])"])
+        assert "ACOSH" in block
+        assert "adapt per §0" in block
+        assert "(default)" in block
+
+    def test_declines_are_marked_not_a_measure_expr(self):
+        # HASONEVALUE is a tail decline (curated unsupported, sql=None) not taught
+        # in the prefix, so retrieval surfaces it with the "not a measure expr" note.
+        block = R.render_function_refs(["IF(HASONEVALUE(Dim[Year]), [M], BLANK())"])
+        assert "HASONEVALUE" in block
+        assert "unsupported" in block
+        assert "not a measure expr" in block
+
+    def test_empty_when_no_tail_functions(self):
+        assert R.render_function_refs(["SUM(t[x])"]) == ""
+
+    def test_respects_max_render_cap(self):
+        block = R.render_function_refs(["GEOMEAN(a) MEDIAN(b) STDEV.S(c)"], max_render=1)
+        assert block.count("### ") == 1
+
+
+class TestDataIntegrity:
+    def test_base_data_loaded(self):
+        assert len(R._BASE) > 300  # ~386 functions
+
+    def test_every_curated_key_exists_in_base(self):
+        missing = [k for k in R._CURATED if k not in R._BASE]
+        assert missing == [], f"curated keys not in base: {missing}"
+
+    def test_curated_entries_have_class_and_note(self):
+        for name, entry in R._CURATED.items():
+            assert entry.get("cls"), f"{name} missing dax_class"
+            assert "note" in entry, f"{name} missing note key"
+
+    def test_prefix_deep_excludes_head_from_curated_noise(self):
+        # sanity: high-frequency head functions are recognised as prefix-covered
+        assert "CALCULATE" in R._PREFIX_DEEP
+        assert "DIVIDE" in R._PREFIX_DEEP

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_generated_table_emitter.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_generated_table_emitter.py
@@ -1,0 +1,59 @@
+"""Tests for generated_table_emitter (KASAL_FIXES Gap 3 materialization) — turning a
+Power Query List.Dates calendar into a CREATE VIEW. Fixture mirrors the JTI date dim."""
+
+from src.engines.crewai.tools.custom.metric_view_utils.generated_table_emitter import (
+    emit_view_sql,
+)
+
+M_DATE = """let
+    StartDate = #date(2020, 1, 1),
+    EndDate = #date(2028, 12, 31),
+    DateList = List.Dates(StartDate, Duration.Days(EndDate - StartDate) + 1, #duration(1,0,0,0)),
+    DateTable = Table.FromList(DateList, Splitter.SplitByNothing(), {"Date"}),
+    AddYear = Table.AddColumn(DateTable, "Year", each Date.Year([Date]), Int64.Type),
+    AddQuarter = Table.AddColumn(AddYear, "Quarter", each "Q" & Text.From(Date.QuarterOfYear([Date]))),
+    AddMonth = Table.AddColumn(AddQuarter, "Month", each Date.ToText([Date], "MMM")),
+    AddWeekDay = Table.AddColumn(AddMonth, "Week Day", each Date.ToText([Date], "dddd")),
+    AddWeekDayNo = Table.AddColumn(AddWeekDay, "Week Day Number", each Date.DayOfWeek([Date], Day.Monday) + 1, Int64.Type),
+    AddDateInteger = Table.AddColumn(AddWeekDayNo, "Date Integer", each Date.Year([Date]) * 10000 + Date.Month([Date]) * 100 + Date.Day([Date]), Int64.Type)
+in AddDateInteger"""
+
+M_NAV = 'let Source = Databricks.Catalogs(...), #"Navigation" = Source{[Item="market_dim"]}[Data] in Navigation'
+
+
+def test_emits_create_view_with_range_and_columns():
+    sql = emit_view_sql(M_DATE, "`cat`.`sch`.`date`")
+    assert sql is not None
+    assert "CREATE OR REPLACE VIEW `cat`.`sch`.`date`" in sql
+    assert "sequence(DATE'2020-01-01', DATE'2028-12-31', INTERVAL 1 DAY)" in sql
+    # column translations
+    assert "year(d) AS `Year`" in sql
+    assert "date_format(d, 'MMM') AS `Month`" in sql
+    assert "date_format(d, 'EEEE') AS `Week Day`" in sql  # dddd -> EEEE
+    assert "weekday(d) + 1 AS `Week Day Number`" in sql
+    assert "year(d) * 10000 + month(d) * 100 + day(d) AS `Date Integer`" in sql
+    assert "concat" not in sql.lower() or "||" in sql  # '&' handled
+
+
+def test_quarter_concat_translation():
+    sql = emit_view_sql(M_DATE, "`c`.`s`.`date`")
+    # "Q" & Text.From(Date.QuarterOfYear([Date])) -> 'Q' || string(quarter(d))
+    assert "'Q' || string(quarter(d)) AS `Quarter`" in sql
+
+
+def test_non_generated_returns_none():
+    assert emit_view_sql(M_NAV, "`c`.`s`.`market_dim`") is None
+    assert emit_view_sql("", "`c`.`s`.`x`") is None
+
+
+def test_untranslatable_column_becomes_todo_not_dropped():
+    m = """let A = #date(2021,1,1), B = #date(2021,12,31),
+        L = List.Dates(A, 10, #duration(1,0,0,0)),
+        T = Table.FromList(L, Splitter.SplitByNothing(), {"Date"}),
+        C = Table.AddColumn(T, "Weird", each Time.Hour([Date]), Int64.Type)
+    in C"""
+    sql = emit_view_sql(m, "`c`.`s`.`cal`")
+    assert sql is not None
+    assert (
+        "TODO translate M" in sql and "`Weird`" in sql
+    )  # kept as placeholder, not dropped

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_mquery_let_evaluator.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_mquery_let_evaluator.py
@@ -1,0 +1,106 @@
+"""Tests for mquery_let_evaluator — the M `let` block evaluator that resolves
+parameter-driven table sources (string concatenation of PBI parameters)
+without an LLM."""
+
+from src.engines.crewai.tools.custom.metric_view_utils.mquery_let_evaluator import (
+    extract_parameter_defaults,
+    resolve_via_let_evaluation,
+)
+
+
+class TestExtractParameterDefaults:
+    def test_extracts_simple_parameter(self):
+        exprs = {
+            "Catalog_Name": '"dc_datalake_prod_001" meta [IsParameterQuery = true, Type = "Text"]'
+        }
+        assert extract_parameter_defaults(exprs) == {
+            "Catalog_Name": "dc_datalake_prod_001"
+        }
+
+    def test_extracts_multiple_parameters_ignores_non_parameters(self):
+        exprs = {
+            "Catalog_Name": '"dc_prod_001" meta [IsParameterQuery=true, Type="Text"]',
+            "Database": '"golden_schema" meta [IsParameterQuery = true, IsParameterQueryRequired=false]',
+            "SomeSharedQuery": "let Source = Databricks.Catalogs() in Source",
+        }
+        params = extract_parameter_defaults(exprs)
+        assert params == {"Catalog_Name": "dc_prod_001", "Database": "golden_schema"}
+
+    def test_unquotes_doubled_quotes_in_value(self):
+        exprs = {"P": '"a""b" meta [IsParameterQuery = true]'}
+        assert extract_parameter_defaults(exprs) == {"P": 'a"b'}
+
+    def test_empty_or_none_expressions(self):
+        assert extract_parameter_defaults({}) == {}
+        assert extract_parameter_defaults(None) == {}
+
+
+class TestResolveViaLetEvaluation:
+    def _params(self):
+        return {
+            "Catalog_Name": "dc_datalake_prod_001",
+            "Database": "application_golden",
+            "Table_Version": "v2",
+            "Version_Type": "official",
+            "Country": "gr",
+        }
+
+    def test_resolves_real_paat_style_pattern(self):
+        # Mirrors the real customer M this module was built to unblock:
+        # a table name AND a WHERE filter built entirely from parameters.
+        m = (
+            "let\n"
+            'Object = "hub_product_" & Table_Version,\n'
+            'FromClause = Catalog_Name & "." & Database & "." & Object,\n'
+            'VersionFilter = if Table_Version = "v2" then " AND version = \'" & Version_Type & "\'" else "",\n'
+            "NativeQuery = Value.NativeQuery(Data_Mesh,\n"
+            '"select * from "& FromClause &" WHERE bu = \'"& Text.From(Country) &"\'"'
+            '& VersionFilter & ""'
+            "\n,null, [EnableFolding=true])\n"
+            "in\n"
+            '    #"NativeQuery"'
+        )
+        sql = resolve_via_let_evaluation(m, self._params())
+        assert sql == (
+            "select * from dc_datalake_prod_001.application_golden.hub_product_v2 "
+            "WHERE bu = 'gr' AND version = 'official'"
+        )
+
+    def test_if_condition_false_branch(self):
+        m = (
+            "let\n"
+            'Filt = if Table_Version = "v99" then " AND x=1" else "",\n'
+            'NativeQuery = Value.NativeQuery(Data_Mesh, "select 1" & Filt, null, [EnableFolding=true])\n'
+            "in\n"
+            "    NativeQuery"
+        )
+        sql = resolve_via_let_evaluation(m, self._params())
+        assert sql == "select 1"
+
+    def test_no_native_query_call_returns_none(self):
+        m = 'let X = Catalog_Name & "." & Database in X'
+        assert resolve_via_let_evaluation(m, self._params()) is None
+
+    def test_unresolvable_reference_returns_none(self):
+        # `Unknown_Param` isn't in the params map — must fail, not guess.
+        m = (
+            "let\n"
+            'FromClause = Unknown_Param & ".t",\n'
+            'NativeQuery = Value.NativeQuery(Data_Mesh, "select * from " & FromClause, null, [EnableFolding=true])\n'
+            "in NativeQuery"
+        )
+        assert resolve_via_let_evaluation(m, self._params()) is None
+
+    def test_nested_let_returns_none(self):
+        m = "let X = (let Y = 1 in Y) in X"
+        assert resolve_via_let_evaluation(m, self._params()) is None
+
+    def test_not_a_let_block_returns_none(self):
+        assert (
+            resolve_via_let_evaluation("GENERATESERIES(1,10)", self._params()) is None
+        )
+
+    def test_empty_or_no_params(self):
+        assert resolve_via_let_evaluation("", self._params()) is None
+        assert resolve_via_let_evaluation(None, self._params()) is None
+        assert resolve_via_let_evaluation("let X = 1 in X", {}) is None

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_mquery_parser.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_mquery_parser.py
@@ -156,6 +156,27 @@ class TestClassifyMquerySource:
              'Binary.FromText("x", BinaryEncoding.Base64))))  // VALUES helper')
         assert self._C(m)[0] == 'inline_const'
 
+    def test_inline_const_plain_literal_rows_no_base64(self):
+        # Table.FromRows with hardcoded rows spelled out in plain M (no
+        # base64/Binary.Decompress wrapper) is the same category — still an
+        # inline constant table, no warehouse source.
+        m = 'let Source = Table.FromRows({{"a", 1}, {"b", 2}}) in Source'
+        assert self._C(m)[0] == 'inline_const'
+
+    def test_dax_calc_summarize(self):
+        # SUMMARIZE is a distinct DAX function from SUMMARIZECOLUMNS — both
+        # must classify as dax_calc.
+        assert self._C('SUMMARIZE(T, T[Col])')[0] == 'dax_calc'
+
+    def test_dax_calc_calculatetable(self):
+        assert self._C('CALCULATETABLE(SUMMARIZE(T, T[Col]), T[Flag]=1)')[0] == 'dax_calc'
+
+    def test_dax_calc_tuple_literal_table(self):
+        # DAX's bare table-constructor syntax: a brace-enclosed list of
+        # parenthesized row tuples, e.g. { ("a", 1), ("b", 2) }.
+        m = '{ ("Sub Domain", NAMEOF(T[Col]), 0, "Check Hierarchy", 0) }'
+        assert self._C(m)[0] == 'dax_calc'
+
 
 class TestExtractSourceTable:
     """extract_source_table: parse catalog.schema.table from an *extractable* M
@@ -206,3 +227,266 @@ class TestExtractSourceTable:
     def test_none_and_empty_input(self):
         assert self._E(None) is None
         assert self._E('') is None
+
+    def test_databricks_quoted_catalog_name(self):
+        # M quotes an identifier as #"like this" whenever it isn't a valid bare
+        # identifier (e.g. contains spaces) — the real shape the Databricks
+        # connector emits for its top-level catalog step. The unquoted-only
+        # regex silently dropped this match, leaving only 2/3 names and always
+        # returning None even though the chain was fully resolvable.
+        m = ('let Source = Databricks.Catalogs(DatabricksHost, DatabricksHTTPpath, '
+             '[Catalog=null, Database=null]), '
+             'metastore_Database = Source{[Name=#"Databricks Data Catalog",Kind="Database"]}[Data], '
+             'curated_Schema = metastore_Database{[Name="curated_data_quality",Kind="Schema"]}[Data], '
+             'dim_Table = curated_Schema{[Name="dim_rules_inventory_v7",Kind="Table"]}[Data] '
+             'in dim_Table')
+        assert self._E(m) == 'Databricks Data Catalog.curated_data_quality.dim_rules_inventory_v7'
+
+    def test_snowflake_catalog_navigation_chain(self):
+        # Non-Databricks catalog-browse connector sharing the same [Name=,Kind=]
+        # navigation shape (a Power Query SDK convention, not Databricks-only).
+        m = ('let Source = Snowflake.Databases("acct.snowflakecomputing.com","WH")'
+             '{[Name="MY_DB"]}[Data]{[Name="PUBLIC"]}[Data]{[Name="ORDERS"]}[Data] in Source')
+        assert self._E(m) == 'MY_DB.PUBLIC.ORDERS'
+
+
+class TestResolveMqueryToSql:
+    """resolve_mquery_to_sql: compile an extractable M source into compact SQL
+    (SELECT ... FROM catalog.schema.table) the downstream SQL-only parser can
+    read directly — the deterministic alternative to routing catalog-browse
+    connector M (Databricks.Catalogs et al) through an LLM."""
+
+    def _R(self, m):
+        from src.engines.crewai.tools.custom.metric_view_utils.mquery_parser import (
+            resolve_mquery_to_sql)
+        return resolve_mquery_to_sql(m)
+
+    def test_databricks_catalogs_with_select_and_rename(self):
+        m = (
+            'let\n'
+            '    Source = Databricks.Catalogs(DatabricksHost, DatabricksHTTPpath, [Catalog=null]),\n'
+            '    metastore_Database = Source{[Name=#"Databricks Data Catalog",Kind="Database"]}[Data],\n'
+            '    curated_Schema = metastore_Database{[Name="curated_data_quality",Kind="Schema"]}[Data],\n'
+            '    dim_Table = curated_Schema{[Name="dim_rules_inventory_v7",Kind="Table"]}[Data],\n'
+            '    #"Removed Other Columns" = Table.SelectColumns(dim_Table,{"rule_code", "domain", "is_active"}),\n'
+            '    #"Renamed Columns" = Table.RenameColumns(#"Removed Other Columns",'
+            '{{"rule_code", "Rule Code"}, {"is_active", "Is Active"}})\n'
+            'in\n'
+            '    #"Renamed Columns"'
+        )
+        sql = self._R(m)
+        assert sql == (
+            'SELECT rule_code AS `Rule Code`, domain, is_active AS `Is Active` '
+            'FROM `Databricks Data Catalog`.curated_data_quality.dim_rules_inventory_v7'
+        )
+
+    def test_quotes_identifiers_with_spaces(self):
+        # Column/alias/catalog names containing spaces (routine in PBI M) must
+        # come out backtick-quoted — unquoted, they're invalid SQL syntax.
+        m = ('let Source = Databricks.Catalogs("h","p"){[Name="My Catalog"]}[Data]'
+             '{[Name="sch"]}[Data]{[Name="tbl"]}[Data],\n'
+             '    Sel = Table.SelectColumns(Source,{"Order Date","amount"})\n'
+             'in Sel')
+        assert self._R(m) == 'SELECT `Order Date`, amount FROM `My Catalog`.sch.tbl'
+
+    def test_databricks_catalogs_no_select_columns_falls_back_to_star(self):
+        m = ('let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+             '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source')
+        assert self._R(m) == 'SELECT * FROM cat.sch.tbl'
+
+    def test_unresolvable_source_returns_none(self):
+        assert self._R('GENERATESERIES(-5, 20, 5)') is None
+        assert self._R('let Source = Access.Database(File.Contents("x.accdb")) in Source') is None
+        assert self._R(None) is None
+        assert self._R('') is None
+
+
+class TestResolveMqueryWithContext:
+    """resolve_mquery_with_context: the direct resolver extended with model-
+    level context for a table's M that can't resolve on its own — a reference
+    to a disabled staging query, or a parameter-driven source."""
+
+    def _RC(self, m, expressions=None):
+        from src.engines.crewai.tools.custom.metric_view_utils.mquery_parser import (
+            resolve_mquery_with_context)
+        return resolve_mquery_with_context(m, expressions)
+
+    def test_falls_through_to_direct_resolver_when_no_context_needed(self):
+        m = ('let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+             '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source')
+        assert self._RC(m) == 'SELECT * FROM cat.sch.tbl'
+
+    def test_follows_quoted_reference_to_shared_expression(self):
+        m = 'let Source = #"f_vendor_universe - DataBricks SQL" in Source'
+        expressions = {
+            "f_vendor_universe - DataBricks SQL": (
+                'let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source'
+            ),
+        }
+        assert self._RC(m, expressions) == 'SELECT * FROM cat.sch.tbl'
+
+    def test_follows_bare_unquoted_reference(self):
+        m = 'let Source = SomeStagingQuery in Source'
+        expressions = {
+            "SomeStagingQuery": (
+                'let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source'
+            ),
+        }
+        assert self._RC(m, expressions) == 'SELECT * FROM cat.sch.tbl'
+
+    def test_follows_bare_name_with_no_let_wrapper(self):
+        # Some Admin-Scanner-reported tables carry just the referenced name,
+        # not even a `let...in` wrapper.
+        m = '"1_Report Measures"'
+        expressions = {"1_Report Measures": 'let Source = Databricks.Catalogs("h","p")'
+                        '{[Name="cat"]}[Data]{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source'}
+        assert self._RC(m, expressions) == 'SELECT * FROM cat.sch.tbl'
+
+    def test_falls_back_to_parameter_evaluation(self):
+        m = (
+            'let\n'
+            'FromClause = Catalog_Name & "." & Database & "." & "hub_product_v2",\n'
+            'NativeQuery = Value.NativeQuery(Data_Mesh, "select * from " & FromClause, null, [EnableFolding=true])\n'
+            'in NativeQuery'
+        )
+        expressions = {
+            "Catalog_Name": '"dc_prod_001" meta [IsParameterQuery = true]',
+            "Database": '"golden" meta [IsParameterQuery = true]',
+        }
+        assert self._RC(m, expressions) == 'select * from dc_prod_001.golden.hub_product_v2'
+
+    def test_no_expressions_returns_none_for_unresolvable(self):
+        m = 'let Source = #"Some Staging Query" in Source'
+        assert self._RC(m, None) is None
+        assert self._RC(m, {}) is None
+
+    def test_reference_target_not_in_expressions_returns_none(self):
+        m = 'let Source = #"Missing Query" in Source'
+        assert self._RC(m, {"Other": "x"}) is None
+
+    def test_follows_reference_with_trailing_column_cleanup(self):
+        # A reference followed by a cosmetic step (TransformColumnTypes) —
+        # not a pure passthrough, but still reads exactly one physical table.
+        m = (
+            'let\n'
+            '    Source = #"Staging Vendor",\n'
+            '    #"Changed Type" = Table.TransformColumnTypes(Source,'
+            '{{"Check Status", Int64.Type}})\n'
+            'in\n'
+            '    #"Changed Type"'
+        )
+        expressions = {
+            "Staging Vendor": ('let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                                '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source'),
+        }
+        assert self._RC(m, expressions) == 'SELECT * FROM cat.sch.tbl'
+
+    def test_does_not_guess_when_sources_are_combined(self):
+        # First binding IS a reference, but the M also Table.Combines it with
+        # a second source — trusting "the first binding" here would silently
+        # drop the second source. Must return None, not guess.
+        m = (
+            'let\n'
+            '    Source = #"Old Query",\n'
+            '    #"Appended Query" = Table.Combine({Source, #"New Query"})\n'
+            'in\n'
+            '    #"Appended Query"'
+        )
+        expressions = {
+            "Old Query": ('let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                          '{[Name="sch"]}[Data]{[Name="tbl1"]}[Data] in Source'),
+            "New Query": ('let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                          '{[Name="sch"]}[Data]{[Name="tbl2"]}[Data] in Source'),
+        }
+        assert self._RC(m, expressions) is None
+
+
+class TestExtractFirstBindingReference:
+    """_extract_first_binding_reference: identify the physical source via a
+    let block's FIRST binding, even when later bindings reshape columns —
+    but never when the M combines multiple sources (that would silently pick
+    only one side of a union)."""
+
+    def _F(self, m):
+        from src.engines.crewai.tools.custom.metric_view_utils.mquery_parser import (
+            _extract_first_binding_reference)
+        return _extract_first_binding_reference(m)
+
+    def test_reference_plus_cleanup_step(self):
+        m = (
+            'let\n'
+            '    Source = #"f_vendor_details_l3_uniqueness - DataBricks SQL",\n'
+            '    #"Changed Type" = Table.TransformColumnTypes(Source,'
+            '{{"Check Status", Int64.Type}})\n'
+            'in\n'
+            '    #"Changed Type"'
+        )
+        assert self._F(m) == 'f_vendor_details_l3_uniqueness - DataBricks SQL'
+
+    def test_bare_unquoted_first_reference(self):
+        m = 'let Source = SomeStagingQuery, X = Table.RenameColumns(Source, {}) in X'
+        assert self._F(m) == 'SomeStagingQuery'
+
+    def test_bails_on_table_combine(self):
+        m = 'let Source = #"A", Y = Table.Combine({Source, #"B"}) in Y'
+        assert self._F(m) is None
+
+    def test_bails_on_table_append(self):
+        m = 'let Source = #"A", Y = Table.Append({Source, #"B"}) in Y'
+        assert self._F(m) is None
+
+    def test_bails_on_table_join(self):
+        m = 'let Source = #"A", Y = Table.Join(Source, "k", #"B", "k") in Y'
+        assert self._F(m) is None
+
+    def test_first_binding_not_a_reference_returns_none(self):
+        m = 'let Source = Databricks.Catalogs() in Source'
+        assert self._F(m) is None
+
+    def test_no_let_block_returns_none(self):
+        assert self._F('GENERATESERIES(1,10)') is None
+        assert self._F(None) is None
+        assert self._F('') is None
+
+
+class TestExtractSourceTableWithContext:
+    """extract_source_table_with_context: same context-aware resolution as
+    resolve_mquery_with_context, but returns just the physical FQN — used for
+    join_key_map[dim].source_table, a plain config value."""
+
+    def _EC(self, m, expressions=None):
+        from src.engines.crewai.tools.custom.metric_view_utils.mquery_parser import (
+            extract_source_table_with_context)
+        return extract_source_table_with_context(m, expressions)
+
+    def test_direct_resolution_unchanged(self):
+        m = ('let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+             '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source')
+        assert self._EC(m) == 'cat.sch.tbl'
+
+    def test_follows_reference_returns_fqn_not_full_sql(self):
+        m = 'let Source = #"Staging" in Source'
+        expressions = {
+            "Staging": ('let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                        '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source'),
+        }
+        assert self._EC(m, expressions) == 'cat.sch.tbl'
+
+    def test_parameter_driven_extracts_fqn_from_resolved_sql(self):
+        m = (
+            'let\n'
+            'FromClause = Catalog_Name & "." & Database & "." & "hub_product_v2",\n'
+            'NativeQuery = Value.NativeQuery(Data_Mesh, "select * from " & FromClause, null, [EnableFolding=true])\n'
+            'in NativeQuery'
+        )
+        expressions = {
+            "Catalog_Name": '"dc_prod_001" meta [IsParameterQuery = true]',
+            "Database": '"golden" meta [IsParameterQuery = true]',
+        }
+        assert self._EC(m, expressions) == 'dc_prod_001.golden.hub_product_v2'
+
+    def test_unresolvable_returns_none(self):
+        assert self._EC('GENERATESERIES(1,10)', {"X": "y"}) is None
+        assert self._EC('let Source = #"Missing" in Source', {"Other": "x"}) is None

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_physical_name_resolver.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_physical_name_resolver.py
@@ -1,0 +1,171 @@
+"""Tests for physical_name_resolver (KASAL_FIXES Gaps 1–3) — resolving PBI
+friendly table names and model column names to the real physical names from the
+Power Query M. Fixtures mirror the JTI ConsumerExperience cases."""
+
+from types import SimpleNamespace
+
+from src.engines.crewai.tools.custom.metric_view_utils.data_classes import (
+    MetricViewSpec,
+    TableInfo,
+    TranslationResult,
+)
+from src.engines.crewai.tools.custom.metric_view_utils.physical_name_resolver import (
+    physical_table,
+    is_generated,
+    column_map,
+    resolve_physical_names,
+    _norm,
+)
+
+# ── M expressions (trimmed to the shape the resolver reads) ──
+M_SURVEY_FACT = '''let
+    Source = Value.NativeQuery(Databricks.Catalogs(...){[Name=#"Default Catalog",Kind="Database"]}[Data],
+    "SELECT id_profile, ResponseId FROM `" & #"Default Catalog" & "`." & #"Schema Market" & ".survey_responses", null, [EnableFolding=true]),
+    #"Renamed Columns" = Table.RenameColumns(Source,{{"ResponseId","Response Id"},{"ChoiceId","Choice Id"},{"CSATRespondentCategory","CSAT Respondent Category"}})
+in #"Renamed Columns"'''
+M_QUESTION = '''let
+    Source = Databricks.Catalogs(...),
+    #"Navigation" = Source{[Item="survey_questions",Schema=#"Schema Market"]}[Data],
+    #"Renamed Columns" = Table.RenameColumns(Navigation,{{"GlobalIdQuestion","Global Question Id"}})
+in #"Renamed Columns"'''
+M_MARKET = '''let
+    Source = Databricks.Catalogs(...),
+    #"Navigation" = Source{[Item="market_dim"]}[Data],
+    #"Renamed Columns" = Table.RenameColumns(Navigation,{{"_TF_MARKET","Market"}})
+in #"Renamed Columns"'''
+M_SUPERVISOR = """let Source = Databricks.Catalogs(...), #"Navigation" = Source{[Item="dim_supervisor"]}[Data] in Navigation"""
+M_DATE = """let StartDate=#date(2020,1,1), DateList=List.Dates(StartDate,100,#duration(1,0,0,0)) in DateList"""
+
+
+def test_physical_table_from_navigation_and_nativequery():
+    assert physical_table(M_QUESTION) == "survey_questions"
+    assert physical_table(M_MARKET) == "market_dim"
+    assert physical_table(M_SUPERVISOR) == "dim_supervisor"
+    assert physical_table(M_SURVEY_FACT) == "survey_responses"
+
+
+def test_generated_table_has_no_physical_source():
+    assert is_generated(M_DATE) is True
+    assert physical_table(M_DATE) is None
+    assert is_generated(M_QUESTION) is False
+
+
+def test_column_map_recovers_renamed_and_camelcase():
+    cm = column_map(M_QUESTION, ["Global Question Id", "KeyQuestion", "Survey Id"])
+    # renamed: display 'Global Question Id' -> physical 'GlobalIdQuestion'
+    assert cm[_norm("global_question_id")] == "GlobalIdQuestion"
+    # NOT renamed camelCase: token 'key_question' must resolve to physical 'KeyQuestion'
+    assert cm[_norm("key_question")] == "KeyQuestion"
+
+
+def _spec():
+    fact = TranslationResult(
+        measure_name="nps",
+        original_name="NPS",
+        is_translatable=True,
+        skip_reason="",
+        dax_expression="",
+        confidence="high",
+        category="dax",
+        sql_expr="AVG(TRY_CAST(source.choice_id AS DOUBLE)) FILTER (WHERE dim_question.global_question_id = 'Q1')",
+    )
+    return MetricViewSpec(
+        fact_table_key="Survey Response Online Fact",
+        source_table="cat.sch.survey_response_online_fact",
+        view_name="mv",
+        comment="",
+        joins=[
+            {
+                "name": "dim_question",
+                "source": "cat.sch.question",
+                "join_on": "source.key_question = dim_question.key_question",
+            },
+            {
+                "name": "dim_market",
+                "source": "cat.sch.market",
+                "join_on": "source.market = dim_market.market",
+            },
+        ],
+        dimensions=[
+            {"name": "gq", "expr": "dim_question.global_question_id"},
+            {"name": "mk", "expr": "dim_market.market"},
+        ],
+        measures=[fact],
+        untranslatable=[],
+    )
+
+
+def _tables():
+    return {
+        "Survey Response Online Fact": TableInfo(
+            "Survey Response Online Fact",
+            "cat.sch.survey_response_online_fact",
+            [{"name": "Choice Id", "source_col": "Choice Id"}],
+            ["Profile Id", "Response Id", "Market"],
+            [],
+            True,
+            "",
+        ),
+        "Question": TableInfo(
+            "Question",
+            "cat.sch.question",
+            [],
+            ["Global Question Id", "KeyQuestion", "Survey Id"],
+            [],
+            False,
+            "",
+        ),
+        "Market": TableInfo("Market", "cat.sch.market", [], ["Market"], [], False, ""),
+    }
+
+
+def _m():
+    return {
+        "Survey Response Online Fact": M_SURVEY_FACT,
+        "Question": M_QUESTION,
+        "Market": M_MARKET,
+    }
+
+
+def test_resolve_rewrites_tables_and_columns():
+    specs = {"Survey Response Online Fact": _spec()}
+    report = resolve_physical_names(specs, _tables(), _m())
+    spec = specs["Survey Response Online Fact"]
+    # Gap 1: join sources -> physical
+    srcs = {j["name"]: j["source"] for j in spec.joins}
+    assert srcs["dim_question"].endswith(".survey_questions")
+    assert srcs["dim_market"].endswith(".market_dim")
+    # Gap 2: columns -> physical (camelCase + rename recovered)
+    assert "dim_question.KeyQuestion" in spec.joins[0]["join_on"]
+    assert "dim_market._TF_MARKET" in spec.joins[1]["join_on"]
+    assert spec.dimensions[0]["expr"] == "dim_question.GlobalIdQuestion"
+    assert "dim_question.GlobalIdQuestion = 'Q1'" in spec.measures[0].sql_expr
+    # 'Choice Id' (display) was renamed in M from physical 'ChoiceId' → resolve to that
+    assert "source.ChoiceId" in spec.measures[0].sql_expr
+    assert report["tables_resolved"] >= 2
+
+
+def test_generated_table_reported():
+    specs = {"Survey Response Online Fact": _spec()}
+    report = resolve_physical_names(specs, _tables(), {**_m(), "Date": M_DATE})
+    assert "Date" in report["generated_tables"]
+
+
+def test_fail_open_without_m():
+    specs = {"Survey Response Online Fact": _spec()}
+    before = specs["Survey Response Online Fact"].joins[0]["source"]
+    report = resolve_physical_names(specs, _tables(), {})
+    assert specs["Survey Response Online Fact"].joins[0]["source"] == before
+    assert report["tables_resolved"] == 0
+
+
+def test_unknown_column_left_untouched():
+    specs = {"Survey Response Online Fact": _spec()}
+    specs["Survey Response Online Fact"].measures[
+        0
+    ].sql_expr = "COUNT(source.some_unknown_col)"
+    resolve_physical_names(specs, _tables(), _m())
+    assert (
+        "source.some_unknown_col"
+        in specs["Survey Response Online Fact"].measures[0].sql_expr
+    )

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_recovery_recommender.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_recovery_recommender.py
@@ -1,8 +1,34 @@
 """Tests for recovery_recommender (KASAL_FIXES Gaps 4 & 5)."""
 
 from src.engines.crewai.tools.custom.metric_view_utils.recovery_recommender import (
+    draft_source_view,
     recommend,
 )
+
+
+def test_draft_crossfact_unions_the_facts():
+    dax = (
+        "var a = SUMX(fact_pe005, fact_pe005[val]) "
+        "var b = SUMX(fact_scorecard_Actuals_wc, fact_scorecard_Actuals_wc[val]) RETURN a+b"
+    )
+    d = draft_source_view(dax, fact_table="fact_pe005")
+    assert d and "DRAFT · UNVERIFIED" in d
+    assert "UNION ALL" in d and "fact_pe005" in d and "fact_scorecard_Actuals_wc" in d
+    assert "CREATE OR REPLACE VIEW" in d
+
+
+def test_draft_multistage_precompute_view():
+    dax = (
+        "VAR t = SUMMARIZE(FILTER('F', TRUE()), 'F'[k], \"x\", 1) "
+        "RETURN AVERAGEX(t, [x])"
+    )
+    d = draft_source_view(dax, fact_table="survey_responses", measure_name="adc")
+    assert d and "DRAFT · UNVERIFIED" in d
+    assert "GROUP BY <grain_cols>" in d and "SEPARATE UCMV" in d
+
+
+def test_draft_none_for_simple_measure():
+    assert draft_source_view("SUM('Fact'[amount])", fact_table="Fact") is None
 
 
 def test_gap5_multistage_aggregation():

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_recovery_recommender.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_recovery_recommender.py
@@ -1,0 +1,57 @@
+"""Tests for recovery_recommender (KASAL_FIXES Gaps 4 & 5)."""
+
+from src.engines.crewai.tools.custom.metric_view_utils.recovery_recommender import (
+    recommend,
+)
+
+
+def test_gap5_multistage_aggregation():
+    dax = (
+        "VAR _u = UNION(SUMMARIZE(FILTER('Fact', TRUE()), 'Fact'[Profile], \"AvgDC\", "
+        "AVERAGEX(CURRENTGROUP(), [x]))) RETURN AVERAGEX(_u, [AvgDC])"
+    )
+    rec = recommend(dax)
+    assert rec and "Multi-stage aggregation" in rec and "SEPARATE metric view" in rec
+
+
+def test_gap4_manyside_filter_gets_exists_recipe():
+    dax = (
+        "CALCULATE(COUNT('Interactions - Fact'[_SK_INTERACTION]), "
+        "'Termination Reason'[Reason] = \"Unmet Legal Requirements\")"
+    )
+    rec = recommend(
+        dax,
+        fact_table="Interactions - Fact",
+        m2n_tables={"Termination Reason"},
+        join_tables={"dim_interaction"},
+    )
+    assert rec and "EXISTS" in rec and "Termination Reason" in rec
+
+
+def test_gap4_zero_match_flags_not_exists():
+    dax = (
+        "VAR p = FILTER(VALUES('Fact'[Profile Id]), "
+        "CALCULATE(COUNTROWS('Fact'), 'Termination Reason'[Reason]=\"x\") = 0) "
+        "RETURN CALCULATE(DISTINCTCOUNT('Fact'[Profile Id]), p)"
+    )
+    rec = recommend(dax, m2n_tables={"Termination Reason"})
+    assert rec and "NOT EXISTS" in rec
+
+
+def test_no_recipe_for_plain_filter():
+    # a filter on an already-joined dim → not a Gap 4/5 case
+    dax = "CALCULATE(COUNT('Fact'[id]), 'Dim'[flag] = \"y\")"
+    assert recommend(dax, m2n_tables=set(), join_tables={"Dim"}) is None
+
+
+def test_no_recipe_for_simple_measure():
+    assert recommend("SUM('Fact'[amount])") is None
+
+
+def test_generic_zero_match_without_known_m2n():
+    dax = (
+        "CALCULATE(DISTINCTCOUNT('Fact'[Profile Id]), "
+        "FILTER(VALUES('Fact'[Profile Id]), CALCULATE(COUNTROWS('Fact'), 'Q'[id]=\"5.4\")=0))"
+    )
+    rec = recommend(dax)
+    assert rec and "NOT-EXISTS" in rec.upper()

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_report_emitter.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_report_emitter.py
@@ -230,3 +230,22 @@ class TestTablesNotEmitted:
         stats = {'Weird': self._skip('some_new_cat', 'let x = 1 in x')}
         report = emit_migration_report({}, stats)
         assert '**Weird**' in report
+
+
+from src.engines.crewai.tools.custom.metric_view_utils.report_emitter import build_proposal
+
+
+class TestBuildProposal:
+    """Every not-emitted measure gets an actionable proposal, not just a reason."""
+
+    def test_llm_explanation_used_verbatim(self):
+        p = build_proposal('architecture_change', 'Precompute the scorecard KPI as a column.', 'reason')
+        assert p == 'Precompute the scorecard KPI as a column.'
+
+    def test_class_default_when_no_explanation(self):
+        assert 'dashboard' in build_proposal('display_layer', None, 'slicer dispatch').lower()
+        assert 'base measure' in build_proposal('composed', '', 'dep').lower()
+        assert 'source-view' in build_proposal('architecture_change', None, 'x').lower()
+
+    def test_unknown_class_falls_back(self):
+        assert 'manual translation' in build_proposal(None, None, None).lower()

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_yaml_emitter.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_utils/test_yaml_emitter.py
@@ -773,3 +773,43 @@ class TestSourceSqlDangerousDrop:
         # inline SQL dropped → falls back to plain source_table, no DROP in output
         assert 'DROP TABLE' not in y
         assert 'source: cat.sch.tbl' in y or 'source: `cat`' in y or 'source:' in y
+
+
+class TestLLMProvenanceComments:
+    """LLM-translated (best-effort) measures carry a provenance comment;
+    deterministic regex measures do not (they are exact by construction)."""
+
+    def _llm(self, name, dax_class, confidence, explanation):
+        return TranslationResult(
+            measure_name=name, original_name='PBI ' + name,
+            sql_expr=f'SUM(source.{name})', is_translatable=True, skip_reason='',
+            dax_expression='', confidence=confidence, category='llm_translated',
+            dax_class=dax_class, explanation=explanation,
+        )
+
+    def _det(self, name):
+        return TranslationResult(
+            measure_name=name, original_name=name,
+            sql_expr=f'SUM(source.{name})', is_translatable=True, skip_reason='',
+            dax_expression='', confidence='high', category='single_table',
+        )
+
+    def _spec(self, measures):
+        return MetricViewSpec(
+            fact_table_key='fact', source_table='cat.sch.tbl', view_name='v',
+            comment='Test', joins=[], dimensions=[], measures=measures, untranslatable=[],
+        )
+
+    def test_llm_measure_gets_provenance(self):
+        y = emit_yaml(self._spec([self._llm('geo', 'translatable_direct', 'medium', 'geo mean via LN')]))
+        assert 'LLM[medium/translatable_direct]' in y
+        assert 'geo mean via LN' in y
+
+    def test_deterministic_measure_has_no_provenance(self):
+        y = emit_yaml(self._spec([self._det('total')]))
+        assert 'LLM[' not in y
+
+    def test_long_explanation_truncated(self):
+        y = emit_yaml(self._spec([self._llm('x', 'architecture_change', 'low', 'z' * 300)]))
+        assert '…' in y
+        assert 'z' * 300 not in y

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_validation_utils/test_dax_expression_parser.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_validation_utils/test_dax_expression_parser.py
@@ -4,7 +4,25 @@ import pytest
 from src.engines.crewai.tools.custom.metric_view_validation_utils.dax_expression_parser import (
     DAXExpressionParser,
     _MAX_VAR_SUBSTITUTION_ITERATIONS,
+    _MAX_EXPANDED_EXPR_CHARS,
 )
+
+
+def _chained_var_dax(n: int, refs: int = 2) -> str:
+    """A depth-n chained-VAR measure reducing to SUM(fact_sales[amount]).
+
+    Each VAR references the next ``refs`` times, so *textual* substitution would
+    expand it to ~refs**n characters (the historical ~1h hang). It stays a single
+    SUM over one reference, so the parser must still report that cleanly.
+    """
+    lines = []
+    for i in range(1, n + 1):
+        if i < n:
+            lines.append(f"VAR v{i} = " + " + ".join([f"v{i + 1}"] * refs))
+        else:
+            lines.append(f"VAR v{i} = SUM(fact_sales[amount])")
+    lines.append("RETURN " + " + ".join(["v1"] * refs))
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +235,49 @@ class TestSubstituteAllVariablesRecursively:
         ]
         with pytest.raises(RuntimeError, match="maximum iterations"):
             parser.substitute_all_variables_recursively(vars_)
+
+    def test_size_cap_fails_open_on_exponential_chain(self, parser):
+        # Retained public helper still guards any external caller that drives it
+        # into exponential VAR-chain expansion: it must fail open (RuntimeError),
+        # never hang. decompose()/parse() no longer route through this method.
+        vars_ = [
+            {"variable_name": f"v{i}", "variable_expr": f"v{i + 1} + v{i + 1}"}
+            for i in range(1, 30)
+        ]
+        vars_.append({"variable_name": "v30", "variable_expr": "SUM(f[a])"})
+        with pytest.raises(RuntimeError, match="maximum expression size"):
+            parser.substitute_all_variables_recursively(vars_)
+
+
+# ---------------------------------------------------------------------------
+# Chained-VAR measures must parse in linear time without exploding
+# ---------------------------------------------------------------------------
+
+class TestChainedVarNoBlowup:
+    """Regression: chained VARs that each reference the next >1x used to expand
+    ~2^N under textual substitution and wedge the per-table validation loop for
+    ~an hour. decompose() now unions per-subtree components in linear time."""
+
+    def test_deep_chain_parses_fast(self, parser):
+        import time
+        t0 = time.time()
+        result = parser.parse(_chained_var_dax(40))
+        elapsed = time.time() - t0
+        assert elapsed < 2.0, f"chained-VAR parse took {elapsed:.2f}s (regression?)"
+        # Components are still recovered correctly from the union of subtrees.
+        assert any(a["type"] == "SUM" for a in result["aggregations"])
+        assert "fact_sales.amount" in result["references"]
+
+    def test_very_deep_chain_does_not_raise(self, parser):
+        # The linear union path never trips the size cap, even very deep.
+        result = parser.parse(_chained_var_dax(60))
+        assert any(a["type"] == "SUM" for a in result["aggregations"])
+
+    def test_expanded_return_stays_small(self, parser):
+        # decompose() must not build a giant flattened expression.
+        tree = parser.decompose(_chained_var_dax(50))
+        assert tree.get("function") == "__VARS_ROOT__"
+        assert len(str(tree)) < _MAX_EXPANDED_EXPR_CHARS
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_validation_utils/test_pipeline.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/metric_view_validation_utils/test_pipeline.py
@@ -265,3 +265,58 @@ class TestMappingMerge:
             table_mappings={"fact": "source"},
         )
         assert result["is_valid"] is True
+
+
+# ---------------------------------------------------------------------------
+# Chained-VAR measures must validate (not hang, not be skipped)
+# ---------------------------------------------------------------------------
+
+def _chained_var_dax(n: int, refs: int = 2) -> str:
+    """Depth-n chained-VAR measure reducing to SUM(fact[amount]); each VAR
+    references the next ``refs`` times (the historical ~2^N textual-expansion
+    hang)."""
+    lines = []
+    for i in range(1, n + 1):
+        if i < n:
+            lines.append(f"VAR v{i} = " + " + ".join([f"v{i + 1}"] * refs))
+        else:
+            lines.append(f"VAR v{i} = SUM(fact[amount])")
+    lines.append("RETURN " + " + ".join(["v1"] * refs))
+    return "\n".join(lines)
+
+
+class TestChainedVarValidation:
+    def test_direct_chained_var_validates_valid(self):
+        # A depth-30 chained-VAR DAX (would have hung) validates as a clean
+        # match against the generated Databricks SUM.
+        pipe = MetricExpressionValidatorPipeline(table_mappings={"fact": "source"})
+        result = pipe.run(
+            databricks_expr="SUM(source.amount)",
+            dax_expr=_chained_var_dax(30),
+        )
+        assert result["is_valid"] is True
+        assert result["status"] == "VALID"
+
+    def test_file_based_chained_var_is_evaluated_not_skipped(self, tmp_path):
+        yaml_file = tmp_path / "mv.yaml"
+        yaml_file.write_text(textwrap.dedent("""\
+            measures:
+              - name: chained_measure
+                expr: "SUM(source.amount) + SUM(source.amount)"
+                comment: ""
+        """))
+        json_file = tmp_path / "mapping.json"
+        json_file.write_text(json.dumps([
+            {"measure_name": "chained_measure",
+             "dax_expression": _chained_var_dax(30),
+             "proposed_allocation": "fact"},
+        ]))
+        result = MetricExpressionValidatorPipeline(
+            table_mappings={"fact": "source"}
+        ).run(
+            metrics_view_yaml_path=str(yaml_file),
+            table_mapping_json_path=str(json_file),
+        )
+        # The measure is evaluated (scored), not skipped or errored away.
+        evaluated_names = {m.get("measure_name") for m in result.get("evaluated", [])}
+        assert "chained_measure" in evaluated_names

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_pipeline_config_generator_tool.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_pipeline_config_generator_tool.py
@@ -892,6 +892,93 @@ class TestUCMVHandoffPayload:
         # UCMV pipeline iterates mapping expecting these keys
         assert set(out[0]) >= {"measure_name", "dax_expression", "proposed_allocation"}
 
+    def test_build_ucmv_mquery_resolves_catalog_nav_to_compact_sql(self):
+        """A Databricks.Catalogs (click-together, no embedded SQL) table gets
+        compiled to compact SQL instead of shipping the raw M — this is the
+        actual fix for the reported "0 views generated" bug: raw M for this
+        connector shape carries no FROM clause the downstream parser can read."""
+        admin_tables = {
+            "dim_Rules": {
+                "mquery_expression": (
+                    'let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                    '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source'
+                ),
+                "measures": [],
+            },
+        }
+        out = PipelineConfigGeneratorTool._build_ucmv_mquery(admin_tables)
+        entry = next(e for e in out if e["table_name"] == "dim_Rules")
+        assert entry["transpiled_sql"] == "SELECT * FROM cat.sch.tbl"
+
+    def test_build_ucmv_mquery_follows_reference_via_expressions(self):
+        """A table that's nothing but a passthrough to a disabled staging
+        query only resolves with the model's shared `expressions` supplied."""
+        admin_tables = {
+            "DCC Vendor Universe": {
+                "mquery_expression": 'let Source = #"f_vendor_universe - DataBricks SQL" in Source',
+                "measures": [],
+            },
+        }
+        expressions = {
+            "f_vendor_universe - DataBricks SQL": (
+                'let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source'
+            ),
+        }
+        # Without expressions: unresolved, but small enough to ship as-is.
+        out_no_ctx = PipelineConfigGeneratorTool._build_ucmv_mquery(admin_tables)
+        assert out_no_ctx[0]["transpiled_sql"] == admin_tables["DCC Vendor Universe"]["mquery_expression"]
+        # With expressions: resolved to the referenced query's compact SQL.
+        out_ctx = PipelineConfigGeneratorTool._build_ucmv_mquery(admin_tables, expressions)
+        assert out_ctx[0]["transpiled_sql"] == "SELECT * FROM cat.sch.tbl"
+
+    def test_build_ucmv_mquery_caps_large_unresolved_raw_m(self):
+        """A table that's extractable-looking but unresolvable, and too large
+        to ship in full, is capped — not omitted (still reported) and not
+        shipped whole (that's what broke the pipeline-config → UCMV handoff)."""
+        from src.engines.crewai.tools.custom.pipeline_config_generator_tool import (
+            _UNRESOLVED_MQUERY_PREVIEW_CHARS,
+        )
+        huge_unresolvable = 'let Source = Databricks.Query("h","p") in Source' + ("x" * 5000)
+        admin_tables = {"T": {"mquery_expression": huge_unresolvable, "measures": []}}
+        out = PipelineConfigGeneratorTool._build_ucmv_mquery(admin_tables)
+        assert len(out[0]["transpiled_sql"]) == _UNRESOLVED_MQUERY_PREVIEW_CHARS
+        assert out[0]["transpiled_sql"] == huge_unresolvable[:_UNRESOLVED_MQUERY_PREVIEW_CHARS]
+
+
+class TestEnrichSourceTablesWithExpressions:
+    """_enrich_source_tables_from_mquery must also benefit from reference-
+    following / parameter-driven resolution when a dimension's own M alone
+    isn't enough."""
+
+    def test_fills_source_table_via_reference_following(self):
+        config = {"join_key_map": {"DimVendor": {"source_table": "TODO: fill"}}}
+        admin_tables = {
+            "DimVendor": {
+                "mquery_expression": 'let Source = #"Staging Vendor" in Source',
+            },
+        }
+        expressions = {
+            "Staging Vendor": (
+                'let Source = Databricks.Catalogs("h","p"){[Name="cat"]}[Data]'
+                '{[Name="sch"]}[Data]{[Name="tbl"]}[Data] in Source'
+            ),
+        }
+        log = PipelineConfigGeneratorTool._enrich_source_tables_from_mquery(
+            config, admin_tables, expressions)
+        assert config["join_key_map"]["DimVendor"]["source_table"] == "cat.sch.tbl"
+        assert log[0]["status"] == "filled"
+
+    def test_without_expressions_stays_todo(self):
+        config = {"join_key_map": {"DimVendor": {"source_table": "TODO: fill"}}}
+        admin_tables = {
+            "DimVendor": {"mquery_expression": 'let Source = #"Staging Vendor" in Source'},
+        }
+        log = PipelineConfigGeneratorTool._enrich_source_tables_from_mquery(
+            config, admin_tables, None)
+        assert config["join_key_map"]["DimVendor"]["source_table"] == "TODO: fill"
+        assert log[0]["status"] == "skipped"
+
 
 # ---------------------------------------------------------------------------
 # Measure allocation (P0 re-homing: holder-table measures → referenced facts)
@@ -1188,6 +1275,84 @@ class TestReportIdAutoDiscovery:
 
     def test_api_failure_returns_none(self):
         assert self._discover([], status=403) is None
+
+
+class TestParseAdminExpressions:
+    """parse_admin_expressions: pull a model's named/shared expressions (and
+    parameters — an expression is just one tagged IsParameterQuery=true) out
+    of an Admin Scan result. Lives in a SEPARATE dataset key from `tables`, so
+    a table that's only a reference to a disabled staging query, or whose
+    source is built from parameters, is invisible without this."""
+
+    def _gc(self):
+        return PipelineConfigGeneratorTool()._import_generate_config()
+
+    def test_extracts_expressions_for_matching_dataset(self):
+        gc = self._gc()
+        scan_result = {"workspaces": [{"datasets": [
+            {"id": "ds1", "tables": [], "expressions": [
+                {"name": "f_vendor_universe - DataBricks SQL", "expression": "let Source = Databricks.Catalogs() in Source"},
+                {"name": "Catalog_Name", "expression": '"dc_prod_001" meta [IsParameterQuery = true]'},
+            ]},
+            {"id": "ds2", "tables": [], "expressions": [{"name": "Other", "expression": "x"}]},
+        ]}]}
+        exprs = gc.parse_admin_expressions(scan_result, dataset_id="ds1")
+        assert set(exprs) == {"f_vendor_universe - DataBricks SQL", "Catalog_Name"}
+        assert exprs["Catalog_Name"] == '"dc_prod_001" meta [IsParameterQuery = true]'
+
+    def test_no_dataset_id_filter_includes_all(self):
+        gc = self._gc()
+        scan_result = {"workspaces": [{"datasets": [
+            {"id": "ds1", "expressions": [{"name": "A", "expression": "x"}]},
+            {"id": "ds2", "expressions": [{"name": "B", "expression": "y"}]},
+        ]}]}
+        exprs = gc.parse_admin_expressions(scan_result)
+        assert set(exprs) == {"A", "B"}
+
+    def test_no_match_returns_empty(self):
+        gc = self._gc()
+        scan_result = {"workspaces": [{"datasets": [{"id": "ds1", "expressions": []}]}]}
+        assert gc.parse_admin_expressions(scan_result, dataset_id="nope") == {}
+
+    def test_missing_expressions_key_returns_empty(self):
+        gc = self._gc()
+        scan_result = {"workspaces": [{"datasets": [{"id": "ds1", "tables": []}]}]}
+        assert gc.parse_admin_expressions(scan_result, dataset_id="ds1") == {}
+
+
+class TestParseTmdlExpressions:
+    """Fabric TMDL fallback equivalent — best-effort (not live-verified, see
+    the function's own docstring), but must not crash on real-shaped input."""
+
+    def _gc(self):
+        return PipelineConfigGeneratorTool()._import_generate_config()
+
+    def test_parses_single_expressions_file_multiple_blocks(self):
+        gc = self._gc()
+        content = (
+            'expression Catalog_Name =\n'
+            '\t\t"dc_prod_001" meta [IsParameterQuery = true]\n'
+            '\tlineageTag: abc-123\n'
+            '\n'
+            'expression Database =\n'
+            '\t\t"golden_schema" meta [IsParameterQuery=true]\n'
+            '\tlineageTag: def-456\n'
+        )
+        parts = [{"path": "definition/expressions.tmdl",
+                   "payload": base64.b64encode(content.encode()).decode()}]
+        exprs = gc.parse_tmdl_expressions(parts)
+        assert exprs["Catalog_Name"] == '"dc_prod_001" meta [IsParameterQuery = true]'
+        assert exprs["Database"] == '"golden_schema" meta [IsParameterQuery=true]'
+
+    def test_ignores_non_expression_parts(self):
+        gc = self._gc()
+        parts = [{"path": "definition/tables/T.tmdl", "payload": base64.b64encode(b"table T\n").decode()}]
+        assert gc.parse_tmdl_expressions(parts) == {}
+
+    def test_empty_or_none_input(self):
+        gc = self._gc()
+        assert gc.parse_tmdl_expressions(None) == {}
+        assert gc.parse_tmdl_expressions([]) == {}
 
 
 class TestDaxQualityGuard:

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_uc_metric_view_generator_tool.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_uc_metric_view_generator_tool.py
@@ -476,3 +476,46 @@ class TestAgentJunkKwargsGuard:
         result = tool._run(measures_json="", mquery_json="", config_json="")
         data = json.loads(result)
         assert not data.get("error", "").startswith("Invalid JSON")
+
+
+class TestBuildUnallocatedItems:
+    """Completeness: every measure not emitted and not noted untranslatable must
+    be surfaced here with a reason — never silently dropped."""
+
+    def test_reconciles_all_three_buckets(self):
+        specs = {
+            "fact_sales": {
+                "view_name": "mv_fact_sales",
+                "measures": [{"original_name": "Total Sales"}],       # emitted
+                "untranslatable": [{"original_name": "Weird Measure"}],  # noted
+            },
+        }
+        stats = {
+            "_Measures": {"skipped": True,
+                          "skip_reason": "inline constant table (slicer/selector helper)",
+                          "skip_category": "inline_const"},
+        }
+        measures = [
+            {"original_name": "Total Sales", "proposed_allocation": "fact_sales"},   # accounted (emitted)
+            {"original_name": "Weird Measure", "proposed_allocation": "fact_sales"}, # accounted (untranslatable)
+            {"original_name": "Amber", "proposed_allocation": "_Measures", "referenced_by": "5"},  # inline table
+            {"original_name": "Orphan", "proposed_allocation": "", "referenced_by": "2"},          # no allocation
+            {"original_name": "Dropped", "proposed_allocation": "fact_sales", "referenced_by": "0"},  # alloc has a view but not emitted
+        ]
+        items = UCMetricViewGeneratorTool._build_unallocated_items(measures, specs, stats)
+        by_name = {i["original_name"]: i for i in items}
+        # The two accounted measures are excluded.
+        assert "Total Sales" not in by_name and "Weird Measure" not in by_name
+        # The three leftovers are surfaced with the right categories.
+        assert by_name["Amber"]["category"] == "inline_const"
+        assert "inline constant table" in by_name["Amber"]["reason"]
+        assert by_name["Orphan"]["category"] == "unallocated"
+        assert by_name["Dropped"]["category"] == "dropped_in_generation"
+        assert all(i["needs_review"] for i in items)
+        # Sorted by impact (referenced_by desc): Amber(5) before Orphan(2).
+        assert [i["original_name"] for i in items][:2] == ["Amber", "Orphan"]
+
+    def test_empty_when_all_accounted(self):
+        specs = {"t": {"measures": [{"original_name": "M1"}], "untranslatable": []}}
+        measures = [{"original_name": "M1", "proposed_allocation": "t"}]
+        assert UCMetricViewGeneratorTool._build_unallocated_items(measures, specs, {}) == []

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_uc_metric_view_generator_tool.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_uc_metric_view_generator_tool.py
@@ -103,6 +103,68 @@ class TestBuildRawDaxExtract:
         assert extract[0]['dax_expression'] == ''
 
 
+class TestBuildUntranslatableItems:
+    """_build_untranslatable_items flattens per-spec untranslatable measures into
+    the UI review-panel list (full DAX + reason + category + impact)."""
+
+    def _specs(self):
+        return {
+            'fact_sales': {
+                'view_name': 'mv_fact_sales',
+                'untranslatable': [
+                    {
+                        'name': 'YoY Growth', 'original_name': 'YoY Growth',
+                        'skip_reason': 'prior-year time-intelligence',
+                        'category': 'cross_table',
+                        'dax_expression': 'CALCULATE([Sales], SAMEPERIODLASTYEAR(cal[date]))',
+                        'dax_class': 'unsupported', 'referenced_by': 3,
+                    },
+                    {
+                        'name': 'Sales Color', 'original_name': 'Sales Color',
+                        'skip_reason': 'display artifact', 'category': 'unassigned',
+                        'dax_expression': 'IF([Sales] > 0, "green", "red")',
+                        'dax_class': 'display_layer', 'referenced_by': 0,
+                    },
+                ],
+            },
+            'fact_empty': {'view_name': 'mv_empty', 'untranslatable': []},
+        }
+
+    def test_flattens_all_untranslatable_with_rich_fields(self):
+        items = UCMetricViewGeneratorTool._build_untranslatable_items(self._specs())
+        assert len(items) == 2
+        yoy = next(i for i in items if i['original_name'] == 'YoY Growth')
+        assert yoy['table_key'] == 'fact_sales'
+        assert yoy['view_name'] == 'mv_fact_sales'
+        assert yoy['dax_expression'].startswith('CALCULATE')
+        assert yoy['skip_reason'] == 'prior-year time-intelligence'
+        assert yoy['category'] == 'cross_table'
+        assert yoy['dax_class'] == 'unsupported'
+        assert yoy['referenced_by'] == 3
+
+    def test_sorted_by_impact_desc(self):
+        items = UCMetricViewGeneratorTool._build_untranslatable_items(self._specs())
+        # highest referenced_by first
+        assert items[0]['original_name'] == 'YoY Growth'
+        assert [i['referenced_by'] for i in items] == sorted(
+            [i['referenced_by'] for i in items], reverse=True)
+
+    def test_empty_specs_returns_empty(self):
+        assert UCMetricViewGeneratorTool._build_untranslatable_items({}) == []
+        assert UCMetricViewGeneratorTool._build_untranslatable_items(None) == []
+
+    def test_all_translated_returns_empty(self):
+        specs = {'fact_x': {'view_name': 'mv_x', 'untranslatable': []}}
+        assert UCMetricViewGeneratorTool._build_untranslatable_items(specs) == []
+
+    def test_falls_back_to_name_when_original_name_missing(self):
+        specs = {'t': {'view_name': 'v', 'untranslatable': [{'name': 'M1'}]}}
+        items = UCMetricViewGeneratorTool._build_untranslatable_items(specs)
+        assert items[0]['original_name'] == 'M1'
+        assert items[0]['dax_expression'] == ''
+        assert items[0]['referenced_by'] == 0
+
+
 class TestSaveDaxToConversionHistory:
     """_save_dax_to_conversion_history persists to conversion_history, fail-open."""
 

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_ucmv_best_effort.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_ucmv_best_effort.py
@@ -117,3 +117,53 @@ class TestBuildBestEffortViews:
         )
         assert "may be MISSING" in report["warning"]
         assert "upstream semantic model" in report["warning"]
+
+
+class TestDiagnoseZeroViews:
+    """The actionable 'why 0 views + what to do' diagnosis for empty runs."""
+
+    def test_thin_report_with_resolvable_measures(self):
+        # No source tables, but some measures resolved → thin report, best-effort viable.
+        d = UCMetricViewGeneratorTool._diagnose_zero_views(
+            mquery_entries=[{"table_name": "t", "transpiled_sql": ""}],  # no real source
+            measures=[{"measure_name": "m"}],
+            config=_config({"m": {"base_expr": "SUM(source.x)", "base_filters": []}}),
+        )
+        assert d["case"] == "thin_report_no_source_tables"
+        assert d["signals"]["has_source_tables"] is False
+        assert d["signals"]["resolvable_measures"] == 1
+        assert "upstream" in d["recommended_action"].lower()
+        assert "fact_source_map" in d["recommended_action"]
+
+    def test_thin_report_no_resolvable_measures(self):
+        # No source, nothing resolves (the DCC signature) → cannot convert.
+        d = UCMetricViewGeneratorTool._diagnose_zero_views(
+            mquery_entries=[],
+            measures=[{"measure_name": "a"}, {"measure_name": "b"}],
+            config=_config({
+                "a": {"base_expr": "TODO: fill", "base_filters": []},
+                "b": {"base_expr": "SELECTEDVALUE(x)", "base_filters": []},
+            }),
+        )
+        assert d["case"] == "thin_report_no_source_tables"
+        assert d["signals"]["resolvable_measures"] == 0
+        assert "cannot be converted" in d["recommended_action"]
+
+    def test_sources_present_but_no_views(self):
+        # Real source tables exist → not a thin-report problem.
+        d = UCMetricViewGeneratorTool._diagnose_zero_views(
+            mquery_entries=[{"table_name": "t", "transpiled_sql": "SELECT * FROM cat.sch.t"}],
+            measures=[{"measure_name": "m"}],
+            config=_config({}),
+        )
+        assert d["case"] == "sources_present_no_views"
+        assert d["signals"]["has_source_tables"] is True
+        assert "no source mapping needed" in d["recommended_action"].lower()
+
+    def test_mquery_expression_counts_as_source(self):
+        d = UCMetricViewGeneratorTool._diagnose_zero_views(
+            mquery_entries=[{"table_name": "t", "mquery_expression": "let Source = Sql.Database(...)"}],
+            measures=[],
+            config=_config({}),
+        )
+        assert d["signals"]["has_source_tables"] is True

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_ucmv_best_effort.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_ucmv_best_effort.py
@@ -1,0 +1,119 @@
+"""Unit tests for best-effort UCMV generation (thin-report fallback).
+
+Covers `UCMetricViewGeneratorTool._build_best_effort_views` — the opt-in path that
+drafts thin metric views for a report-layer model (no M-Query source tables) from
+measures that already resolved to real aggregatable SQL. Key guarantees:
+  * never emits unresolved / TODO SQL (correctness contract),
+  * skips tables with no supplied source and surfaces them in the report,
+  * flags every emitted measure `TODO: verify`,
+  * empty / absent fact_source_map → no views (gate).
+"""
+import pytest
+
+from src.engines.crewai.tools.custom.uc_metric_view_generator_tool import (
+    UCMetricViewGeneratorTool,
+)
+
+
+def _config(resolutions):
+    return {"measure_resolutions": resolutions}
+
+
+def _measures(pairs):
+    # pairs: list of (measure_name, allocated_pbi_table)
+    return [{"measure_name": n, "proposed_allocation": t} for n, t in pairs]
+
+
+class TestBuildBestEffortViews:
+    def test_emits_view_for_resolved_measure_with_source(self):
+        views, report = UCMetricViewGeneratorTool._build_best_effort_views(
+            fact_source_map={"sat_roi_main": "cat.sch.sat_roi"},
+            config=_config({
+                "cm_abs": {"base_expr": "SUM(source.customer_margin_abs)", "base_filters": []},
+            }),
+            measures=_measures([("cm_abs", "sat_roi_main")]),
+        )
+        assert "sat_roi_main" in views
+        v = views["sat_roi_main"]
+        assert v["source"] == "cat.sch.sat_roi"
+        assert v["version"] == "1.1"
+        assert len(v["measures"]) == 1
+        m = v["measures"][0]
+        assert m["expr"] == "SUM(source.customer_margin_abs)"
+        assert m["name"] == "cm_abs"
+        # every drafted measure must be flagged for review
+        assert "TODO: verify" in m["comment"]
+        # view comment must warn about missing content
+        assert "MISSING" in v["comment"]
+        assert report["tables_emitted"] == 1
+        assert report["measures_emitted"] == 1
+        assert report["mode"] == "best_effort"
+
+    def test_never_emits_todo_or_nonagg_sql(self):
+        views, report = UCMetricViewGeneratorTool._build_best_effort_views(
+            fact_source_map={"t": "cat.sch.t"},
+            config=_config({
+                "good": {"base_expr": "SUM(source.x)", "base_filters": []},
+                "todo": {"base_expr": "TODO: fill SQL expression", "base_filters": []},
+                "selector": {"base_expr": "SELECTEDVALUE(foo)", "base_filters": []},
+                "empty": {"base_expr": "", "base_filters": []},
+            }),
+            measures=_measures([("good", "t"), ("todo", "t"), ("selector", "t"), ("empty", "t")]),
+        )
+        emitted = {m["name"] for m in views["t"]["measures"]}
+        assert emitted == {"good"}  # only the real aggregate
+        assert report["measures_emitted"] == 1
+        assert report["measures_skipped_unresolved"] == 3
+        assert set(report["skipped_measures"]) == {"todo", "selector", "empty"}
+
+    def test_applies_base_filters(self):
+        views, _ = UCMetricViewGeneratorTool._build_best_effort_views(
+            fact_source_map={"t": "cat.sch.t"},
+            config=_config({
+                "m": {"base_expr": "SUM(source.v)", "base_filters": ["source.flag = 1", "source.reg = 'X'"]},
+            }),
+            measures=_measures([("m", "t")]),
+        )
+        assert views["t"]["measures"][0]["expr"] == \
+            "SUM(source.v) FILTER (WHERE source.flag = 1 AND source.reg = 'X')"
+
+    def test_table_without_source_is_skipped_and_reported(self):
+        views, report = UCMetricViewGeneratorTool._build_best_effort_views(
+            fact_source_map={"has_source": "cat.sch.a"},
+            config=_config({
+                "m1": {"base_expr": "SUM(source.x)", "base_filters": []},   # alloc -> has_source
+                "m2": {"base_expr": "SUM(source.y)", "base_filters": []},   # alloc -> no_source (not mapped)
+            }),
+            measures=_measures([("m1", "has_source"), ("m2", "no_source")]),
+        )
+        # only the mapped table is emitted; m2's table isn't in fact_source_map
+        assert set(views) == {"has_source"}
+        assert report["measures_emitted"] == 1
+
+    def test_mapped_table_with_no_resolved_measures_reported_missing(self):
+        views, report = UCMetricViewGeneratorTool._build_best_effort_views(
+            fact_source_map={"empty_table": "cat.sch.e"},
+            config=_config({}),
+            measures=_measures([]),
+        )
+        assert views == {}
+        assert "empty_table" in report["tables_without_source"]
+
+    @pytest.mark.parametrize("fsm", [None, {}, "not-a-dict-and-not-json"])
+    def test_no_source_map_gate_returns_no_views(self, fsm):
+        views, report = UCMetricViewGeneratorTool._build_best_effort_views(
+            fact_source_map=fsm,
+            config=_config({"m": {"base_expr": "SUM(source.x)", "base_filters": []}}),
+            measures=_measures([("m", "t")]),
+        )
+        assert views == {}
+        assert report["tables_emitted"] == 0
+
+    def test_report_carries_missing_warning(self):
+        _, report = UCMetricViewGeneratorTool._build_best_effort_views(
+            fact_source_map={"t": "cat.sch.t"},
+            config=_config({"m": {"base_expr": "SUM(source.x)", "base_filters": []}}),
+            measures=_measures([("m", "t")]),
+        )
+        assert "may be MISSING" in report["warning"]
+        assert "upstream semantic model" in report["warning"]

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_ucmv_reevaluation.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_ucmv_reevaluation.py
@@ -1,0 +1,329 @@
+"""Tests for UCMV re-evaluation: capability fingerprint, the retry engine, and the tool.
+
+The feature re-tries ONLY previously-failed measures against today's transpiler and
+reports which are now recoverable. See
+src/docs/powerbi/ucmv-reevaluation-recoverable-measures.md
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.engines.crewai.tools.custom.metric_view_utils import capability_version as cv
+from src.engines.crewai.tools.custom.metric_view_utils.reevaluate import (
+    IMPOSSIBLE_CATEGORIES,
+    RETRYABLE_CATEGORIES,
+    is_retryable,
+    reevaluate_measures,
+    review_key,
+)
+from src.engines.crewai.tools.custom.ucmv_reevaluation_tool import UCMVReevaluationTool
+
+
+# --------------------------------------------------------------------------
+# Capability fingerprint
+# --------------------------------------------------------------------------
+class TestCapabilityFingerprint:
+    def test_fingerprint_is_stable_and_non_trivial(self):
+        cv.capability_fingerprint.cache_clear()
+        fp1 = cv.capability_fingerprint()
+        fp2 = cv.capability_fingerprint()
+        assert fp1 == fp2
+        assert fp1 != cv._UNKNOWN
+        assert len(fp1) == 16
+
+    def test_summary_reports_real_capability_surface(self):
+        s = cv.capability_summary()
+        assert s['pattern_count'] > 10, 'translator should register many patterns'
+        assert s['skill_file_count'] >= 8, 'skill corpus should be present'
+        assert all(f.endswith('.md') for f in s['skill_files'])
+
+    def test_change_detection(self):
+        current = cv.capability_fingerprint()
+        # Unknown/missing stored fingerprint → assume a gain is possible.
+        assert cv.has_capability_changed(None) is True
+        assert cv.has_capability_changed('') is True
+        assert cv.has_capability_changed(cv._UNKNOWN) is True
+        # Different → changed. Same → nothing to gain.
+        assert cv.has_capability_changed('0000000000000000') is True
+        assert cv.has_capability_changed(current) is False
+
+
+# --------------------------------------------------------------------------
+# Retry gating
+# --------------------------------------------------------------------------
+class TestRetryGating:
+    def test_impossible_and_retryable_are_disjoint(self):
+        assert not (IMPOSSIBLE_CATEGORIES & RETRYABLE_CATEGORIES)
+
+    def test_permanent_categories_are_skipped_by_default(self):
+        item = {'original_name': 'C', 'dax_expression': 'IF(1,"a","b")',
+                'category': 'display artifact'}
+        ok, why = is_retryable(item)
+        assert ok is False
+        assert 'permanent limitation' in why
+
+    def test_permanent_categories_can_be_opted_into(self):
+        item = {'original_name': 'C', 'dax_expression': 'IF(1,"a","b")',
+                'category': 'display artifact'}
+        ok, _ = is_retryable(item, include_impossible=True)
+        assert ok is True
+
+    def test_missing_dax_is_not_retryable(self):
+        ok, why = is_retryable({'original_name': 'X', 'dax_expression': '   ',
+                                'category': 'complex DAX — needs manual translation'})
+        assert ok is False
+        assert 'no DAX' in why
+
+    def test_reviewer_dismissed_measures_are_suppressed(self):
+        item = {'table_key': 't', 'original_name': 'M', 'dax_expression': 'SUM(t[a])',
+                'category': 'complex DAX — needs manual translation'}
+        for status in ('wont_fix', 'hand_written'):
+            ok, why = is_retryable(item, review={review_key(item): {'status': status}})
+            assert ok is False, status
+            assert 'dismissed' in why
+        # A non-settling status must NOT suppress
+        ok, _ = is_retryable(item, review={review_key(item): {'status': 'todo'}})
+        assert ok is True
+
+    def test_review_key_matches_frontend_contract(self):
+        assert review_key({'table_key': 'fact_x', 'original_name': 'My Measure'}) == 'fact_x::My Measure'
+
+
+# --------------------------------------------------------------------------
+# Re-evaluation engine
+# --------------------------------------------------------------------------
+class TestReevaluateMeasures:
+    def _simple(self, name='Total Amount', refs=5):
+        # A plain SUM: today's deterministic fast-path handles this.
+        return {
+            'table_key': 'fact_sales', 'original_name': name,
+            'dax_expression': 'SUM(fact_sales[amount])',
+            'skip_reason': 'no matching pattern',
+            'category': 'complex DAX — needs manual translation',
+            'referenced_by': refs,
+        }
+
+    def test_recovers_a_now_translatable_measure(self):
+        out = reevaluate_measures([self._simple()], {})
+        assert out['counts']['recovered'] == 1
+        rec = out['newly_translatable'][0]
+        assert rec['original_name'] == 'Total Amount'
+        assert rec['new_sql']  # real SQL produced
+        assert rec['previous_skip_reason'] == 'no matching pattern'
+        assert rec['referenced_by'] == 5
+
+    def test_never_retries_permanent_or_dismissed(self):
+        items = [
+            self._simple(),
+            {'table_key': 'fact_sales', 'original_name': 'Color',
+             'dax_expression': 'IF(1,"g","r")', 'category': 'display artifact',
+             'referenced_by': 0},
+            self._simple(name='Dismissed', refs=9),
+        ]
+        review = {'fact_sales::Dismissed': {'status': 'wont_fix'}}
+        out = reevaluate_measures(items, {}, review=review)
+        assert out['counts']['retried'] == 1
+        assert out['counts']['skipped'] == 2
+        names = {s['original_name'] for s in out['skipped']}
+        assert names == {'Color', 'Dismissed'}
+
+    def test_results_ordered_by_impact(self):
+        out = reevaluate_measures(
+            [self._simple(name='low', refs=1), self._simple(name='high', refs=42)], {}
+        )
+        assert [r['original_name'] for r in out['newly_translatable']] == ['high', 'low']
+
+    def test_limit_applies_after_impact_ordering(self):
+        items = [self._simple(name='low', refs=1), self._simple(name='high', refs=42)]
+        out = reevaluate_measures(items, {}, limit=1)
+        assert out['counts']['retried'] == 1
+        # The high-impact one must be the one that got the budget.
+        assert out['newly_translatable'][0]['original_name'] == 'high'
+
+    def test_untranslatable_measure_reports_still_failing(self):
+        item = {
+            'table_key': 'fact_sales', 'original_name': 'Weird',
+            # Deliberately not something the fast-path can do.
+            'dax_expression': 'CALCULATE(SUMX(FILTER(ALL(x), x[a]>1), [m]), TREATAS({1}, y[b]))',
+            'category': 'complex DAX — needs manual translation', 'referenced_by': 2,
+        }
+        out = reevaluate_measures([item], {})
+        assert out['counts']['recovered'] == 0
+        assert out['counts']['still_failing'] == 1
+
+    def test_empty_input_is_safe(self):
+        out = reevaluate_measures([], {})
+        assert out['counts'] == {
+            'considered': 0, 'retried': 0, 'recovered': 0,
+            'still_failing': 0, 'skipped': 0,
+        }
+
+    def test_ignores_non_dict_rows(self):
+        out = reevaluate_measures([self._simple(), 'garbage', 42], {})  # type: ignore[list-item]
+        assert out['counts']['considered'] == 1
+
+
+# --------------------------------------------------------------------------
+# Tool
+# --------------------------------------------------------------------------
+class TestUCMVReevaluationTool:
+    def _record(self, dataset_id, fingerprint, items):
+        return SimpleNamespace(
+            id=1, created_at='2026-07-01',
+            configuration={'dataset_id': dataset_id, 'workspace_id': 'ws1',
+                           'capability_fingerprint': fingerprint},
+            input_data={'dataset_id': dataset_id},
+            output_data={'untranslatable_items': items},
+        )
+
+    def _items(self):
+        return [{
+            'table_key': 'fact_sales', 'original_name': 'Total Amount',
+            'dax_expression': 'SUM(fact_sales[amount])',
+            'skip_reason': 'no matching pattern',
+            'category': 'complex DAX — needs manual translation', 'referenced_by': 7,
+        }]
+
+    def _run_with(self, records, **kwargs):
+        """Drive the ConversionHistory FALLBACK path.
+
+        The tool prefers executionhistory (where untranslatable_items actually
+        lands), so that must be stubbed empty for the conversion path to run.
+        """
+        async def _no_executions(self, ids, gid, maxd):
+            return []
+
+        async def _fake_load(self, ids, gid, maxd):
+            return records
+
+        with patch.object(UCMVReevaluationTool, '_load_executions', _no_executions), \
+             patch.object(UCMVReevaluationTool, '_load_records', _fake_load):
+            return json.loads(UCMVReevaluationTool()._run(group_id='g1', **kwargs))
+
+    def test_reports_recoveries_for_a_stale_run(self):
+        out = self._run_with([self._record('ds-old', 'oldfingerprint00', self._items())])
+        assert out['summary']['measures_recovered'] == 1
+        ds = out['datasets'][0]
+        assert ds['dataset_id'] == 'ds-old'
+        assert ds['fingerprint_changed'] is True
+        assert ds['newly_translatable'][0]['new_sql']
+
+    def test_skips_runs_at_the_current_capability_level(self):
+        current = cv.capability_fingerprint()
+        out = self._run_with([self._record('ds-cur', current, self._items())])
+        ds = out['datasets'][0]
+        assert ds['fingerprint_changed'] is False
+        assert ds['newly_translatable'] == []
+        assert 'nothing to gain' in ds['note']
+        assert out['summary']['measures_recovered'] == 0
+
+    def test_force_retries_even_at_current_capability(self):
+        """`force` exists so the sweep can be verified (and re-checked after a change
+        the fingerprint didn't capture) without editing stored rows."""
+        current = cv.capability_fingerprint()
+        rec = [self._record('ds-cur', current, self._items())]
+        without = self._run_with(rec)
+        forced = self._run_with(rec, force=True)
+        assert without['summary']['measures_recovered'] == 0
+        assert forced['summary']['measures_recovered'] == 1
+        assert forced['settings']['force'] is True
+
+    def test_run_without_stored_items_is_reported_not_crashed(self):
+        out = self._run_with([self._record('ds-empty', 'oldfingerprint00', [])])
+        ds = out['datasets'][0]
+        assert ds['newly_translatable'] == []
+        assert 'no stored non-transpiled measures' in ds['note']
+
+    def test_reports_capability_and_settings(self):
+        out = self._run_with([self._record('ds', 'old0', self._items())], use_llm=False)
+        assert out['capability']['fingerprint'] == cv.capability_fingerprint()
+        # use_llm must default OFF so a scheduled sweep burns no tokens.
+        assert out['settings']['use_llm'] is False
+
+    def test_load_failure_is_reported_not_raised(self):
+        """A dead DB must produce an error report, never an exception that kills a
+        scheduled sweep. Both sources must fail for the error to surface."""
+        async def _no_executions(self, ids, gid, maxd):
+            return []
+
+        async def _boom(self, ids, gid, maxd):
+            raise RuntimeError('db down')
+
+        with patch.object(UCMVReevaluationTool, '_load_executions', _no_executions), \
+             patch.object(UCMVReevaluationTool, '_load_records', _boom):
+            out = json.loads(UCMVReevaluationTool()._run(group_id='g1'))
+        assert 'db down' in out['error']
+        assert out['datasets'] == []
+
+    def test_execution_source_is_preferred_over_conversion_history(self):
+        """REGRESSION: untranslatable_items lands in executionhistory.result, NOT in
+        conversion_history (which only gets a summary copy). Reading conversions first
+        made every sweep report 0 measures even with 100+ recorded failures."""
+        ex = {
+            'source': 'execution', 'key': 'job-1', 'label': 'UCMV run',
+            'created_at': '2026-08-05', 'items': self._items(),
+            'fingerprint': 'oldfingerprint00', 'config': {},
+        }
+
+        async def _execs(self, ids, gid, maxd):
+            return [ex]
+
+        async def _never(self, ids, gid, maxd):
+            raise AssertionError('conversion fallback must not run when executions exist')
+
+        with patch.object(UCMVReevaluationTool, '_load_executions', _execs), \
+             patch.object(UCMVReevaluationTool, '_load_records', _never):
+            out = json.loads(UCMVReevaluationTool()._run(group_id='g1'))
+        assert out['summary']['datasets_scanned'] == 1
+        assert out['datasets'][0]['source'] == 'execution'
+        assert out['summary']['measures_recovered'] == 1
+
+    def test_unknown_fingerprint_is_labelled_honestly(self):
+        """A run with no recorded fingerprint is retried (a gain can't be ruled out),
+        but the report must NOT imply the transpiler is known to have improved."""
+        ex = {
+            'source': 'execution', 'key': 'job-2', 'label': 'old run',
+            'created_at': '2026-07-01', 'items': self._items(),
+            'fingerprint': None, 'config': {},
+        }
+
+        async def _execs(self, ids, gid, maxd):
+            return [ex]
+
+        with patch.object(UCMVReevaluationTool, '_load_executions', _execs):
+            out = json.loads(UCMVReevaluationTool()._run(group_id='g1'))
+        ds = out['datasets'][0]
+        assert ds['fingerprint_changed'] is True
+        assert 'pre-dates' in ds['fingerprint_note']
+
+    def test_harvest_finds_items_nested_in_json_strings(self):
+        """Tool outputs are embedded as JSON *strings* inside the execution blob, so a
+        plain .get() misses them — the harvester must recurse and parse."""
+        blob = {
+            'content': {
+                'tool_output': json.dumps({
+                    'yaml': {}, 'untranslatable_items': [
+                        {'original_name': 'M1', 'dax_expression': 'SUM(t[a])'},
+                    ],
+                }),
+            },
+        }
+        found: list = []
+        UCMVReevaluationTool._harvest_untranslatable(blob, found)
+        assert len(found) == 1
+        assert found[0]['original_name'] == 'M1'
+
+    def test_parse_dataset_ids_accepts_json_csv_and_list(self):
+        t = UCMVReevaluationTool()
+        assert t._parse_dataset_ids('["a","b"]') == ['a', 'b']
+        assert t._parse_dataset_ids('c, d') == ['c', 'd']
+        assert t._parse_dataset_ids(['e']) == ['e']
+        assert t._parse_dataset_ids(None) == []
+
+    def test_stored_accessors_tolerate_missing_shapes(self):
+        t = UCMVReevaluationTool()
+        empty = SimpleNamespace()
+        assert t._stored_untranslatable(empty) == []
+        assert t._stored_review(empty) == {}
+        assert t._stored_config(empty) == {}
+        assert t._stored_dataset_id(empty) == ''

--- a/src/backend/tests/unit/engines/crewai/tools/custom/test_ucmv_reevaluation.py
+++ b/src/backend/tests/unit/engines/crewai/tools/custom/test_ucmv_reevaluation.py
@@ -85,6 +85,40 @@ class TestRetryGating:
         ok, _ = is_retryable(item, review={review_key(item): {'status': 'todo'}})
         assert ok is True
 
+    def test_llm_declined_classes_are_not_retried(self):
+        """The LLM's own verdict is authoritative: if the LLM-first translator already
+        classified a measure as untranslatable, retrying at the SAME capability level
+        re-derives the same 'no' (and costs tokens with use_llm=true).
+
+        REGRESSION: before this gate, 73 of 104 real recorded failures were retried
+        even though the LLM had already declined 95 of them — the sweep looked busy
+        but proposed nothing.
+        """
+        for cls in ('unsupported', 'display_layer', 'out_of_scope', 'architecture_change'):
+            item = {'original_name': 'M', 'dax_expression': 'SUM(t[a])',
+                    'category': 'unassigned', 'dax_class': cls}
+            ok, why = is_retryable(item)
+            assert ok is False, cls
+            assert 'LLM already declined' in why
+
+    def test_llm_declined_can_be_opted_into(self):
+        item = {'original_name': 'M', 'dax_expression': 'SUM(t[a])',
+                'category': 'unassigned', 'dax_class': 'unsupported'}
+        assert is_retryable(item, include_impossible=True)[0] is True
+
+    def test_silent_wrong_guard_rejections_ARE_retried(self):
+        """Measures blocked by the silent-wrong guard (dropped ratio denominator,
+        dropped additive term, unresolved measure ref) are genuine candidates — the
+        LLM did not refuse them, the output guard did."""
+        for cls in (None, 'composed', 'translatable_direct'):
+            item = {
+                'original_name': 'Total_NSR', 'dax_expression': 'var a=...\nreturn a+b',
+                'category': 'unassigned', 'dax_class': cls,
+                'skip_reason': 'TODO — not emitted (would be silently wrong/invalid: '
+                               'additive term dropped)',
+            }
+            assert is_retryable(item)[0] is True, cls
+
     def test_review_key_matches_frontend_contract(self):
         assert review_key({'table_key': 'fact_x', 'original_name': 'My Measure'}) == 'fact_x::My Measure'
 

--- a/src/backend/tests/unit/services/test_execution_name_service_unit_extra.py
+++ b/src/backend/tests/unit/services/test_execution_name_service_unit_extra.py
@@ -189,7 +189,10 @@ async def test_get_name_template_opens_standalone_session_when_none():
     fake_template = MagicMock()
     fake_template.get_template_content = AsyncMock(return_value="TEMPLATE BODY")
 
-    with patch("src.db.session.request_scoped_session", return_value=_fake_session_cm()), \
+    # The standalone read uses async_session_factory (NOT request_scoped_session):
+    # the latter reuses the request-scoped session, which would race an in-flight
+    # request. Patch what the code actually calls.
+    with patch("src.db.session.async_session_factory", return_value=_fake_session_cm()), \
          patch("src.services.template_service.TemplateService", return_value=fake_template):
         out = await svc._get_name_template()
 
@@ -206,7 +209,9 @@ async def test_log_llm_interaction_standalone_commits_when_no_session():
     fake_log = MagicMock()
     fake_log.create_log = AsyncMock()
 
-    with patch("src.db.session.request_scoped_session", return_value=session), \
+    # Standalone write goes through async_session_factory (a PRIVATE session) so it
+    # never joins/contends with an in-flight request transaction.
+    with patch("src.db.session.async_session_factory", return_value=session), \
          patch.object(Svc, "_log_llm_interaction", Svc._log_llm_interaction), \
          patch("src.services.log_service.LLMLogService.create", return_value=fake_log):
         await svc._log_llm_interaction(
@@ -263,3 +268,82 @@ async def test_generate_execution_name_none_session_end_to_end(monkeypatch):
 
     assert out.name == "Cool Run"
     fake_template.get_template_content.assert_awaited_once_with("generate_job_name")
+
+
+@pytest.mark.asyncio
+async def test_standalone_mode_detaches_request_session(monkeypatch):
+    """REGRESSION: in standalone mode (session=None) the service must DETACH the
+    request-scoped session ContextVar before doing any DB/LLM work.
+
+    Name generation runs off a task that inherited the HTTP request's context, so
+    `_request_session` still points at the request session. Without detaching, the
+    nested model-config read inside LLMManager.configure_crewai_llm reuses that
+    shared session and races the in-flight request, raising
+    "This session is provisioning a new connection; concurrent operations are not
+    permitted" — which silently downgraded the run name to a timestamp fallback.
+    """
+    svc = Svc.create(None)
+    fake_template = MagicMock()
+    fake_template.get_template_content = AsyncMock(return_value="SYS TEMPLATE")
+    fake_log = MagicMock()
+    fake_log.create_log = AsyncMock()
+
+    class FakeLLMManager:
+        @staticmethod
+        async def completion(messages, model, temperature=0.7, max_tokens=4000, extra_headers=None):
+            return "Detached Name"
+
+    from src.services import execution_name_service as module
+    monkeypatch.setattr(module, "LLMManager", FakeLLMManager, raising=True)
+
+    detach_calls = []
+    import src.db.session as db_session
+    monkeypatch.setattr(
+        db_session, "detach_request_session", lambda: detach_calls.append(1), raising=True
+    )
+
+    req = ExecutionNameGenerationRequest(
+        model="m", agents_yaml={"a": {"role": "R"}}, tasks_yaml={"t": {"name": "T"}}
+    )
+
+    with patch("src.db.session.async_session_factory", return_value=_fake_session_cm()), \
+         patch("src.services.template_service.TemplateService", return_value=fake_template), \
+         patch("src.services.log_service.LLMLogService.create", return_value=fake_log):
+        out = await svc.generate_execution_name(req)
+
+    assert out.name == "Detached Name"
+    assert detach_calls, "standalone mode must detach the request-scoped session"
+
+
+@pytest.mark.asyncio
+async def test_injected_session_does_not_detach(monkeypatch):
+    """With an INJECTED session the caller owns the transaction — we must NOT
+    detach (that would break the caller's request-scoped participation)."""
+    fake_session = MagicMock()
+    svc = Svc.create(fake_session)
+    fake_template = MagicMock()
+    fake_template.get_template_content = AsyncMock(return_value="SYS TEMPLATE")
+
+    class FakeLLMManager:
+        @staticmethod
+        async def completion(messages, model, temperature=0.7, max_tokens=4000, extra_headers=None):
+            return "Injected Name"
+
+    from src.services import execution_name_service as module
+    monkeypatch.setattr(module, "LLMManager", FakeLLMManager, raising=True)
+    svc.template_service = fake_template
+    svc.log_service = MagicMock(create_log=AsyncMock())
+
+    detach_calls = []
+    import src.db.session as db_session
+    monkeypatch.setattr(
+        db_session, "detach_request_session", lambda: detach_calls.append(1), raising=True
+    )
+
+    req = ExecutionNameGenerationRequest(
+        model="m", agents_yaml={"a": {"role": "R"}}, tasks_yaml={"t": {"name": "T"}}
+    )
+    out = await svc.generate_execution_name(req)
+
+    assert out.name == "Injected Name"
+    assert not detach_calls, "injected-session mode must NOT detach"

--- a/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
+++ b/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
@@ -193,7 +193,9 @@ class TestMineExamples:
                 prompt="/load crew Some Crew", status="success", created_at=now
             ),  # slash command
             SimpleNamespace(
-                prompt="Crew generation failed: no credentials", status="success", created_at=now
+                prompt="Crew generation failed: no credentials",
+                status="success",
+                created_at=now,
             ),  # system error string
             SimpleNamespace(prompt="run crew", status="success", created_at=now),
         ]
@@ -219,9 +221,10 @@ class TestReflectionModelResolution:
         svc.model_repository.find_by_key = AsyncMock(
             return_value=SimpleNamespace(provider="databricks")
         )
-        uri, env = await svc._resolve_reflection_model("some-endpoint")
+        uri, env, provider = await svc._resolve_reflection_model("some-endpoint")
         assert uri == "databricks:/some-endpoint"
         assert env == {}
+        assert provider == "databricks"
 
     @pytest.mark.asyncio
     async def test_vllm_provider_sets_openai_env(self):
@@ -229,9 +232,33 @@ class TestReflectionModelResolution:
         svc.model_repository.find_by_key = AsyncMock(
             return_value=SimpleNamespace(provider="vllm")
         )
-        uri, env = await svc._resolve_reflection_model("Qwen3-Coder-30B-A3B-Instruct")
+        uri, env, provider = await svc._resolve_reflection_model(
+            "Qwen3-Coder-30B-A3B-Instruct"
+        )
         assert uri == "openai:/Qwen3-Coder-30B-A3B-Instruct"
+        assert provider == "vllm"
         assert "OPENAI_API_BASE" in env and "OPENAI_API_KEY" in env
+
+    @pytest.mark.asyncio
+    async def test_kimi_provider_resolves_with_key_and_provider_tag(self):
+        # The provider tag drives request quirks downstream — Kimi rejects any
+        # explicit temperature, so the caller must know it is talking to Kimi.
+        svc = PromptOptimizationService(MagicMock())
+        svc.model_repository.find_by_key = AsyncMock(
+            return_value=SimpleNamespace(
+                provider="kimi", name="kimi-k2.7-code-highspeed"
+            )
+        )
+        with patch(
+            "src.services.api_keys_service.ApiKeysService.get_provider_api_key",
+            AsyncMock(return_value="sk-test"),
+        ):
+            uri, env, provider = await svc._resolve_reflection_model(
+                "kimi-k2.7-code-highspeed", _group()
+            )
+        assert uri == "openai:/kimi-k2.7-code-highspeed"
+        assert env["OPENAI_API_KEY"] == "sk-test"
+        assert provider == "kimi"
 
     @pytest.mark.asyncio
     async def test_unknown_provider_raises(self):
@@ -605,9 +632,7 @@ class _FakeMlflowRegistry:
                 self.model = model
 
             def register(self):
-                registry.registered.append(
-                    (self.name, self.instructions, self.model)
-                )
+                registry.registered.append((self.name, self.instructions, self.model))
                 registry.scorers[self.name] = self
 
         mlflow = types.ModuleType("mlflow")
@@ -617,8 +642,10 @@ class _FakeMlflowRegistry:
 
         genai = types.ModuleType("mlflow.genai")
         judges = types.ModuleType("mlflow.genai.judges")
-        judges.make_judge = lambda name, instructions, model, feedback_value_type: _Judge(
-            name, instructions, model
+        judges.make_judge = (
+            lambda name, instructions, model, feedback_value_type: _Judge(
+                name, instructions, model
+            )
         )
         scorers = types.ModuleType("mlflow.genai.scorers")
         scorers.get_scorer = lambda name: registry.scorers[name]
@@ -652,7 +679,7 @@ def fake_mlflow(monkeypatch):
 
 def _judge_service():
     svc = PromptOptimizationService(MagicMock())
-    svc._resolve_reflection_model = AsyncMock(return_value=("openai:/qwen", {}))
+    svc._resolve_reflection_model = AsyncMock(return_value=("openai:/qwen", {}, "vllm"))
     return svc
 
 
@@ -714,7 +741,7 @@ class TestJudgeLifecycle:
         svc = _judge_service()
         await svc.create_judge("acc", "Keep these criteria for {{ outputs }}.")
         svc._resolve_reflection_model = AsyncMock(
-            return_value=("deepseek:/v4", {})
+            return_value=("deepseek:/v4", {}, "deepseek")
         )
         fake_mlflow.registered.clear()
         await svc.update_judge("acc", model="deepseek-v4-pro", group_context=_group())

--- a/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
+++ b/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
@@ -17,6 +17,9 @@ from src.schemas.prompt_optimization import PromptOptimizationRequest
 from src.services import prompt_optimization_service as svc_module
 from src.services.prompt_optimization_service import (
     PromptOptimizationService,
+    _checklist_grade,
+    _distill_requirements,
+    _parse_requirement_lines,
     _extract_user_from_log,
     _intent_format_score,
     _json_keys_score,
@@ -270,6 +273,77 @@ class TestGenericScoringHelpers:
         assert _job_name_score("Run") == pytest.approx(0.5)
         assert _job_name_score('{"name": "Swiss News"}') == 0.0
         assert _job_name_score("") == 0.0
+
+
+class TestRequirementsDistillation:
+    def test_dedupes_repeated_complaints(self):
+        notes = [
+            "it is giving french side we need german side of switzerland",
+            "It is giving FRENCH side, we need german side of switzerland!",
+            "you provided me a link of rent and not buy.",
+            "I am expecting apartments for sale and not rent",
+            "",
+            "it is giving french side we need german side of switzerland",
+        ]
+        reqs = _distill_requirements(notes)
+        assert len(reqs) == 3
+        assert reqs[0].startswith("it is giving french side")
+
+    def test_respects_limit_and_order(self):
+        notes = [f"requirement {i}" for i in range(12)]
+        reqs = _distill_requirements(notes, limit=8)
+        assert len(reqs) == 8
+        assert reqs[0] == "requirement 0"
+
+    def test_empty_input(self):
+        assert _distill_requirements([]) == []
+        assert _distill_requirements(["", "   ", None]) == []
+
+
+class TestParseRequirementLines:
+    def test_parses_numbered_lines(self):
+        text = (
+            "R1. Only German-speaking Switzerland.\n\n"
+            "R2: Apartments for sale, not rent.\n"
+            "Some trailing chatter."
+        )
+        assert _parse_requirement_lines(text) == [
+            "Only German-speaking Switzerland.",
+            "Apartments for sale, not rent.",
+        ]
+
+    def test_empty_or_chatter_returns_nothing(self):
+        assert _parse_requirement_lines("") == []
+        assert _parse_requirement_lines("I could not produce a list.") == []
+
+
+class TestChecklistGrade:
+    def test_grade_computed_from_marks_not_model_arithmetic(self):
+        # The model claims "40" — the grade must come from the marks.
+        verdict = "R1: FAIL — quotes Geneva\nR2: PASS\nR3: PASS\n\n40"
+        grade = _checklist_grade(verdict, 3)
+        # 0.8 * (2/3) + 0.2 * 0.5 (no Q mark -> default 5/10)
+        assert grade == pytest.approx(0.8 * (2 / 3) + 0.1)
+
+    def test_quality_mark_blends_in(self):
+        verdict = "R1: PASS\nR2: PASS\nQ: 8"
+        assert _checklist_grade(verdict, 2) == pytest.approx(0.8 + 0.2 * 0.8)
+
+    def test_all_fail_scores_low_but_not_none(self):
+        verdict = "R1: FAIL — x\nR2: FAIL — y\nQ: 0"
+        assert _checklist_grade(verdict, 2) == pytest.approx(0.0)
+
+    def test_no_marks_returns_none_for_fallback(self):
+        assert _checklist_grade("I think this is a 7.", 3) is None
+        assert _checklist_grade("", 3) is None
+
+    def test_duplicate_marks_first_wins(self):
+        verdict = "R1: PASS\nR1: FAIL — restated\nQ: 5"
+        assert _checklist_grade(verdict, 1) == pytest.approx(0.8 + 0.1)
+
+    def test_case_insensitive_marks(self):
+        verdict = "r1: pass\nr2: fail — z"
+        assert _checklist_grade(verdict, 2) == pytest.approx(0.8 * 0.5 + 0.1)
 
 
 class TestRegistryResolution:

--- a/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
+++ b/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
@@ -300,6 +300,27 @@ class TestRequirementsDistillation:
         assert _distill_requirements(["", "   ", None]) == []
 
 
+class TestCrewDocFenceRescue:
+    DOC = (
+        "[AGENT a1]\nROLE: r\nGOAL: g\nBACKSTORY: b\n\n"
+        "[TASK t1]\nDESCRIPTION: d\nEXPECTED_OUTPUT: e"
+    )
+
+    def test_fenced_doc_parses(self):
+        fenced = f"```\n{self.DOC}\n```"
+        fields = svc_module._parse_crew_doc(fenced)
+        assert fields is not None
+        assert fields["agent.a1.role"] == "r"
+        assert fields["task.t1.expected_output"] == "e"
+
+    def test_language_tagged_fence_parses(self):
+        fenced = f"```text\n{self.DOC}\n```"
+        assert svc_module._parse_crew_doc(fenced) is not None
+
+    def test_json_blob_still_rejected(self):
+        assert svc_module._parse_crew_doc('{"instruction": "be better"}') is None
+
+
 class TestParseRequirementLines:
     def test_parses_numbered_lines(self):
         text = (

--- a/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
+++ b/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
@@ -1,0 +1,401 @@
+"""
+Unit tests for PromptOptimizationService.
+
+Covers the format scorer, example mining (dedupe/status/cutoff filters),
+run lifecycle (start → background completion / failure), group-scoped
+visibility, reflection-model resolution, and the apply flow.
+"""
+
+import asyncio
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.schemas.prompt_optimization import PromptOptimizationRequest
+from src.services import prompt_optimization_service as svc_module
+from src.services.prompt_optimization_service import (
+    PromptOptimizationService,
+    _extract_user_from_log,
+    _intent_format_score,
+    _json_keys_score,
+)
+from src.utils.user_context import GroupContext
+
+EXAMPLES = [
+    "get the news",
+    "run crew",
+    "create an agent for support",
+    "analyze sales",
+    "make a report",
+]
+
+
+def _group(gid="grp1"):
+    return GroupContext(
+        group_ids=[gid], group_email="user@example.com", email_domain="example.com"
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_runs():
+    svc_module._RUNS.clear()
+    yield
+    svc_module._RUNS.clear()
+
+
+def _service(template="TEMPLATE", sync_result=None, sync_error=None):
+    svc = PromptOptimizationService(MagicMock())
+    svc.model_repository = MagicMock()
+    svc.model_repository.find_by_key = AsyncMock(
+        return_value=SimpleNamespace(provider="databricks")
+    )
+    svc._resolve_registry = AsyncMock(
+        return_value=("http://127.0.0.1:5555", "kasal_detect_intent_grp1")
+    )
+    patches = [
+        patch.object(
+            svc_module.TemplateService,
+            "get_effective_template_content",
+            AsyncMock(return_value=template),
+        ),
+    ]
+    if sync_error is not None:
+        patches.append(
+            patch.object(
+                PromptOptimizationService,
+                "_execute_optimization_sync",
+                MagicMock(side_effect=sync_error),
+            )
+        )
+    else:
+        patches.append(
+            patch.object(
+                PromptOptimizationService,
+                "_execute_optimization_sync",
+                MagicMock(
+                    return_value=sync_result
+                    or {
+                        "optimized_template": "BETTER TEMPLATE",
+                        "initial_score": 0.5,
+                        "final_score": 0.9,
+                    }
+                ),
+            )
+        )
+    return svc, patches
+
+
+class TestIntentFormatScore:
+    def test_full_contract_scores_one(self):
+        out = (
+            '{"intent": "generate_crew", "confidence": 0.95, '
+            '"extracted_info": {"goal": "x"}, "suggested_prompt": "do it"}'
+        )
+        assert _intent_format_score(out) == pytest.approx(1.0)
+
+    def test_invalid_intent_loses_main_weight(self):
+        out = '{"intent": "nonsense", "confidence": 0.9, "extracted_info": {}, "suggested_prompt": "p"}'
+        assert _intent_format_score(out) == pytest.approx(0.4)
+
+    def test_garbage_scores_zero(self):
+        assert _intent_format_score("not json at all {{{") == 0.0
+
+    def test_out_of_range_confidence_not_counted(self):
+        out = '{"intent": "generate_crew", "confidence": 1.7}'
+        assert _intent_format_score(out) == pytest.approx(0.6)
+
+
+class TestStartOptimization:
+    @pytest.mark.asyncio
+    async def test_inline_examples_run_completes(self):
+        svc, patches = _service()
+        with patches[0], patches[1]:
+            result = await svc.start_optimization(
+                PromptOptimizationRequest(
+                    template_name="detect_intent", examples=EXAMPLES
+                ),
+                _group(),
+            )
+            run_id = result["run_id"]
+            assert result["status"] == "pending"
+            assert result["dataset_size"] == len(EXAMPLES)
+            await svc_module._RUNS[run_id]["task"]
+        run = svc.get_run(run_id, _group())
+        assert run["status"] == "completed"
+        assert run["optimized_template"] == "BETTER TEMPLATE"
+        assert run["initial_score"] == 0.5
+        assert run["final_score"] == 0.9
+        assert run["baseline_template"] == "TEMPLATE"
+
+    @pytest.mark.asyncio
+    async def test_failure_is_captured_on_the_run(self):
+        svc, patches = _service(sync_error=RuntimeError("gepa exploded"))
+        with patches[0], patches[1]:
+            result = await svc.start_optimization(
+                PromptOptimizationRequest(
+                    template_name="detect_intent", examples=EXAMPLES
+                ),
+                _group(),
+            )
+            await svc_module._RUNS[result["run_id"]]["task"]
+        run = svc.get_run(result["run_id"], _group())
+        assert run["status"] == "failed"
+        assert "gepa exploded" in run["error"]
+
+    @pytest.mark.asyncio
+    async def test_too_few_examples_rejected(self):
+        svc, patches = _service()
+        with patches[0], patches[1]:
+            with pytest.raises(ValueError, match="at least"):
+                await svc.start_optimization(
+                    PromptOptimizationRequest(
+                        template_name="detect_intent", examples=["one", "two"]
+                    ),
+                    _group(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_empty_template_rejected(self):
+        svc, patches = _service(template="   ")
+        with patches[0], patches[1]:
+            with pytest.raises(ValueError, match="template"):
+                await svc.start_optimization(
+                    PromptOptimizationRequest(
+                        template_name="detect_intent", examples=EXAMPLES
+                    ),
+                    _group(),
+                )
+
+
+class TestMineExamples:
+    @pytest.mark.asyncio
+    async def test_filters_dedupes_and_respects_cutoff(self):
+        svc = PromptOptimizationService(MagicMock())
+        now = datetime.utcnow()
+        rows = [
+            SimpleNamespace(prompt="get the news", status="success", created_at=now),
+            SimpleNamespace(
+                prompt="Get The News", status="success", created_at=now
+            ),  # dup (case)
+            SimpleNamespace(
+                prompt="broken", status="error", created_at=now
+            ),  # not success
+            SimpleNamespace(prompt="  ", status="success", created_at=now),  # empty
+            SimpleNamespace(
+                prompt="ancient", status="success", created_at=now - timedelta(days=99)
+            ),
+            SimpleNamespace(
+                prompt="/load crew Some Crew", status="success", created_at=now
+            ),  # slash command
+            SimpleNamespace(
+                prompt="Crew generation failed: no credentials", status="success", created_at=now
+            ),  # system error string
+            SimpleNamespace(prompt="run crew", status="success", created_at=now),
+        ]
+        svc.log_repository = MagicMock()
+        svc.log_repository.get_logs_paginated_by_group = AsyncMock(
+            side_effect=[rows, []]
+        )
+        examples = await svc._mine_examples(
+            "detect-intent", _group(), lookback_days=30, max_examples=10
+        )
+        assert examples == ["get the news", "run crew"]
+
+    @pytest.mark.asyncio
+    async def test_no_group_returns_empty(self):
+        svc = PromptOptimizationService(MagicMock())
+        assert await svc._mine_examples("detect-intent", None, 30, 10) == []
+
+
+class TestReflectionModelResolution:
+    @pytest.mark.asyncio
+    async def test_databricks_provider(self):
+        svc = PromptOptimizationService(MagicMock())
+        svc.model_repository.find_by_key = AsyncMock(
+            return_value=SimpleNamespace(provider="databricks")
+        )
+        uri, env = await svc._resolve_reflection_model("some-endpoint")
+        assert uri == "databricks:/some-endpoint"
+        assert env == {}
+
+    @pytest.mark.asyncio
+    async def test_vllm_provider_sets_openai_env(self):
+        svc = PromptOptimizationService(MagicMock())
+        svc.model_repository.find_by_key = AsyncMock(
+            return_value=SimpleNamespace(provider="vllm")
+        )
+        uri, env = await svc._resolve_reflection_model("Qwen3-Coder-30B-A3B-Instruct")
+        assert uri == "openai:/Qwen3-Coder-30B-A3B-Instruct"
+        assert "OPENAI_API_BASE" in env and "OPENAI_API_KEY" in env
+
+    @pytest.mark.asyncio
+    async def test_unknown_provider_raises(self):
+        svc = PromptOptimizationService(MagicMock())
+        svc.model_repository.find_by_key = AsyncMock(return_value=None)
+        with pytest.raises(ValueError, match="unsupported provider"):
+            await svc._resolve_reflection_model("mystery-model")
+
+
+class TestGenericScoringHelpers:
+    def test_extract_user_from_generation_log(self):
+        assert (
+            _extract_user_from_log("System: tpl text\nUser: build a report")
+            == "build a report"
+        )
+        assert _extract_user_from_log("just a raw message") is None
+        assert _extract_user_from_log("System: tpl\nUser:   ") is None
+
+    def test_json_keys_score_fraction(self):
+        keys = ("name", "role", "goal", "backstory")
+        full = '{"name": "A", "role": "B", "goal": "C", "backstory": "D"}'
+        assert _json_keys_score(full, keys) == pytest.approx(1.0)
+        half = '{"name": "A", "role": "B", "goal": "", "backstory": null}'
+        assert _json_keys_score(half, keys) == pytest.approx(0.5)
+        assert _json_keys_score("not json {{{", keys) == 0.0
+
+    def test_json_keys_score_accepts_lists_and_objects(self):
+        keys = ("agents", "tasks")
+        crew = '{"agents": [{"name": "A"}], "tasks": [{"name": "T"}]}'
+        assert _json_keys_score(crew, keys) == pytest.approx(1.0)
+        empty = '{"agents": [], "tasks": [{"name": "T"}]}'
+        assert _json_keys_score(empty, keys) == pytest.approx(0.5)
+
+    def test_job_name_score(self):
+        from src.services.prompt_optimization_service import _job_name_score
+
+        assert _job_name_score("Swiss News Digest") == pytest.approx(1.0)
+        assert _job_name_score('"Sales Analysis"') == pytest.approx(1.0)
+        assert _job_name_score("Run") == pytest.approx(0.5)
+        assert _job_name_score('{"name": "Swiss News"}') == 0.0
+        assert _job_name_score("") == 0.0
+
+
+class TestRegistryResolution:
+    @pytest.mark.asyncio
+    async def test_local_mode_requires_both_env_vars(self, monkeypatch):
+        svc = PromptOptimizationService(MagicMock())
+        monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+        monkeypatch.delenv("KASAL_LAUNCH_MLFLOW_TRACKING_URI", raising=False)
+        monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:5555")
+        uri, name = await svc._resolve_registry("detect_intent", _group())
+        assert uri == "http://127.0.0.1:5555"
+        assert name == "kasal_detect_intent_grp1"
+
+    @pytest.mark.asyncio
+    async def test_launch_value_survives_runtime_override(self, monkeypatch):
+        # main.py overwrites MLFLOW_TRACKING_URI to "databricks" at startup but
+        # preserves the launch value — local mode must use the launch value.
+        svc = PromptOptimizationService(MagicMock())
+        monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+        monkeypatch.setenv("KASAL_LAUNCH_MLFLOW_TRACKING_URI", "http://127.0.0.1:5555")
+        monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
+        uri, name = await svc._resolve_registry("detect_intent", _group())
+        assert uri == "http://127.0.0.1:5555"
+        assert name == "kasal_detect_intent_grp1"
+
+    @pytest.mark.asyncio
+    async def test_tracking_uri_alone_is_not_local_mode(self, monkeypatch):
+        svc = PromptOptimizationService(MagicMock())
+        monkeypatch.delenv("MCP_SERVER_ENABLED", raising=False)
+        monkeypatch.delenv("KASAL_LAUNCH_MLFLOW_TRACKING_URI", raising=False)
+        monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:5555")
+        fake_db = MagicMock()
+        fake_db.get_databricks_config = AsyncMock(
+            return_value=SimpleNamespace(catalog="main", db_schema="kasal")
+        )
+        with patch(
+            "src.services.databricks_service.DatabricksService", return_value=fake_db
+        ):
+            uri, name = await svc._resolve_registry("detect_intent", _group())
+        assert uri == "databricks-uc"
+        assert name == "main.kasal.kasal_detect_intent_grp1"
+
+    @pytest.mark.asyncio
+    async def test_managed_without_uc_config_raises(self, monkeypatch):
+        svc = PromptOptimizationService(MagicMock())
+        monkeypatch.delenv("MCP_SERVER_ENABLED", raising=False)
+        monkeypatch.delenv("KASAL_LAUNCH_MLFLOW_TRACKING_URI", raising=False)
+        monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+        fake_db = MagicMock()
+        fake_db.get_databricks_config = AsyncMock(return_value=None)
+        with patch(
+            "src.services.databricks_service.DatabricksService", return_value=fake_db
+        ):
+            with pytest.raises(ValueError, match="catalog and schema"):
+                await svc._resolve_registry("detect_intent", _group())
+
+
+class TestVisibilityAndApply:
+    @pytest.mark.asyncio
+    async def test_runs_are_group_scoped(self):
+        svc, patches = _service()
+        with patches[0], patches[1]:
+            result = await svc.start_optimization(
+                PromptOptimizationRequest(
+                    template_name="detect_intent", examples=EXAMPLES
+                ),
+                _group("grp1"),
+            )
+            await svc_module._RUNS[result["run_id"]]["task"]
+        assert svc.get_run(result["run_id"], _group("other")) is None
+        assert svc.list_runs(_group("other")) == []
+        assert len(svc.list_runs(_group("grp1"))) == 1
+
+    @pytest.mark.asyncio
+    async def test_apply_writes_group_override(self):
+        svc, patches = _service()
+        with patches[0], patches[1]:
+            result = await svc.start_optimization(
+                PromptOptimizationRequest(
+                    template_name="detect_intent", examples=EXAMPLES
+                ),
+                _group(),
+            )
+            await svc_module._RUNS[result["run_id"]]["task"]
+
+        fake_row = SimpleNamespace(id=42)
+        fake_template_service = MagicMock()
+        fake_template_service.find_by_name_with_group_check = AsyncMock(
+            return_value=fake_row
+        )
+        fake_template_service.update_with_group_check = AsyncMock(
+            return_value=SimpleNamespace(id=42)
+        )
+        with patch.object(
+            svc_module, "TemplateService", return_value=fake_template_service
+        ):
+            applied = await svc.apply_run(result["run_id"], _group())
+        assert applied["applied"] is True
+        update_args = fake_template_service.update_with_group_check.call_args
+        assert update_args.args[0] == 42
+        assert update_args.args[1].template == "BETTER TEMPLATE"
+        assert svc.get_run(result["run_id"], _group())["applied"] is True
+
+    @pytest.mark.asyncio
+    async def test_apply_rejects_unfinished_run(self):
+        svc = PromptOptimizationService(MagicMock())
+        svc_module._RUNS["r1"] = {
+            "run_id": "r1",
+            "template_name": "detect_intent",
+            "status": "running",
+            "group_id": "grp1",
+            "created_at": datetime.utcnow(),
+        }
+        with pytest.raises(ValueError, match="no completed proposal"):
+            await svc.apply_run("r1", _group("grp1"))
+
+    @pytest.mark.asyncio
+    async def test_apply_rejects_other_groups_run(self):
+        svc = PromptOptimizationService(MagicMock())
+        svc_module._RUNS["r2"] = {
+            "run_id": "r2",
+            "template_name": "detect_intent",
+            "status": "completed",
+            "optimized_template": "X",
+            "group_id": "grp1",
+            "created_at": datetime.utcnow(),
+        }
+        with pytest.raises(ValueError, match="not found"):
+            await svc.apply_run("r2", _group("other"))

--- a/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
+++ b/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
@@ -494,3 +494,353 @@ class TestVisibilityAndApply:
         }
         with pytest.raises(ValueError, match="not found"):
             await svc.apply_run("r2", _group("other"))
+
+
+class TestCrewDocSerialization:
+    """The serialize/parse pair is the GEPA mutation contract: candidates that
+    survive parsing execute for real; everything else free-rejects."""
+
+    @staticmethod
+    def _crew():
+        agent = SimpleNamespace(
+            id="a1", role="Researcher", goal="Find facts", backstory="line1\nline2"
+        )
+        task = SimpleNamespace(
+            id="t1", description="Do the research", expected_output="A table"
+        )
+        return [agent], [task]
+
+    def test_round_trip_preserves_fields_and_keys(self):
+        agents, tasks = self._crew()
+        doc, keys = svc_module._serialize_crew_doc(agents, tasks)
+        fields = svc_module._parse_crew_doc(doc)
+        assert fields is not None
+        assert set(fields) == set(keys)
+        assert fields["agent.a1.role"] == "Researcher"
+        assert fields["task.t1.expected_output"] == "A table"
+
+    def test_multiline_field_survives_via_continuation_lines(self):
+        agents, tasks = self._crew()
+        doc, _ = svc_module._serialize_crew_doc(agents, tasks)
+        fields = svc_module._parse_crew_doc(doc)
+        assert fields["agent.a1.backstory"] == "line1\nline2"
+
+    def test_doc_layout_uses_labeled_sections(self):
+        agents, tasks = self._crew()
+        doc, _ = svc_module._serialize_crew_doc(agents, tasks)
+        assert "[AGENT a1]" in doc
+        assert "[TASK t1]" in doc
+        assert "ROLE: Researcher" in doc
+        assert "EXPECTED_OUTPUT: A table" in doc
+
+    def test_label_before_any_entity_is_rejected(self):
+        assert svc_module._parse_crew_doc("ROLE: orphan") is None
+
+    def test_plain_prose_is_rejected(self):
+        assert svc_module._parse_crew_doc("Here is a better prompt for you.") is None
+
+    def test_json_blob_is_rejected(self):
+        assert svc_module._parse_crew_doc('{"instruction": "be better"}') is None
+
+    def test_empty_doc_is_rejected(self):
+        assert svc_module._parse_crew_doc("") is None
+        assert svc_module._parse_crew_doc(None) is None
+
+    def test_mutated_doc_with_changed_key_set_detectable(self):
+        # A mutation that drops a section parses, but the key set differs —
+        # the caller compares against expected_keys and rejects for free.
+        agents, tasks = self._crew()
+        _, keys = svc_module._serialize_crew_doc(agents, tasks)
+        partial = "[AGENT a1]\nROLE: Only role"
+        fields = svc_module._parse_crew_doc(partial)
+        assert fields is not None
+        assert set(fields) != set(keys)
+
+
+class TestJudgeValueToGrade:
+    def test_numeric_scales(self):
+        grade = svc_module._judge_value_to_grade
+        assert grade(7) == 0.7
+        assert grade(0.4) == 0.4
+        assert grade("3") == pytest.approx(0.3)
+        assert grade(10) == 1.0
+        # Above the 0-10 scale clamps rather than exploding
+        assert grade(15) == 1.0
+
+    def test_booleans(self):
+        assert svc_module._judge_value_to_grade(True) == 1.0
+        assert svc_module._judge_value_to_grade(False) == 0.0
+
+    def test_categorical_words(self):
+        grade = svc_module._judge_value_to_grade
+        assert grade("excellent") == 1.0
+        assert grade("Satisfactory") == 0.75
+        assert grade("partial") == 0.5
+        assert grade("poor") == 0.25
+        assert grade("fail") == 0.0
+
+    def test_unusable_values_return_none(self):
+        assert svc_module._judge_value_to_grade(None) is None
+        assert svc_module._judge_value_to_grade("gibberish verdict") is None
+
+
+class _FakeMlflowRegistry:
+    """Fake mlflow + mlflow.genai.{judges,scorers} module tree that records
+    registrations so judge-lifecycle tests never touch a real server."""
+
+    def __init__(self):
+        import types
+
+        self.registered = []  # (name, instructions, model)
+        self.deleted = []
+        self.experiments = []
+        self.scorers = {}
+
+        registry = self
+
+        class _Judge:
+            def __init__(self, name, instructions, model):
+                self.name = name
+                self.instructions = instructions
+                self.model = model
+
+            def register(self):
+                registry.registered.append(
+                    (self.name, self.instructions, self.model)
+                )
+                registry.scorers[self.name] = self
+
+        mlflow = types.ModuleType("mlflow")
+        mlflow.get_tracking_uri = lambda: "prev://"
+        mlflow.set_tracking_uri = lambda uri: None
+        mlflow.set_experiment = lambda name: registry.experiments.append(name)
+
+        genai = types.ModuleType("mlflow.genai")
+        judges = types.ModuleType("mlflow.genai.judges")
+        judges.make_judge = lambda name, instructions, model, feedback_value_type: _Judge(
+            name, instructions, model
+        )
+        scorers = types.ModuleType("mlflow.genai.scorers")
+        scorers.get_scorer = lambda name: registry.scorers[name]
+        scorers.delete_scorer = lambda name, version: registry.deleted.append(
+            (name, version)
+        )
+        scorers.list_scorers = lambda: list(registry.scorers.values())
+        mlflow.genai = genai
+        genai.judges = judges
+        genai.scorers = scorers
+        self.modules = {
+            "mlflow": mlflow,
+            "mlflow.genai": genai,
+            "mlflow.genai.judges": judges,
+            "mlflow.genai.scorers": scorers,
+        }
+
+
+@pytest.fixture()
+def fake_mlflow(monkeypatch):
+    import sys
+
+    registry = _FakeMlflowRegistry()
+    for name, module in registry.modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:5555")
+    monkeypatch.delenv("KASAL_LAUNCH_MLFLOW_TRACKING_URI", raising=False)
+    return registry
+
+
+def _judge_service():
+    svc = PromptOptimizationService(MagicMock())
+    svc._resolve_reflection_model = AsyncMock(return_value=("openai:/qwen", {}))
+    return svc
+
+
+class TestJudgeLifecycle:
+    @pytest.mark.asyncio
+    async def test_create_from_crew_registers_library_and_scoped_copy(
+        self, fake_mlflow
+    ):
+        svc = _judge_service()
+        crew_id = "88ab4478-823c-4f12-b1ca-8e74c568995e"
+        result = await svc.create_judge(
+            "accuracy", "Rate accuracy 0-10.", crew_id=crew_id, group_context=_group()
+        )
+        names = [name for name, _, _ in fake_mlflow.registered]
+        assert names == ["accuracy", "crew_88ab4478823c__accuracy"]
+        assert result["full_name"] == "crew_88ab4478823c__accuracy"
+        # {{ outputs }} template variable auto-appended when missing
+        assert "{{ outputs }}" in fake_mlflow.registered[0][1]
+
+    @pytest.mark.asyncio
+    async def test_create_without_crew_registers_library_only(self, fake_mlflow):
+        svc = _judge_service()
+        await svc.create_judge("style", "Judge style of {{ outputs }}.")
+        assert [n for n, _, _ in fake_mlflow.registered] == ["style"]
+
+    @pytest.mark.asyncio
+    async def test_create_validates_inputs(self, fake_mlflow):
+        svc = _judge_service()
+        with pytest.raises(ValueError, match="name"):
+            await svc.create_judge("   ", "criteria")
+        with pytest.raises(ValueError, match="instructions"):
+            await svc.create_judge("ok", "   ")
+
+    @pytest.mark.asyncio
+    async def test_create_requires_local_mode(self, fake_mlflow, monkeypatch):
+        monkeypatch.setenv("MCP_SERVER_ENABLED", "false")
+        svc = _judge_service()
+        with pytest.raises(ValueError, match="local MLflow"):
+            await svc.create_judge("x", "y")
+
+    @pytest.mark.asyncio
+    async def test_update_replaces_instructions_keeps_model(self, fake_mlflow):
+        svc = _judge_service()
+        await svc.create_judge("acc", "Old criteria for {{ outputs }}.")
+        fake_mlflow.registered.clear()
+        result = await svc.update_judge(
+            "acc", instructions="New criteria.", group_context=_group()
+        )
+        assert len(fake_mlflow.registered) == 1
+        name, instructions, model = fake_mlflow.registered[0]
+        assert name == "acc"
+        assert "New criteria." in instructions
+        assert "{{ outputs }}" in instructions
+        assert model == "openai:/qwen"  # unchanged from creation
+        assert result["model"] == "openai:/qwen"
+
+    @pytest.mark.asyncio
+    async def test_update_model_keeps_instructions(self, fake_mlflow):
+        svc = _judge_service()
+        await svc.create_judge("acc", "Keep these criteria for {{ outputs }}.")
+        svc._resolve_reflection_model = AsyncMock(
+            return_value=("deepseek:/v4", {})
+        )
+        fake_mlflow.registered.clear()
+        await svc.update_judge("acc", model="deepseek-v4-pro", group_context=_group())
+        name, instructions, model = fake_mlflow.registered[0]
+        assert model == "deepseek:/v4"
+        assert "Keep these criteria" in instructions
+
+    @pytest.mark.asyncio
+    async def test_update_with_nothing_to_change_rejected(self, fake_mlflow):
+        svc = _judge_service()
+        with pytest.raises(ValueError, match="Nothing to update"):
+            await svc.update_judge("acc")
+
+    @pytest.mark.asyncio
+    async def test_assign_copies_source_into_crew_scope(self, fake_mlflow):
+        svc = _judge_service()
+        await svc.create_judge("shared", "Shared criteria for {{ outputs }}.")
+        fake_mlflow.registered.clear()
+        result = await svc.assign_judge(
+            "shared", "11112222-3333-4444-5555-666677778888"
+        )
+        assert result["full_name"] == "crew_111122223333__shared"
+        name, instructions, _ = fake_mlflow.registered[0]
+        assert name == "crew_111122223333__shared"
+        assert "Shared criteria" in instructions
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_all_versions(self, fake_mlflow):
+        svc = _judge_service()
+        assert await svc.delete_judge("obsolete") is True
+        assert fake_mlflow.deleted == [("obsolete", "all")]
+
+    @pytest.mark.asyncio
+    async def test_list_splits_library_and_crew_judges(self, fake_mlflow):
+        svc = _judge_service()
+        await svc.create_judge("lib", "Library judge for {{ outputs }}.")
+        await svc.assign_judge("lib", "aaaabbbbccccdddd")
+        judges = await svc.list_judges()
+        by_full = {j["full_name"]: j for j in judges}
+        assert by_full["lib"]["crew_id"] is None
+        assert by_full["crew_aaaabbbbcccc__lib"]["crew_id"] == "aaaabbbbcccc"
+        assert by_full["crew_aaaabbbbcccc__lib"]["name"] == "lib"
+
+    @pytest.mark.asyncio
+    async def test_every_operation_pins_the_experiment(self, fake_mlflow):
+        svc = _judge_service()
+        await svc.create_judge("a", "b {{ outputs }}")
+        await svc.list_judges()
+        await svc.delete_judge("a")
+        # create, list and delete each pinned (assign/update covered above via
+        # the same helper); the exact count just needs to be one per call.
+        assert len(fake_mlflow.experiments) == 3
+
+
+class TestRunRegistryBehaviors:
+    def test_public_fields_expose_progress_chips(self):
+        assert "human_feedback_count" in svc_module._PUBLIC_FIELDS
+        assert "candidates_tried" in svc_module._PUBLIC_FIELDS
+        assert "executions_used" in svc_module._PUBLIC_FIELDS
+
+    def test_get_run_never_leaks_internal_keys(self):
+        from datetime import timezone
+
+        svc = PromptOptimizationService(MagicMock())
+        svc_module._RUNS["r1"] = {
+            "run_id": "r1",
+            "template_name": "detect_intent",
+            "status": "running",
+            "group_id": "grp1",
+            "created_at": datetime.now(timezone.utc),
+            "task": object(),
+            "cancel_requested": False,
+        }
+        run = svc.get_run("r1", _group("grp1"))
+        assert "task" not in run
+        assert "cancel_requested" not in run
+
+    def test_list_runs_sorts_aware_timestamps_descending(self):
+        from datetime import timezone
+
+        svc = PromptOptimizationService(MagicMock())
+        older = datetime.now(timezone.utc) - timedelta(minutes=5)
+        newer = datetime.now(timezone.utc)
+        svc_module._RUNS["old"] = {
+            "run_id": "old",
+            "status": "completed",
+            "group_id": "grp1",
+            "created_at": older,
+        }
+        svc_module._RUNS["new"] = {
+            "run_id": "new",
+            "status": "completed",
+            "group_id": "grp1",
+            "created_at": newer,
+        }
+        runs = svc.list_runs(_group("grp1"))
+        assert [r["run_id"] for r in runs] == ["new", "old"]
+
+    def test_cancel_run_transitions_and_guards(self):
+        svc = PromptOptimizationService(MagicMock())
+        svc_module._RUNS["r1"] = {
+            "run_id": "r1",
+            "status": "running",
+            "group_id": "grp1",
+        }
+        result = svc.cancel_run("r1", _group("grp1"))
+        assert result["cancelling"] is True
+        assert svc_module._RUNS["r1"]["cancel_requested"] is True
+
+        svc_module._RUNS["r1"]["status"] = "completed"
+        with pytest.raises(ValueError, match="not active"):
+            svc.cancel_run("r1", _group("grp1"))
+        with pytest.raises(ValueError, match="not found"):
+            svc.cancel_run("missing", _group("grp1"))
+
+    def test_prune_keeps_active_runs(self):
+        from datetime import timezone
+
+        base = datetime.now(timezone.utc)
+        for i in range(svc_module._MAX_KEPT_RUNS + 5):
+            svc_module._RUNS[f"r{i}"] = {
+                "run_id": f"r{i}",
+                "status": "completed" if i else "running",
+                "group_id": "grp1",
+                "created_at": base + timedelta(seconds=i),
+            }
+        PromptOptimizationService._prune_runs()
+        assert len(svc_module._RUNS) == svc_module._MAX_KEPT_RUNS
+        assert "r0" in svc_module._RUNS  # the running one survived pruning

--- a/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
+++ b/src/backend/tests/unit/services/test_prompt_optimization_service_unit.py
@@ -214,58 +214,106 @@ class TestMineExamples:
         assert await svc._mine_examples("detect-intent", None, 30, 10) == []
 
 
-class TestReflectionModelResolution:
-    @pytest.mark.asyncio
-    async def test_databricks_provider(self):
-        svc = PromptOptimizationService(MagicMock())
-        svc.model_repository.find_by_key = AsyncMock(
-            return_value=SimpleNamespace(provider="databricks")
-        )
-        uri, env, provider = await svc._resolve_reflection_model("some-endpoint")
-        assert uri == "databricks:/some-endpoint"
-        assert env == {}
-        assert provider == "databricks"
+class TestLLMManagerRouting:
+    """All LLM calls route through LLMManager — this covers the pure helpers
+    that replaced the old URI/env resolver."""
 
-    @pytest.mark.asyncio
-    async def test_vllm_provider_sets_openai_env(self):
-        svc = PromptOptimizationService(MagicMock())
-        svc.model_repository.find_by_key = AsyncMock(
-            return_value=SimpleNamespace(provider="vllm")
+    def test_stored_judge_model_to_key_strips_uri_schemes(self):
+        to_key = svc_module._stored_judge_model_to_key
+        assert to_key("openai:/qwen-30b") == "qwen-30b"
+        assert to_key("databricks:/databricks-llama-4-maverick") == (
+            "databricks-llama-4-maverick"
         )
-        uri, env, provider = await svc._resolve_reflection_model(
-            "Qwen3-Coder-30B-A3B-Instruct"
-        )
-        assert uri == "openai:/Qwen3-Coder-30B-A3B-Instruct"
-        assert provider == "vllm"
-        assert "OPENAI_API_BASE" in env and "OPENAI_API_KEY" in env
+        assert to_key("deepseek:/deepseek-v4-pro") == "deepseek-v4-pro"
+        assert to_key("bare-kasal-key") == "bare-kasal-key"
+        assert to_key(None) is None
+        assert to_key("") is None
 
-    @pytest.mark.asyncio
-    async def test_kimi_provider_resolves_with_key_and_provider_tag(self):
-        # The provider tag drives request quirks downstream — Kimi rejects any
-        # explicit temperature, so the caller must know it is talking to Kimi.
-        svc = PromptOptimizationService(MagicMock())
-        svc.model_repository.find_by_key = AsyncMock(
-            return_value=SimpleNamespace(
-                provider="kimi", name="kimi-k2.7-code-highspeed"
-            )
-        )
-        with patch(
-            "src.services.api_keys_service.ApiKeysService.get_provider_api_key",
-            AsyncMock(return_value="sk-test"),
+    def test_parse_grade_from_text(self):
+        parse = svc_module._parse_grade_from_text
+        assert parse("Solid answer.\n7") == pytest.approx(0.7)
+        assert parse("thinking 3 things...\nfinal grade: 9") == pytest.approx(0.9)
+        # (10, 100] read as a percentage — clamping alone made "40" a perfect 10
+        assert parse("40") == pytest.approx(0.4)
+        assert parse("no digits here") is None
+        assert parse("") is None
+
+    def test_reflection_bridge_overrides_reflection_lm(self, monkeypatch):
+        import sys
+        import types
+
+        calls = {}
+        fake_gepa = types.ModuleType("gepa")
+
+        def original_optimize(**kwargs):
+            calls.update(kwargs)
+            return "result"
+
+        fake_gepa.optimize = original_optimize
+        monkeypatch.setitem(sys.modules, "gepa", fake_gepa)
+
+        svc_module._install_gepa_reflection_bridge()
+        assert getattr(fake_gepa.optimize, "_kasal_reflection_bridge", False)
+        # Idempotent — a second install must not double-wrap.
+        wrapped = fake_gepa.optimize
+        svc_module._install_gepa_reflection_bridge()
+        assert fake_gepa.optimize is wrapped
+
+        marker = object()
+        svc_module._GEPA_REFLECTION_STATE.reflection_fn = marker
+        try:
+            fake_gepa.optimize(reflection_lm="openai/placeholder")
+            assert calls["reflection_lm"] is marker
+        finally:
+            svc_module._GEPA_REFLECTION_STATE.reflection_fn = None
+
+        # With no override armed, the caller's reflection_lm passes through.
+        calls.clear()
+        fake_gepa.optimize(reflection_lm="openai/placeholder")
+        assert calls["reflection_lm"] == "openai/placeholder"
+
+    def test_preflight_wraps_provider_errors(self):
+        with patch.object(
+            svc_module,
+            "_sync_llm_completion",
+            MagicMock(side_effect=RuntimeError("connection refused")),
         ):
-            uri, env, provider = await svc._resolve_reflection_model(
-                "kimi-k2.7-code-highspeed", _group()
-            )
-        assert uri == "openai:/kimi-k2.7-code-highspeed"
-        assert env["OPENAI_API_KEY"] == "sk-test"
-        assert provider == "kimi"
+            with pytest.raises(ValueError, match="failed a test call"):
+                svc_module._preflight_reflection(MagicMock(), "dead-model", None, None)
 
-    @pytest.mark.asyncio
-    async def test_unknown_provider_raises(self):
-        svc = PromptOptimizationService(MagicMock())
-        svc.model_repository.find_by_key = AsyncMock(return_value=None)
-        with pytest.raises(ValueError, match="unsupported provider"):
-            await svc._resolve_reflection_model("mystery-model")
+    def test_reflection_fn_shapes_messages_and_params(self):
+        captured = {}
+
+        def fake_completion(loop, messages, model, max_tokens, **kwargs):
+            captured.update(
+                {
+                    "messages": messages,
+                    "model": model,
+                    "max_tokens": max_tokens,
+                    **kwargs,
+                }
+            )
+            return "IMPROVED DOC"
+
+        with patch.object(svc_module, "_sync_llm_completion", fake_completion):
+            fn = svc_module._make_reflection_fn(MagicMock(), "qwen-30b", None, None)
+            assert fn("improve this") == "IMPROVED DOC"
+        assert captured["model"] == "qwen-30b"
+        assert captured["temperature"] == 0.8
+        assert captured["max_tokens"] == 6000
+        # cache-buster system line + the actual prompt
+        assert captured["messages"][0]["role"] == "system"
+        assert "reflection request" in captured["messages"][0]["content"]
+        assert captured["messages"][1] == {
+            "role": "user",
+            "content": "improve this",
+        }
+        # A second call must produce a DIFFERENT cache-buster.
+        first_buster = captured["messages"][0]["content"]
+        with patch.object(svc_module, "_sync_llm_completion", fake_completion):
+            fn = svc_module._make_reflection_fn(MagicMock(), "qwen-30b", None, None)
+            fn("improve this")
+        assert captured["messages"][0]["content"] != first_buster
 
 
 class TestGenericScoringHelpers:
@@ -678,9 +726,7 @@ def fake_mlflow(monkeypatch):
 
 
 def _judge_service():
-    svc = PromptOptimizationService(MagicMock())
-    svc._resolve_reflection_model = AsyncMock(return_value=("openai:/qwen", {}, "vllm"))
-    return svc
+    return PromptOptimizationService(MagicMock())
 
 
 class TestJudgeLifecycle:
@@ -733,20 +779,18 @@ class TestJudgeLifecycle:
         assert name == "acc"
         assert "New criteria." in instructions
         assert "{{ outputs }}" in instructions
-        assert model == "openai:/qwen"  # unchanged from creation
-        assert result["model"] == "openai:/qwen"
+        # unchanged from creation (the wrapped default Kasal key)
+        assert model == f"openai:/{svc_module.DEFAULT_TARGET_MODEL}"
+        assert result["model"] == f"openai:/{svc_module.DEFAULT_TARGET_MODEL}"
 
     @pytest.mark.asyncio
     async def test_update_model_keeps_instructions(self, fake_mlflow):
         svc = _judge_service()
         await svc.create_judge("acc", "Keep these criteria for {{ outputs }}.")
-        svc._resolve_reflection_model = AsyncMock(
-            return_value=("deepseek:/v4", {}, "deepseek")
-        )
         fake_mlflow.registered.clear()
         await svc.update_judge("acc", model="deepseek-v4-pro", group_context=_group())
         name, instructions, model = fake_mlflow.registered[0]
-        assert model == "deepseek:/v4"
+        assert model == "openai:/deepseek-v4-pro"
         assert "Keep these criteria" in instructions
 
     @pytest.mark.asyncio

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -1,23 +1,23 @@
 version = 1
-revision = 3
+revision = 1
 requires-python = "==3.11.*"
 
 [[package]]
 name = "aiofiles"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", upload-time = "2024-06-24T11:02:03.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", upload-time = "2024-06-24T11:02:01.529Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896 },
 ]
 
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", upload-time = "2025-03-12T01:42:48.764Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", upload-time = "2025-03-12T01:42:47.083Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265 },
 ]
 
 [[package]]
@@ -33,25 +33,25 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", upload-time = "2026-01-03T17:33:05.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/4c/a164164834f03924d9a29dc3acd9e7ee58f95857e0b467f6d04298594ebb/aiohttp-3.13.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5b6073099fb654e0a068ae678b10feff95c5cae95bbfcbfa7af669d361a8aa6b", upload-time = "2026-01-03T17:29:43.287Z" },
-    { url = "https://files.pythonhosted.org/packages/82/71/d5c31390d18d4f58115037c432b7e0348c60f6f53b727cad33172144a112/aiohttp-3.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cb93e166e6c28716c8c6aeb5f99dfb6d5ccf482d29fe9bf9a794110e6d0ab64", upload-time = "2026-01-03T17:29:44.822Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/c9/741f8ac91e14b1d2e7100690425a5b2b919a87a5075406582991fb7de920/aiohttp-3.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e027cf2f6b641693a09f631759b4d9ce9165099d2b5d92af9bd4e197690eea", upload-time = "2026-01-03T17:29:46.405Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b5/31d4d2e802dfd59f74ed47eba48869c1c21552c586d5e81a9d0d5c2ad640/aiohttp-3.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b61b7169ababd7802f9568ed96142616a9118dd2be0d1866e920e77ec8fa92a", upload-time = "2026-01-03T17:29:48.083Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/3e/eefad0ad42959f226bb79664826883f2687d602a9ae2941a18e0484a74d3/aiohttp-3.13.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:80dd4c21b0f6237676449c6baaa1039abae86b91636b6c91a7f8e61c87f89540", upload-time = "2026-01-03T17:29:49.648Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3a/54a64299fac2891c346cdcf2aa6803f994a2e4beeaf2e5a09dcc54acc842/aiohttp-3.13.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65d2ccb7eabee90ce0503c17716fc77226be026dcc3e65cce859a30db715025b", upload-time = "2026-01-03T17:29:51.244Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/70/ddc1b7169cf64075e864f64595a14b147a895a868394a48f6a8031979038/aiohttp-3.13.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b179331a481cb5529fca8b432d8d3c7001cb217513c94cd72d668d1248688a3", upload-time = "2026-01-03T17:29:53.938Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7e/6815aab7d3a56610891c76ef79095677b8b5be6646aaf00f69b221765021/aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d4c940f02f49483b18b079d1c27ab948721852b281f8b015c058100e9421dd1", upload-time = "2026-01-03T17:29:55.484Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/f2/073b145c4100da5511f457dc0f7558e99b2987cf72600d42b559db856fbc/aiohttp-3.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9444f105664c4ce47a2a7171a2418bce5b7bae45fb610f4e2c36045d85911d3", upload-time = "2026-01-03T17:29:57.179Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/c1/778d011920cae03ae01424ec202c513dc69243cf2db303965615b81deeea/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:694976222c711d1d00ba131904beb60534f93966562f64440d0c9d41b8cdb440", upload-time = "2026-01-03T17:29:58.914Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/cb/3419eabf4ec1e9ec6f242c32b689248365a1cf621891f6f0386632525494/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f33ed1a2bf1997a36661874b017f5c4b760f41266341af36febaf271d179f6d7", upload-time = "2026-01-03T17:30:01.962Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/e5/76cf77bdbc435bf233c1f114edad39ed4177ccbfab7c329482b179cff4f4/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e636b3c5f61da31a92bf0d91da83e58fdfa96f178ba682f11d24f31944cdd28c", upload-time = "2026-01-03T17:30:03.609Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/d4/dd1ca234c794fd29c057ce8c0566b8ef7fd6a51069de5f06fa84b9a1971c/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5d2d94f1f5fcbe40838ac51a6ab5704a6f9ea42e72ceda48de5e6b898521da51", upload-time = "2026-01-03T17:30:05.132Z" },
-    { url = "https://files.pythonhosted.org/packages/55/58/4345b5f26661a6180afa686c473620c30a66afdf120ed3dd545bbc809e85/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2be0e9ccf23e8a94f6f0650ce06042cefc6ac703d0d7ab6c7a917289f2539ad4", upload-time = "2026-01-03T17:30:07.135Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/06/05950619af6c2df7e0a431d889ba2813c9f0129cec76f663e547a5ad56f2/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9af5e68ee47d6534d36791bbe9b646d2a7c7deb6fc24d7943628edfbb3581f29", upload-time = "2026-01-03T17:30:09.083Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/80/958f16de79ba0422d7c1e284b2abd0c84bc03394fbe631d0a39ffa10e1eb/aiohttp-3.13.3-cp311-cp311-win32.whl", hash = "sha256:a2212ad43c0833a873d0fb3c63fa1bacedd4cf6af2fee62bf4b739ceec3ab239", upload-time = "2026-01-03T17:30:10.869Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/f2/27cdf04c9851712d6c1b99df6821a6623c3c9e55956d4b1e318c337b5a48/aiohttp-3.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:642f752c3eb117b105acbd87e2c143de710987e09860d674e068c4c2c441034f", upload-time = "2026-01-03T17:30:12.719Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4c/a164164834f03924d9a29dc3acd9e7ee58f95857e0b467f6d04298594ebb/aiohttp-3.13.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5b6073099fb654e0a068ae678b10feff95c5cae95bbfcbfa7af669d361a8aa6b", size = 746051 },
+    { url = "https://files.pythonhosted.org/packages/82/71/d5c31390d18d4f58115037c432b7e0348c60f6f53b727cad33172144a112/aiohttp-3.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cb93e166e6c28716c8c6aeb5f99dfb6d5ccf482d29fe9bf9a794110e6d0ab64", size = 499234 },
+    { url = "https://files.pythonhosted.org/packages/0e/c9/741f8ac91e14b1d2e7100690425a5b2b919a87a5075406582991fb7de920/aiohttp-3.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e027cf2f6b641693a09f631759b4d9ce9165099d2b5d92af9bd4e197690eea", size = 494979 },
+    { url = "https://files.pythonhosted.org/packages/75/b5/31d4d2e802dfd59f74ed47eba48869c1c21552c586d5e81a9d0d5c2ad640/aiohttp-3.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b61b7169ababd7802f9568ed96142616a9118dd2be0d1866e920e77ec8fa92a", size = 1748297 },
+    { url = "https://files.pythonhosted.org/packages/1a/3e/eefad0ad42959f226bb79664826883f2687d602a9ae2941a18e0484a74d3/aiohttp-3.13.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:80dd4c21b0f6237676449c6baaa1039abae86b91636b6c91a7f8e61c87f89540", size = 1707172 },
+    { url = "https://files.pythonhosted.org/packages/c5/3a/54a64299fac2891c346cdcf2aa6803f994a2e4beeaf2e5a09dcc54acc842/aiohttp-3.13.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65d2ccb7eabee90ce0503c17716fc77226be026dcc3e65cce859a30db715025b", size = 1805405 },
+    { url = "https://files.pythonhosted.org/packages/6c/70/ddc1b7169cf64075e864f64595a14b147a895a868394a48f6a8031979038/aiohttp-3.13.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b179331a481cb5529fca8b432d8d3c7001cb217513c94cd72d668d1248688a3", size = 1899449 },
+    { url = "https://files.pythonhosted.org/packages/a1/7e/6815aab7d3a56610891c76ef79095677b8b5be6646aaf00f69b221765021/aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d4c940f02f49483b18b079d1c27ab948721852b281f8b015c058100e9421dd1", size = 1748444 },
+    { url = "https://files.pythonhosted.org/packages/6b/f2/073b145c4100da5511f457dc0f7558e99b2987cf72600d42b559db856fbc/aiohttp-3.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9444f105664c4ce47a2a7171a2418bce5b7bae45fb610f4e2c36045d85911d3", size = 1606038 },
+    { url = "https://files.pythonhosted.org/packages/0a/c1/778d011920cae03ae01424ec202c513dc69243cf2db303965615b81deeea/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:694976222c711d1d00ba131904beb60534f93966562f64440d0c9d41b8cdb440", size = 1724156 },
+    { url = "https://files.pythonhosted.org/packages/0e/cb/3419eabf4ec1e9ec6f242c32b689248365a1cf621891f6f0386632525494/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f33ed1a2bf1997a36661874b017f5c4b760f41266341af36febaf271d179f6d7", size = 1722340 },
+    { url = "https://files.pythonhosted.org/packages/7a/e5/76cf77bdbc435bf233c1f114edad39ed4177ccbfab7c329482b179cff4f4/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e636b3c5f61da31a92bf0d91da83e58fdfa96f178ba682f11d24f31944cdd28c", size = 1783041 },
+    { url = "https://files.pythonhosted.org/packages/9d/d4/dd1ca234c794fd29c057ce8c0566b8ef7fd6a51069de5f06fa84b9a1971c/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5d2d94f1f5fcbe40838ac51a6ab5704a6f9ea42e72ceda48de5e6b898521da51", size = 1596024 },
+    { url = "https://files.pythonhosted.org/packages/55/58/4345b5f26661a6180afa686c473620c30a66afdf120ed3dd545bbc809e85/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2be0e9ccf23e8a94f6f0650ce06042cefc6ac703d0d7ab6c7a917289f2539ad4", size = 1804590 },
+    { url = "https://files.pythonhosted.org/packages/7b/06/05950619af6c2df7e0a431d889ba2813c9f0129cec76f663e547a5ad56f2/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9af5e68ee47d6534d36791bbe9b646d2a7c7deb6fc24d7943628edfbb3581f29", size = 1740355 },
+    { url = "https://files.pythonhosted.org/packages/3e/80/958f16de79ba0422d7c1e284b2abd0c84bc03394fbe631d0a39ffa10e1eb/aiohttp-3.13.3-cp311-cp311-win32.whl", hash = "sha256:a2212ad43c0833a873d0fb3c63fa1bacedd4cf6af2fee62bf4b739ceec3ab239", size = 433701 },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/27cdf04c9851712d6c1b99df6821a6623c3c9e55956d4b1e318c337b5a48/aiohttp-3.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:642f752c3eb117b105acbd87e2c143de710987e09860d674e068c4c2c441034f", size = 457678 },
 ]
 
 [[package]]
@@ -62,9 +62,9 @@ dependencies = [
     { name = "frozenlist" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", upload-time = "2025-07-03T22:54:43.528Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", upload-time = "2025-07-03T22:54:42.156Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490 },
 ]
 
 [[package]]
@@ -74,9 +74,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", upload-time = "2025-02-03T07:30:16.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", upload-time = "2025-02-03T07:30:13.6Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792 },
 ]
 
 [[package]]
@@ -88,27 +88,27 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/41/ab8f624929847b49f84955c594b165855efd829b0c271e1a8cac694138e5/alembic-1.18.3.tar.gz", hash = "sha256:1212aa3778626f2b0f0aa6dd4e99a5f99b94bd25a0c1ac0bba3be65e081e50b0", upload-time = "2026-01-29T20:24:15.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/41/ab8f624929847b49f84955c594b165855efd829b0c271e1a8cac694138e5/alembic-1.18.3.tar.gz", hash = "sha256:1212aa3778626f2b0f0aa6dd4e99a5f99b94bd25a0c1ac0bba3be65e081e50b0", size = 2052564 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/8e/d79281f323e7469b060f15bd229e48d7cdd219559e67e71c013720a88340/alembic-1.18.3-py3-none-any.whl", hash = "sha256:12a0359bfc068a4ecbb9b3b02cf77856033abfdb59e4a5aca08b7eacd7b74ddd", upload-time = "2026-01-29T20:24:17.488Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8e/d79281f323e7469b060f15bd229e48d7cdd219559e67e71c013720a88340/alembic-1.18.3-py3-none-any.whl", hash = "sha256:12a0359bfc068a4ecbb9b3b02cf77856033abfdb59e4a5aca08b7eacd7b74ddd", size = 262282 },
 ]
 
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", upload-time = "2025-11-10T22:07:42.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", upload-time = "2025-11-10T22:07:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303 },
 ]
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", upload-time = "2024-05-20T21:33:25.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", upload-time = "2024-05-20T21:33:24.1Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
 ]
 
 [[package]]
@@ -119,70 +119,70 @@ dependencies = [
     { name = "idna" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", upload-time = "2026-01-06T11:45:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", upload-time = "2026-01-06T11:45:19.497Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592 },
 ]
 
 [[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", upload-time = "2020-05-11T07:59:51.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", upload-time = "2020-05-11T07:59:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566 },
 ]
 
 [[package]]
 name = "asn1crypto"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", upload-time = "2022-03-15T14:46:52.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", upload-time = "2022-03-15T14:46:51.055Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045 },
 ]
 
 [[package]]
 name = "async-generator"
 version = "1.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/b6/6fa6b3b598a03cba5e80f829e0dadbb49d7645f523d209b2fb7ea0bbb02a/async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144", upload-time = "2018-08-01T03:36:21.69Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/b6/6fa6b3b598a03cba5e80f829e0dadbb49d7645f523d209b2fb7ea0bbb02a/async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144", size = 29870 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/52/39d20e03abd0ac9159c162ec24b93fbcaa111e8400308f2465432495ca2b/async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b", upload-time = "2018-08-01T03:36:20.029Z" },
+    { url = "https://files.pythonhosted.org/packages/71/52/39d20e03abd0ac9159c162ec24b93fbcaa111e8400308f2465432495ca2b/async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b", size = 18857 },
 ]
 
 [[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", upload-time = "2024-11-06T16:41:39.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", upload-time = "2024-11-06T16:41:37.9Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233 },
 ]
 
 [[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", upload-time = "2025-11-24T23:27:00.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", upload-time = "2025-11-24T23:25:36.443Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", upload-time = "2025-11-24T23:25:37.89Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", upload-time = "2025-11-24T23:25:39.461Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", upload-time = "2025-11-24T23:25:41.512Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", upload-time = "2025-11-24T23:25:43.153Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", upload-time = "2025-11-24T23:25:44.942Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", upload-time = "2025-11-24T23:25:46.486Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", upload-time = "2025-11-24T23:25:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159 },
+    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157 },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051 },
+    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640 },
+    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050 },
+    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574 },
+    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076 },
+    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980 },
 ]
 
 [[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", upload-time = "2025-10-06T13:54:44.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", upload-time = "2025-10-06T13:54:43.17Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615 },
 ]
 
 [[package]]
@@ -193,9 +193,9 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", upload-time = "2026-01-12T17:03:05.535Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", size = 363033 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/d8/b8fcba9464f02b121f39de2db2bf57f0b216fe11d014513d666e8634380d/azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335", upload-time = "2026-01-12T17:03:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d8/b8fcba9464f02b121f39de2db2bf57f0b216fe11d014513d666e8634380d/azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335", size = 217825 },
 ]
 
 [[package]]
@@ -209,37 +209,37 @@ dependencies = [
     { name = "msal-extensions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8d/1a6c41c28a37eab26dc85ab6c86992c700cd3f4a597d9ed174b0e9c69489/azure_identity-1.25.1.tar.gz", hash = "sha256:87ca8328883de6036443e1c37b40e8dc8fb74898240f61071e09d2e369361456", upload-time = "2025-10-06T20:30:02.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/8d/1a6c41c28a37eab26dc85ab6c86992c700cd3f4a597d9ed174b0e9c69489/azure_identity-1.25.1.tar.gz", hash = "sha256:87ca8328883de6036443e1c37b40e8dc8fb74898240f61071e09d2e369361456", size = 279826 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/7b/5652771e24fff12da9dde4c20ecf4682e606b104f26419d139758cc935a6/azure_identity-1.25.1-py3-none-any.whl", hash = "sha256:e9edd720af03dff020223cd269fa3a61e8f345ea75443858273bcb44844ab651", upload-time = "2025-10-06T20:30:04.251Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7b/5652771e24fff12da9dde4c20ecf4682e606b104f26419d139758cc935a6/azure_identity-1.25.1-py3-none-any.whl", hash = "sha256:e9edd720af03dff020223cd269fa3a61e8f345ea75443858273bcb44844ab651", size = 191317 },
 ]
 
 [[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", upload-time = "2022-10-05T19:19:32.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", upload-time = "2022-10-05T19:19:30.546Z" },
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148 },
 ]
 
 [[package]]
 name = "bcrypt"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/ae/3af7d006aacf513975fd1948a6b4d6f8b4a307f8a244e1a3d3774b297aad/bcrypt-4.0.1.tar.gz", hash = "sha256:27d375903ac8261cfe4047f6709d16f7d18d39b1ec92aaf72af989552a650ebd", upload-time = "2022-10-09T15:36:49.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/ae/3af7d006aacf513975fd1948a6b4d6f8b4a307f8a244e1a3d3774b297aad/bcrypt-4.0.1.tar.gz", hash = "sha256:27d375903ac8261cfe4047f6709d16f7d18d39b1ec92aaf72af989552a650ebd", size = 25498 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f", upload-time = "2022-10-09T15:36:25.481Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0a/1582790232fef6c2aa201f345577306b8bfe465c2c665dec04c86a016879/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:08d2947c490093a11416df18043c27abe3921558d2c03e2076ccb28a116cb6d0", upload-time = "2022-10-09T15:37:09.447Z" },
-    { url = "https://files.pythonhosted.org/packages/41/16/49ff5146fb815742ad58cafb5034907aa7f166b1344d0ddd7fd1c818bd17/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0eaa47d4661c326bfc9d08d16debbc4edf78778e6aaba29c1bc7ce67214d4410", upload-time = "2022-10-09T15:37:10.69Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/48/fd2b197a9741fa790ba0b88a9b10b5e88e62ff5cf3e1bc96d8354d7ce613/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae88eca3024bb34bb3430f964beab71226e761f51b912de5133470b649d82344", upload-time = "2022-10-09T15:36:27.195Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/50/e683d8418974a602ba40899c8a5c38b3decaf5a4d36c32fc65dce454d8a8/bcrypt-4.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:a522427293d77e1c29e303fc282e2d71864579527a04ddcfda6d4f8396c6c36a", upload-time = "2022-10-09T15:36:28.481Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/a7/ee4561fd9b78ca23c8e5591c150cc58626a5dfb169345ab18e1c2c664ee0/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fbdaec13c5105f0c4e5c52614d04f0bca5f5af007910daa8b6b12095edaa67b3", upload-time = "2022-10-09T15:37:11.962Z" },
-    { url = "https://files.pythonhosted.org/packages/64/fe/da28a5916128d541da0993328dc5cf4b43dfbf6655f2c7a2abe26ca2dc88/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ca3204d00d3cb2dfed07f2d74a25f12fc12f73e606fcaa6975d1f7ae69cacbb2", upload-time = "2022-10-09T15:36:30.049Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/4f/3632a69ce344c1551f7c9803196b191a8181c6a1ad2362c225581ef0d383/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:089098effa1bc35dc055366740a067a2fc76987e8ec75349eb9484061c54f535", upload-time = "2022-10-09T15:37:14.107Z" },
-    { url = "https://files.pythonhosted.org/packages/87/69/edacb37481d360d06fc947dab5734aaf511acb7d1a1f9e2849454376c0f8/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e9a51bbfe7e9802b5f3508687758b564069ba937748ad7b9e890086290d2f79e", upload-time = "2022-10-09T15:36:31.251Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ca/6a534669890725cbb8c1fb4622019be31813c8edaa7b6d5b62fc9360a17e/bcrypt-4.0.1-cp36-abi3-win32.whl", hash = "sha256:2caffdae059e06ac23fce178d31b4a702f2a3264c20bfb5ff541b338194d8fab", upload-time = "2022-10-09T15:36:32.893Z" },
-    { url = "https://files.pythonhosted.org/packages/46/81/d8c22cd7e5e1c6a7d48e41a1d1d46c92f17dae70a54d9814f746e6027dec/bcrypt-4.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:8a68f4341daf7522fe8d73874de8906f3a339048ba406be6ddc1b3ccb16fc0d9", upload-time = "2022-10-09T15:36:34.635Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f", size = 473446 },
+    { url = "https://files.pythonhosted.org/packages/ec/0a/1582790232fef6c2aa201f345577306b8bfe465c2c665dec04c86a016879/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:08d2947c490093a11416df18043c27abe3921558d2c03e2076ccb28a116cb6d0", size = 583044 },
+    { url = "https://files.pythonhosted.org/packages/41/16/49ff5146fb815742ad58cafb5034907aa7f166b1344d0ddd7fd1c818bd17/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0eaa47d4661c326bfc9d08d16debbc4edf78778e6aaba29c1bc7ce67214d4410", size = 583189 },
+    { url = "https://files.pythonhosted.org/packages/aa/48/fd2b197a9741fa790ba0b88a9b10b5e88e62ff5cf3e1bc96d8354d7ce613/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae88eca3024bb34bb3430f964beab71226e761f51b912de5133470b649d82344", size = 593473 },
+    { url = "https://files.pythonhosted.org/packages/7d/50/e683d8418974a602ba40899c8a5c38b3decaf5a4d36c32fc65dce454d8a8/bcrypt-4.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:a522427293d77e1c29e303fc282e2d71864579527a04ddcfda6d4f8396c6c36a", size = 593249 },
+    { url = "https://files.pythonhosted.org/packages/fb/a7/ee4561fd9b78ca23c8e5591c150cc58626a5dfb169345ab18e1c2c664ee0/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fbdaec13c5105f0c4e5c52614d04f0bca5f5af007910daa8b6b12095edaa67b3", size = 583586 },
+    { url = "https://files.pythonhosted.org/packages/64/fe/da28a5916128d541da0993328dc5cf4b43dfbf6655f2c7a2abe26ca2dc88/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ca3204d00d3cb2dfed07f2d74a25f12fc12f73e606fcaa6975d1f7ae69cacbb2", size = 593659 },
+    { url = "https://files.pythonhosted.org/packages/dd/4f/3632a69ce344c1551f7c9803196b191a8181c6a1ad2362c225581ef0d383/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:089098effa1bc35dc055366740a067a2fc76987e8ec75349eb9484061c54f535", size = 613116 },
+    { url = "https://files.pythonhosted.org/packages/87/69/edacb37481d360d06fc947dab5734aaf511acb7d1a1f9e2849454376c0f8/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e9a51bbfe7e9802b5f3508687758b564069ba937748ad7b9e890086290d2f79e", size = 624290 },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/6a534669890725cbb8c1fb4622019be31813c8edaa7b6d5b62fc9360a17e/bcrypt-4.0.1-cp36-abi3-win32.whl", hash = "sha256:2caffdae059e06ac23fce178d31b4a702f2a3264c20bfb5ff541b338194d8fab", size = 159428 },
+    { url = "https://files.pythonhosted.org/packages/46/81/d8c22cd7e5e1c6a7d48e41a1d1d46c92f17dae70a54d9814f746e6027dec/bcrypt-4.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:8a68f4341daf7522fe8d73874de8906f3a339048ba406be6ddc1b3ccb16fc0d9", size = 152930 },
 ]
 
 [[package]]
@@ -250,9 +250,9 @@ dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", upload-time = "2025-08-24T14:06:13.168Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", upload-time = "2025-08-24T14:06:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", size = 105113 },
 ]
 
 [[package]]
@@ -267,23 +267,23 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/88/560b11e521c522440af991d46848a2bde64b5f7202ec14e1f46f9509d328/black-26.1.0.tar.gz", hash = "sha256:d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58", upload-time = "2026-01-18T04:50:11.993Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/88/560b11e521c522440af991d46848a2bde64b5f7202ec14e1f46f9509d328/black-26.1.0.tar.gz", hash = "sha256:d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58", size = 658785 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/83/f05f22ff13756e1a8ce7891db517dbc06200796a16326258268f4658a745/black-26.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3cee1487a9e4c640dc7467aaa543d6c0097c391dc8ac74eb313f2fbf9d7a7cb5", upload-time = "2026-01-18T04:59:21.38Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/f2/b2c570550e39bedc157715e43927360312d6dd677eed2cc149a802577491/black-26.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d62d14ca31c92adf561ebb2e5f2741bf8dea28aef6deb400d49cca011d186c68", upload-time = "2026-01-18T04:59:23.257Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/d7/990d6a94dc9e169f61374b1c3d4f4dd3037e93c2cc12b6f3b12bc663aa7b/black-26.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb1dafbbaa3b1ee8b4550a84425aac8874e5f390200f5502cf3aee4a2acb2f14", upload-time = "2026-01-18T04:59:24.729Z" },
-    { url = "https://files.pythonhosted.org/packages/36/1c/cbd7bae7dd3cb315dfe6eeca802bb56662cc92b89af272e014d98c1f2286/black-26.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:101540cb2a77c680f4f80e628ae98bd2bd8812fb9d72ade4f8995c5ff019e82c", upload-time = "2026-01-18T04:59:27.381Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b1/9fe6132bb2d0d1f7094613320b56297a108ae19ecf3041d9678aec381b37/black-26.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:6f3977a16e347f1b115662be07daa93137259c711e526402aa444d7a88fdc9d4", upload-time = "2026-01-18T04:59:28.711Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/3d/51bdb3ecbfadfaf825ec0c75e1de6077422b4afa2091c6c9ba34fbfc0c2d/black-26.1.0-py3-none-any.whl", hash = "sha256:1054e8e47ebd686e078c0bb0eaf31e6ce69c966058d122f2c0c950311f9f3ede", upload-time = "2026-01-18T04:50:09.978Z" },
+    { url = "https://files.pythonhosted.org/packages/30/83/f05f22ff13756e1a8ce7891db517dbc06200796a16326258268f4658a745/black-26.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3cee1487a9e4c640dc7467aaa543d6c0097c391dc8ac74eb313f2fbf9d7a7cb5", size = 1831956 },
+    { url = "https://files.pythonhosted.org/packages/7d/f2/b2c570550e39bedc157715e43927360312d6dd677eed2cc149a802577491/black-26.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d62d14ca31c92adf561ebb2e5f2741bf8dea28aef6deb400d49cca011d186c68", size = 1672499 },
+    { url = "https://files.pythonhosted.org/packages/7a/d7/990d6a94dc9e169f61374b1c3d4f4dd3037e93c2cc12b6f3b12bc663aa7b/black-26.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb1dafbbaa3b1ee8b4550a84425aac8874e5f390200f5502cf3aee4a2acb2f14", size = 1735431 },
+    { url = "https://files.pythonhosted.org/packages/36/1c/cbd7bae7dd3cb315dfe6eeca802bb56662cc92b89af272e014d98c1f2286/black-26.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:101540cb2a77c680f4f80e628ae98bd2bd8812fb9d72ade4f8995c5ff019e82c", size = 1400468 },
+    { url = "https://files.pythonhosted.org/packages/59/b1/9fe6132bb2d0d1f7094613320b56297a108ae19ecf3041d9678aec381b37/black-26.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:6f3977a16e347f1b115662be07daa93137259c711e526402aa444d7a88fdc9d4", size = 1207332 },
+    { url = "https://files.pythonhosted.org/packages/e4/3d/51bdb3ecbfadfaf825ec0c75e1de6077422b4afa2091c6c9ba34fbfc0c2d/black-26.1.0-py3-none-any.whl", hash = "sha256:1054e8e47ebd686e078c0bb0eaf31e6ce69c966058d122f2c0c950311f9f3ede", size = 204010 },
 ]
 
 [[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", upload-time = "2024-11-08T17:25:47.436Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", upload-time = "2024-11-08T17:25:46.184Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458 },
 ]
 
 [[package]]
@@ -295,9 +295,9 @@ dependencies = [
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/88/de5c2a0ce069973345f9fac81200de5b58f503e231dbd566357a5b8c9109/boto3-1.42.44.tar.gz", hash = "sha256:d5601ea520d30674c1d15791a1f98b5c055e973c775e1d9952ccc09ee5913c4e", upload-time = "2026-02-06T20:28:05.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/88/de5c2a0ce069973345f9fac81200de5b58f503e231dbd566357a5b8c9109/boto3-1.42.44.tar.gz", hash = "sha256:d5601ea520d30674c1d15791a1f98b5c055e973c775e1d9952ccc09ee5913c4e", size = 112865 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/fb/0341da1482f7fa256d257cfba89383f6692570b741598d4e26d879b26c57/boto3-1.42.44-py3-none-any.whl", hash = "sha256:32e995b0d56e19422cff22f586f698e8924c792eb00943de9c517ff4607e4e18", upload-time = "2026-02-06T20:28:03.598Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fb/0341da1482f7fa256d257cfba89383f6692570b741598d4e26d879b26c57/boto3-1.42.44-py3-none-any.whl", hash = "sha256:32e995b0d56e19422cff22f586f698e8924c792eb00943de9c517ff4607e4e18", size = 140604 },
 ]
 
 [[package]]
@@ -309,9 +309,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/ff/54cef2c5ff4e1c77fabc0ed68781e48eb36f33433f82bba3605e9c0e45ce/botocore-1.42.44.tar.gz", hash = "sha256:47ba27360f2afd2c2721545d8909217f7be05fdee16dd8fc0b09589535a0701c", upload-time = "2026-02-06T20:27:53.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/ff/54cef2c5ff4e1c77fabc0ed68781e48eb36f33433f82bba3605e9c0e45ce/botocore-1.42.44.tar.gz", hash = "sha256:47ba27360f2afd2c2721545d8909217f7be05fdee16dd8fc0b09589535a0701c", size = 14936071 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/9e/b45c54abfbb902ff174444a48558f97f9917143bc2e996729220f2631db1/botocore-1.42.44-py3-none-any.whl", hash = "sha256:ba406b9243a20591ee87d53abdb883d46416705cebccb639a7f1c923f9dd82df", upload-time = "2026-02-06T20:27:49.565Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9e/b45c54abfbb902ff174444a48558f97f9917143bc2e996729220f2631db1/botocore-1.42.44-py3-none-any.whl", hash = "sha256:ba406b9243a20591ee87d53abdb883d46416705cebccb639a7f1c923f9dd82df", size = 14611152 },
 ]
 
 [[package]]
@@ -323,27 +323,27 @@ dependencies = [
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", upload-time = "2026-01-08T16:41:47.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", size = 50054 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/0d/84a4380f930db0010168e0aa7b7a8fed9ba1835a8fbb1472bc6d0201d529/build-1.4.0-py3-none-any.whl", hash = "sha256:6a07c1b8eb6f2b311b96fcbdbce5dab5fe637ffda0fd83c9cac622e927501596", upload-time = "2026-01-08T16:41:46.453Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0d/84a4380f930db0010168e0aa7b7a8fed9ba1835a8fbb1472bc6d0201d529/build-1.4.0-py3-none-any.whl", hash = "sha256:6a07c1b8eb6f2b311b96fcbdbce5dab5fe637ffda0fd83c9cac622e927501596", size = 24141 },
 ]
 
 [[package]]
 name = "cachetools"
 version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", upload-time = "2026-01-27T20:32:59.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", upload-time = "2026-01-27T20:32:58.527Z" },
+    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668 },
 ]
 
 [[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900 },
 ]
 
 [[package]]
@@ -353,46 +353,46 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", upload-time = "2025-09-08T23:24:04.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", upload-time = "2025-09-08T23:22:26.456Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", upload-time = "2025-09-08T23:22:28.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", upload-time = "2025-09-08T23:22:40.95Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", upload-time = "2025-09-08T23:22:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344 },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560 },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613 },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476 },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374 },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597 },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574 },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971 },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972 },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078 },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076 },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820 },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635 },
 ]
 
 [[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", upload-time = "2025-10-14T04:42:32.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", upload-time = "2025-10-14T04:40:33.79Z" },
-    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", upload-time = "2025-10-14T04:40:34.961Z" },
-    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", upload-time = "2025-10-14T04:40:36.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", upload-time = "2025-10-14T04:40:37.188Z" },
-    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", upload-time = "2025-10-14T04:40:38.435Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", upload-time = "2025-10-14T04:40:40.053Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", upload-time = "2025-10-14T04:40:41.163Z" },
-    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", upload-time = "2025-10-14T04:40:42.276Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", upload-time = "2025-10-14T04:40:43.439Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", upload-time = "2025-10-14T04:40:44.547Z" },
-    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", upload-time = "2025-10-14T04:40:46.018Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", upload-time = "2025-10-14T04:40:47.081Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", upload-time = "2025-10-14T04:40:48.246Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", upload-time = "2025-10-14T04:40:49.376Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", upload-time = "2025-10-14T04:40:50.844Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", upload-time = "2025-10-14T04:40:52.272Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", upload-time = "2025-10-14T04:42:31.76Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988 },
+    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324 },
+    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742 },
+    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863 },
+    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837 },
+    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550 },
+    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162 },
+    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019 },
+    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310 },
+    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022 },
+    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383 },
+    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098 },
+    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991 },
+    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456 },
+    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978 },
+    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969 },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402 },
 ]
 
 [[package]]
@@ -428,13 +428,13 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/48/11851dddeadad6abe36ee071fedc99b5bdd2c324df3afa8cb952ae02798b/chromadb-1.1.1.tar.gz", hash = "sha256:ebfce0122753e306a76f1e291d4ddaebe5f01b5979b97ae0bc80b1d4024ff223", upload-time = "2025-10-05T02:49:14.834Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/48/11851dddeadad6abe36ee071fedc99b5bdd2c324df3afa8cb952ae02798b/chromadb-1.1.1.tar.gz", hash = "sha256:ebfce0122753e306a76f1e291d4ddaebe5f01b5979b97ae0bc80b1d4024ff223", size = 1338109 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/59/0d881a9b7eb63d8d2446cf67fcbb53fb8ae34991759d2b6024a067e90a9a/chromadb-1.1.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:27fe0e25ef0f83fb09c30355ab084fe6f246808a7ea29e8c19e85cf45785b90d", upload-time = "2025-10-05T02:49:12.525Z" },
-    { url = "https://files.pythonhosted.org/packages/94/4f/5a9fa317c84c98e70af48f74b00aa25589626c03a0428b4381b2095f3d73/chromadb-1.1.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:95aed58869683f12e7dcbf68b039fe5f576dbe9d1b86b8f4d014c9d077ccafd2", upload-time = "2025-10-05T02:49:09.236Z" },
-    { url = "https://files.pythonhosted.org/packages/45/1a/02defe2f1c8d1daedb084bbe85f5b6083510a3ba192ed57797a3649a4310/chromadb-1.1.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06776dad41389a00e7d63d936c3a15c179d502becaf99f75745ee11b062c9b6a", upload-time = "2025-10-05T02:49:03.299Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0d/80be82717e5dc19839af24558494811b6f2af2b261a8f21c51b872193b09/chromadb-1.1.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bba0096a7f5e975875ead23a91c0d41d977fbd3767f60d3305a011b0ace7afd3", upload-time = "2025-10-05T02:49:06.481Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/6e/956e62975305a4e31daf6114a73b3b0683a8f36f8d70b20aabd466770edb/chromadb-1.1.1-cp39-abi3-win_amd64.whl", hash = "sha256:a77aa026a73a18181fd89bbbdb86191c9a82fd42aa0b549ff18d8cae56394c8b", upload-time = "2025-10-05T02:49:16.925Z" },
+    { url = "https://files.pythonhosted.org/packages/39/59/0d881a9b7eb63d8d2446cf67fcbb53fb8ae34991759d2b6024a067e90a9a/chromadb-1.1.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:27fe0e25ef0f83fb09c30355ab084fe6f246808a7ea29e8c19e85cf45785b90d", size = 19175479 },
+    { url = "https://files.pythonhosted.org/packages/94/4f/5a9fa317c84c98e70af48f74b00aa25589626c03a0428b4381b2095f3d73/chromadb-1.1.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:95aed58869683f12e7dcbf68b039fe5f576dbe9d1b86b8f4d014c9d077ccafd2", size = 18267188 },
+    { url = "https://files.pythonhosted.org/packages/45/1a/02defe2f1c8d1daedb084bbe85f5b6083510a3ba192ed57797a3649a4310/chromadb-1.1.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06776dad41389a00e7d63d936c3a15c179d502becaf99f75745ee11b062c9b6a", size = 18855754 },
+    { url = "https://files.pythonhosted.org/packages/5a/0d/80be82717e5dc19839af24558494811b6f2af2b261a8f21c51b872193b09/chromadb-1.1.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bba0096a7f5e975875ead23a91c0d41d977fbd3767f60d3305a011b0ace7afd3", size = 19893681 },
+    { url = "https://files.pythonhosted.org/packages/2d/6e/956e62975305a4e31daf6114a73b3b0683a8f36f8d70b20aabd466770edb/chromadb-1.1.1-cp39-abi3-win_amd64.whl", hash = "sha256:a77aa026a73a18181fd89bbbdb86191c9a82fd42aa0b549ff18d8cae56394c8b", size = 19844042 },
 ]
 
 [[package]]
@@ -444,27 +444,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
 ]
 
 [[package]]
 name = "cloudpickle"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", upload-time = "2025-11-03T09:25:26.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", upload-time = "2025-11-03T09:25:25.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228 },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", upload-time = "2022-10-25T02:36:22.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", upload-time = "2022-10-25T02:36:20.889Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
 ]
 
 [[package]]
@@ -474,46 +474,46 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", upload-time = "2025-07-26T12:03:12.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/2e/c4390a31919d8a78b90e8ecf87cd4b4c4f05a5b48d05ec17db8e5404c6f4/contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1", upload-time = "2025-07-26T12:01:02.277Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/44/c4b0b6095fef4dc9c420e041799591e3b63e9619e3044f7f4f6c21c0ab24/contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381", upload-time = "2025-07-26T12:01:04.072Z" },
-    { url = "https://files.pythonhosted.org/packages/30/2e/dd4ced42fefac8470661d7cb7e264808425e6c5d56d175291e93890cce09/contourpy-1.3.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:929ddf8c4c7f348e4c0a5a3a714b5c8542ffaa8c22954862a46ca1813b667ee7", upload-time = "2025-07-26T12:01:05.688Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/74/cc6ec2548e3d276c71389ea4802a774b7aa3558223b7bade3f25787fafc2/contourpy-1.3.3-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e999574eddae35f1312c2b4b717b7885d4edd6cb46700e04f7f02db454e67c1", upload-time = "2025-07-26T12:01:07.054Z" },
-    { url = "https://files.pythonhosted.org/packages/03/b3/64ef723029f917410f75c09da54254c5f9ea90ef89b143ccadb09df14c15/contourpy-1.3.3-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf67e0e3f482cb69779dd3061b534eb35ac9b17f163d851e2a547d56dba0a3a", upload-time = "2025-07-26T12:01:08.801Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/4b/6157f24ca425b89fe2eb7e7be642375711ab671135be21e6faa100f7448c/contourpy-1.3.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db", upload-time = "2025-07-26T12:01:10.319Z" },
-    { url = "https://files.pythonhosted.org/packages/98/56/f914f0dd678480708a04cfd2206e7c382533249bc5001eb9f58aa693e200/contourpy-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:598c3aaece21c503615fd59c92a3598b428b2f01bfb4b8ca9c4edeecc2438620", upload-time = "2025-07-26T12:01:12.659Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d7/4a972334a0c971acd5172389671113ae82aa7527073980c38d5868ff1161/contourpy-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:322ab1c99b008dad206d406bb61d014cf0174df491ae9d9d0fac6a6fda4f977f", upload-time = "2025-07-26T12:01:15.533Z" },
-    { url = "https://files.pythonhosted.org/packages/75/3e/f2cc6cd56dc8cff46b1a56232eabc6feea52720083ea71ab15523daab796/contourpy-1.3.3-cp311-cp311-win32.whl", hash = "sha256:fd907ae12cd483cd83e414b12941c632a969171bf90fc937d0c9f268a31cafff", upload-time = "2025-07-26T12:01:17.088Z" },
-    { url = "https://files.pythonhosted.org/packages/98/4b/9bd370b004b5c9d8045c6c33cf65bae018b27aca550a3f657cdc99acdbd8/contourpy-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:3519428f6be58431c56581f1694ba8e50626f2dd550af225f82fb5f5814d2a42", upload-time = "2025-07-26T12:01:18.256Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/b6/71771e02c2e004450c12b1120a5f488cad2e4d5b590b1af8bad060360fe4/contourpy-1.3.3-cp311-cp311-win_arm64.whl", hash = "sha256:15ff10bfada4bf92ec8b31c62bf7c1834c244019b4a33095a68000d7075df470", upload-time = "2025-07-26T12:01:19.848Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/29/8dcfe16f0107943fa92388c23f6e05cff0ba58058c4c95b00280d4c75a14/contourpy-1.3.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cd5dfcaeb10f7b7f9dc8941717c6c2ade08f587be2226222c12b25f0483ed497", upload-time = "2025-07-26T12:02:52.74Z" },
-    { url = "https://files.pythonhosted.org/packages/85/a9/8b37ef4f7dafeb335daee3c8254645ef5725be4d9c6aa70b50ec46ef2f7e/contourpy-1.3.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0c1fc238306b35f246d61a1d416a627348b5cf0648648a031e14bb8705fcdfe8", upload-time = "2025-07-26T12:02:54.037Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/59/ebfb8c677c75605cc27f7122c90313fd2f375ff3c8d19a1694bda74aaa63/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e", upload-time = "2025-07-26T12:02:55.947Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", upload-time = "2025-07-26T12:02:57.468Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", upload-time = "2025-07-26T12:02:58.801Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2e/c4390a31919d8a78b90e8ecf87cd4b4c4f05a5b48d05ec17db8e5404c6f4/contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1", size = 288773 },
+    { url = "https://files.pythonhosted.org/packages/0d/44/c4b0b6095fef4dc9c420e041799591e3b63e9619e3044f7f4f6c21c0ab24/contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381", size = 270149 },
+    { url = "https://files.pythonhosted.org/packages/30/2e/dd4ced42fefac8470661d7cb7e264808425e6c5d56d175291e93890cce09/contourpy-1.3.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:929ddf8c4c7f348e4c0a5a3a714b5c8542ffaa8c22954862a46ca1813b667ee7", size = 329222 },
+    { url = "https://files.pythonhosted.org/packages/f2/74/cc6ec2548e3d276c71389ea4802a774b7aa3558223b7bade3f25787fafc2/contourpy-1.3.3-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e999574eddae35f1312c2b4b717b7885d4edd6cb46700e04f7f02db454e67c1", size = 377234 },
+    { url = "https://files.pythonhosted.org/packages/03/b3/64ef723029f917410f75c09da54254c5f9ea90ef89b143ccadb09df14c15/contourpy-1.3.3-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf67e0e3f482cb69779dd3061b534eb35ac9b17f163d851e2a547d56dba0a3a", size = 380555 },
+    { url = "https://files.pythonhosted.org/packages/5f/4b/6157f24ca425b89fe2eb7e7be642375711ab671135be21e6faa100f7448c/contourpy-1.3.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db", size = 355238 },
+    { url = "https://files.pythonhosted.org/packages/98/56/f914f0dd678480708a04cfd2206e7c382533249bc5001eb9f58aa693e200/contourpy-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:598c3aaece21c503615fd59c92a3598b428b2f01bfb4b8ca9c4edeecc2438620", size = 1326218 },
+    { url = "https://files.pythonhosted.org/packages/fb/d7/4a972334a0c971acd5172389671113ae82aa7527073980c38d5868ff1161/contourpy-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:322ab1c99b008dad206d406bb61d014cf0174df491ae9d9d0fac6a6fda4f977f", size = 1392867 },
+    { url = "https://files.pythonhosted.org/packages/75/3e/f2cc6cd56dc8cff46b1a56232eabc6feea52720083ea71ab15523daab796/contourpy-1.3.3-cp311-cp311-win32.whl", hash = "sha256:fd907ae12cd483cd83e414b12941c632a969171bf90fc937d0c9f268a31cafff", size = 183677 },
+    { url = "https://files.pythonhosted.org/packages/98/4b/9bd370b004b5c9d8045c6c33cf65bae018b27aca550a3f657cdc99acdbd8/contourpy-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:3519428f6be58431c56581f1694ba8e50626f2dd550af225f82fb5f5814d2a42", size = 225234 },
+    { url = "https://files.pythonhosted.org/packages/d9/b6/71771e02c2e004450c12b1120a5f488cad2e4d5b590b1af8bad060360fe4/contourpy-1.3.3-cp311-cp311-win_arm64.whl", hash = "sha256:15ff10bfada4bf92ec8b31c62bf7c1834c244019b4a33095a68000d7075df470", size = 193123 },
+    { url = "https://files.pythonhosted.org/packages/a5/29/8dcfe16f0107943fa92388c23f6e05cff0ba58058c4c95b00280d4c75a14/contourpy-1.3.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cd5dfcaeb10f7b7f9dc8941717c6c2ade08f587be2226222c12b25f0483ed497", size = 278809 },
+    { url = "https://files.pythonhosted.org/packages/85/a9/8b37ef4f7dafeb335daee3c8254645ef5725be4d9c6aa70b50ec46ef2f7e/contourpy-1.3.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0c1fc238306b35f246d61a1d416a627348b5cf0648648a031e14bb8705fcdfe8", size = 261593 },
+    { url = "https://files.pythonhosted.org/packages/0a/59/ebfb8c677c75605cc27f7122c90313fd2f375ff3c8d19a1694bda74aaa63/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e", size = 302202 },
+    { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", size = 329207 },
+    { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", size = 225315 },
 ]
 
 [[package]]
 name = "coverage"
 version = "7.13.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/43/3e4ac666cc35f231fa70c94e9f38459299de1a152813f9d2f60fc5f3ecaf/coverage-7.13.3.tar.gz", hash = "sha256:f7f6182d3dfb8802c1747eacbfe611b669455b69b7c037484bb1efbbb56711ac", upload-time = "2026-02-03T14:02:30.944Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/43/3e4ac666cc35f231fa70c94e9f38459299de1a152813f9d2f60fc5f3ecaf/coverage-7.13.3.tar.gz", hash = "sha256:f7f6182d3dfb8802c1747eacbfe611b669455b69b7c037484bb1efbbb56711ac", size = 826832 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/09/1ac74e37cf45f17eb41e11a21854f7f92a4c2d6c6098ef4a1becb0c6d8d3/coverage-7.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5907605ee20e126eeee2abe14aae137043c2c8af2fa9b38d2ab3b7a6b8137f73", upload-time = "2026-02-03T14:00:00.296Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/cb/71908b08b21beb2c437d0d5870c4ec129c570ca1b386a8427fcdb11cf89c/coverage-7.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a88705500988c8acad8b8fd86c2a933d3aa96bec1ddc4bc5cb256360db7bbd00", upload-time = "2026-02-03T14:00:02.414Z" },
-    { url = "https://files.pythonhosted.org/packages/09/85/c4f3dd69232887666a2c0394d4be21c60ea934d404db068e6c96aa59cd87/coverage-7.13.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7bbb5aa9016c4c29e3432e087aa29ebee3f8fda089cfbfb4e6d64bd292dcd1c2", upload-time = "2026-02-03T14:00:04.197Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/cc/560ad6f12010344d0778e268df5ba9aa990aacccc310d478bf82bf3d302c/coverage-7.13.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0c2be202a83dde768937a61cdc5d06bf9fb204048ca199d93479488e6247656c", upload-time = "2026-02-03T14:00:05.639Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/66/3193985fb2c58e91f94cfbe9e21a6fdf941e9301fe2be9e92c072e9c8f8c/coverage-7.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f45e32ef383ce56e0ca099b2e02fcdf7950be4b1b56afaab27b4ad790befe5b", upload-time = "2026-02-03T14:00:07.738Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/78/f0f91556bf1faa416792e537c523c5ef9db9b1d32a50572c102b3d7c45b3/coverage-7.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ed2e787249b922a93cd95c671cc9f4c9797a106e81b455c83a9ddb9d34590c0", upload-time = "2026-02-03T14:00:09.224Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/aa/fc654e45e837d137b2c1f3a2cc09b4aea1e8b015acd2f774fa0f3d2ddeba/coverage-7.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:05dd25b21afffe545e808265897c35f32d3e4437663923e0d256d9ab5031fb14", upload-time = "2026-02-03T14:00:10.712Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4d/ab53063992add8a9ca0463c9d92cce5994a29e17affd1c2daa091b922a93/coverage-7.13.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:46d29926349b5c4f1ea4fca95e8c892835515f3600995a383fa9a923b5739ea4", upload-time = "2026-02-03T14:00:12.402Z" },
-    { url = "https://files.pythonhosted.org/packages/29/25/83694b81e46fcff9899694a1b6f57573429cdd82b57932f09a698f03eea5/coverage-7.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:fae6a21537519c2af00245e834e5bf2884699cc7c1055738fd0f9dc37a3644ad", upload-time = "2026-02-03T14:00:13.868Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/ef/d68fc304301f4cb4bf6aefa0045310520789ca38dabdfba9dbecd3f37919/coverage-7.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c672d4e2f0575a4ca2bf2aa0c5ced5188220ab806c1bb6d7179f70a11a017222", upload-time = "2026-02-03T14:00:15.461Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/85/240ad396f914df361d0f71e912ddcedb48130c71b88dc4193fe3c0306f00/coverage-7.13.3-cp311-cp311-win32.whl", hash = "sha256:fcda51c918c7a13ad93b5f89a58d56e3a072c9e0ba5c231b0ed81404bf2648fb", upload-time = "2026-02-03T14:00:17.462Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/71/165b3a6d3d052704a9ab52d11ea64ef3426745de517dda44d872716213a7/coverage-7.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:d1a049b5c51b3b679928dd35e47c4a2235e0b6128b479a7596d0ef5b42fa6301", upload-time = "2026-02-03T14:00:19.449Z" },
-    { url = "https://files.pythonhosted.org/packages/51/d0/0ddc9c5934cdd52639c5df1f1eb0fdab51bb52348f3a8d1c7db9c600d93a/coverage-7.13.3-cp311-cp311-win_arm64.whl", hash = "sha256:79f2670c7e772f4917895c3d89aad59e01f3dbe68a4ed2d0373b431fad1dcfba", upload-time = "2026-02-03T14:00:20.968Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/fb/70af542d2d938c778c9373ce253aa4116dbe7c0a5672f78b2b2ae0e1b94b/coverage-7.13.3-py3-none-any.whl", hash = "sha256:90a8af9dba6429b2573199622d72e0ebf024d6276f16abce394ad4d181bb0910", upload-time = "2026-02-03T14:02:27.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/09/1ac74e37cf45f17eb41e11a21854f7f92a4c2d6c6098ef4a1becb0c6d8d3/coverage-7.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5907605ee20e126eeee2abe14aae137043c2c8af2fa9b38d2ab3b7a6b8137f73", size = 219276 },
+    { url = "https://files.pythonhosted.org/packages/2e/cb/71908b08b21beb2c437d0d5870c4ec129c570ca1b386a8427fcdb11cf89c/coverage-7.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a88705500988c8acad8b8fd86c2a933d3aa96bec1ddc4bc5cb256360db7bbd00", size = 219776 },
+    { url = "https://files.pythonhosted.org/packages/09/85/c4f3dd69232887666a2c0394d4be21c60ea934d404db068e6c96aa59cd87/coverage-7.13.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7bbb5aa9016c4c29e3432e087aa29ebee3f8fda089cfbfb4e6d64bd292dcd1c2", size = 250196 },
+    { url = "https://files.pythonhosted.org/packages/9c/cc/560ad6f12010344d0778e268df5ba9aa990aacccc310d478bf82bf3d302c/coverage-7.13.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0c2be202a83dde768937a61cdc5d06bf9fb204048ca199d93479488e6247656c", size = 252111 },
+    { url = "https://files.pythonhosted.org/packages/f0/66/3193985fb2c58e91f94cfbe9e21a6fdf941e9301fe2be9e92c072e9c8f8c/coverage-7.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f45e32ef383ce56e0ca099b2e02fcdf7950be4b1b56afaab27b4ad790befe5b", size = 254217 },
+    { url = "https://files.pythonhosted.org/packages/c5/78/f0f91556bf1faa416792e537c523c5ef9db9b1d32a50572c102b3d7c45b3/coverage-7.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ed2e787249b922a93cd95c671cc9f4c9797a106e81b455c83a9ddb9d34590c0", size = 250318 },
+    { url = "https://files.pythonhosted.org/packages/6f/aa/fc654e45e837d137b2c1f3a2cc09b4aea1e8b015acd2f774fa0f3d2ddeba/coverage-7.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:05dd25b21afffe545e808265897c35f32d3e4437663923e0d256d9ab5031fb14", size = 251909 },
+    { url = "https://files.pythonhosted.org/packages/73/4d/ab53063992add8a9ca0463c9d92cce5994a29e17affd1c2daa091b922a93/coverage-7.13.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:46d29926349b5c4f1ea4fca95e8c892835515f3600995a383fa9a923b5739ea4", size = 249971 },
+    { url = "https://files.pythonhosted.org/packages/29/25/83694b81e46fcff9899694a1b6f57573429cdd82b57932f09a698f03eea5/coverage-7.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:fae6a21537519c2af00245e834e5bf2884699cc7c1055738fd0f9dc37a3644ad", size = 249692 },
+    { url = "https://files.pythonhosted.org/packages/d4/ef/d68fc304301f4cb4bf6aefa0045310520789ca38dabdfba9dbecd3f37919/coverage-7.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c672d4e2f0575a4ca2bf2aa0c5ced5188220ab806c1bb6d7179f70a11a017222", size = 250597 },
+    { url = "https://files.pythonhosted.org/packages/8d/85/240ad396f914df361d0f71e912ddcedb48130c71b88dc4193fe3c0306f00/coverage-7.13.3-cp311-cp311-win32.whl", hash = "sha256:fcda51c918c7a13ad93b5f89a58d56e3a072c9e0ba5c231b0ed81404bf2648fb", size = 221773 },
+    { url = "https://files.pythonhosted.org/packages/2f/71/165b3a6d3d052704a9ab52d11ea64ef3426745de517dda44d872716213a7/coverage-7.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:d1a049b5c51b3b679928dd35e47c4a2235e0b6128b479a7596d0ef5b42fa6301", size = 222711 },
+    { url = "https://files.pythonhosted.org/packages/51/d0/0ddc9c5934cdd52639c5df1f1eb0fdab51bb52348f3a8d1c7db9c600d93a/coverage-7.13.3-cp311-cp311-win_arm64.whl", hash = "sha256:79f2670c7e772f4917895c3d89aad59e01f3dbe68a4ed2d0373b431fad1dcfba", size = 221377 },
+    { url = "https://files.pythonhosted.org/packages/7d/fb/70af542d2d938c778c9373ce253aa4116dbe7c0a5672f78b2b2ae0e1b94b/coverage-7.13.3-py3-none-any.whl", hash = "sha256:90a8af9dba6429b2573199622d72e0ebf024d6276f16abce394ad4d181bb0910", size = 211237 },
 ]
 
 [package.optional-dependencies]
@@ -557,9 +557,9 @@ dependencies = [
     { name = "tomli" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/12/b974c1b36af1d4a5928825f6ac7f7d34fc88b12e4715dcb43e119157663d/crewai-1.14.5.tar.gz", hash = "sha256:e64dfa4f309f94bbaacab0a4ca5d4f8e02b18c528b2876a390cd396135d46631", upload-time = "2026-05-18T19:20:43.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/12/b974c1b36af1d4a5928825f6ac7f7d34fc88b12e4715dcb43e119157663d/crewai-1.14.5.tar.gz", hash = "sha256:e64dfa4f309f94bbaacab0a4ca5d4f8e02b18c528b2876a390cd396135d46631", size = 7681243 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/5c/c274c1657d164ef170b70ee725e1b6164062440b8b47a96a104d12f5245c/crewai-1.14.5-py3-none-any.whl", hash = "sha256:be6580aab9d5ee2c73de5ed26cdd29c7d04d826e0d14e0a5ddd2e1e0742fa9f8", upload-time = "2026-05-18T19:20:41.437Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5c/c274c1657d164ef170b70ee725e1b6164062440b8b47a96a104d12f5245c/crewai-1.14.5-py3-none-any.whl", hash = "sha256:be6580aab9d5ee2c73de5ed26cdd29c7d04d826e0d14e0a5ddd2e1e0742fa9f8", size = 976841 },
 ]
 
 [package.optional-dependencies]
@@ -589,9 +589,9 @@ dependencies = [
     { name = "tomli-w" },
     { name = "uv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/e2/5fec7c86f561be3cf6a1766939e4e6dc8592213fd1f3a3c2228f53cbf644/crewai_cli-1.14.5.tar.gz", hash = "sha256:faf05a8ce8ba655f49a1fc61473efc439a9ad70ce0329a768de265243726e0f0", upload-time = "2026-05-18T19:20:46.521Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/e2/5fec7c86f561be3cf6a1766939e4e6dc8592213fd1f3a3c2228f53cbf644/crewai_cli-1.14.5.tar.gz", hash = "sha256:faf05a8ce8ba655f49a1fc61473efc439a9ad70ce0329a768de265243726e0f0", size = 107149 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/3e/a8e66982d3b5a9e98ccd66cd4516c184a37f94ccb2320e7ae1d3969ed9ac/crewai_cli-1.14.5-py3-none-any.whl", hash = "sha256:0e4811a093a95a9c7a177abfdac6cb90af806cf0850efddc42072739e0bdcac9", upload-time = "2026-05-18T19:20:45.436Z" },
+    { url = "https://files.pythonhosted.org/packages/07/3e/a8e66982d3b5a9e98ccd66cd4516c184a37f94ccb2320e7ae1d3969ed9ac/crewai_cli-1.14.5-py3-none-any.whl", hash = "sha256:0e4811a093a95a9c7a177abfdac6cb90af806cf0850efddc42072739e0bdcac9", size = 108319 },
 ]
 
 [[package]]
@@ -612,9 +612,9 @@ dependencies = [
     { name = "rich" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/1a/b3ce01f4d4b7773dbd2aa21bdda9d4d3d11778dde3e6b6f4a690f5cd89f8/crewai_core-1.14.5.tar.gz", hash = "sha256:b72c0cfb953bf934b252fa826cb71c80127ccc42f9a39feb2a7a97ee8272be82", upload-time = "2026-05-18T19:20:48.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/1a/b3ce01f4d4b7773dbd2aa21bdda9d4d3d11778dde3e6b6f4a690f5cd89f8/crewai_core-1.14.5.tar.gz", hash = "sha256:b72c0cfb953bf934b252fa826cb71c80127ccc42f9a39feb2a7a97ee8272be82", size = 19168 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/52/05da585bdc287c7d9b368e6f58bf23d01a2bf20ba953370119e8cdc2d3ea/crewai_core-1.14.5-py3-none-any.whl", hash = "sha256:f2349160d10345e9096660c78ed6c5a6a9922033cd4c5e1b18dcbf8ea72a48b3", upload-time = "2026-05-18T19:20:47.325Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/52/05da585bdc287c7d9b368e6f58bf23d01a2bf20ba953370119e8cdc2d3ea/crewai_core-1.14.5-py3-none-any.whl", hash = "sha256:f2349160d10345e9096660c78ed6c5a6a9922033cd4c5e1b18dcbf8ea72a48b3", size = 27385 },
 ]
 
 [[package]]
@@ -631,9 +631,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "youtube-transcript-api" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/be/a1d068a8cd416b0be3cb649fb9c960b7bb8501a17e903614ce35949e8a53/crewai_tools-1.14.5.tar.gz", hash = "sha256:eacf3e719eadf91607c3103dbd42ff5dcf149e64801f97c50c6904f356c7efd2", upload-time = "2026-05-18T19:20:53.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/be/a1d068a8cd416b0be3cb649fb9c960b7bb8501a17e903614ce35949e8a53/crewai_tools-1.14.5.tar.gz", hash = "sha256:eacf3e719eadf91607c3103dbd42ff5dcf149e64801f97c50c6904f356c7efd2", size = 900866 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/08/6d838e6f9476b18f5db61c20dff7054dcb1fa97aadbf43c6bc88bb3f8903/crewai_tools-1.14.5-py3-none-any.whl", hash = "sha256:e17b0bbc2dbc3b0e98b87d797964c603ae13293a8c7a936faf40a9e117563eb1", upload-time = "2026-05-18T19:20:51.95Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/08/6d838e6f9476b18f5db61c20dff7054dcb1fa97aadbf43c6bc88bb3f8903/crewai_tools-1.14.5-py3-none-any.whl", hash = "sha256:e17b0bbc2dbc3b0e98b87d797964c603ae13293a8c7a936faf40a9e117563eb1", size = 814053 },
 ]
 
 [[package]]
@@ -644,9 +644,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/2f/44d1ae153a0e27be56be43465e5cb39b9650c781e001e7864389deb25090/croniter-6.0.0.tar.gz", hash = "sha256:37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577", upload-time = "2024-12-17T17:17:47.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2f/44d1ae153a0e27be56be43465e5cb39b9650c781e001e7864389deb25090/croniter-6.0.0.tar.gz", hash = "sha256:37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577", size = 64481 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/4b/290b4c3efd6417a8b0c284896de19b1d5855e6dbdb97d2a35e68fa42de85/croniter-6.0.0-py2.py3-none-any.whl", hash = "sha256:2f878c3856f17896979b2a4379ba1f09c83e374931ea15cc835c5dd2eee9b368", upload-time = "2024-12-17T17:17:45.359Z" },
+    { url = "https://files.pythonhosted.org/packages/07/4b/290b4c3efd6417a8b0c284896de19b1d5855e6dbdb97d2a35e68fa42de85/croniter-6.0.0-py2.py3-none-any.whl", hash = "sha256:2f878c3856f17896979b2a4379ba1f09c83e374931ea15cc835c5dd2eee9b368", size = 25468 },
 ]
 
 [[package]]
@@ -656,56 +656,56 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", upload-time = "2025-09-01T11:15:03.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", size = 744980 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/91/925c0ac74362172ae4516000fe877912e33b5983df735ff290c653de4913/cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee", upload-time = "2025-09-01T11:13:59.684Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/63/43641c5acce3a6105cf8bd5baeceeb1846bb63067d26dae3e5db59f1513a/cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6", upload-time = "2025-09-01T11:14:02.517Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/29/c238dd9107f10bfde09a4d1c52fd38828b1aa353ced11f358b5dd2507d24/cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339", upload-time = "2025-09-01T11:14:04.522Z" },
-    { url = "https://files.pythonhosted.org/packages/62/62/24203e7cbcc9bd7c94739428cd30680b18ae6b18377ae66075c8e4771b1b/cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8", upload-time = "2025-09-01T11:14:06.309Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/e3/e7de4771a08620eef2389b86cd87a2c50326827dea5528feb70595439ce4/cryptography-45.0.7-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:465ccac9d70115cd4de7186e60cfe989de73f7bb23e8a7aa45af18f7412e75bf", upload-time = "2025-09-01T11:14:08.152Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b8/bca71059e79a0bb2f8e4ec61d9c205fbe97876318566cde3b5092529faa9/cryptography-45.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16ede8a4f7929b4b7ff3642eba2bf79aa1d71f24ab6ee443935c0d269b6bc513", upload-time = "2025-09-01T11:14:09.755Z" },
-    { url = "https://files.pythonhosted.org/packages/58/67/3f5b26937fe1218c40e95ef4ff8d23c8dc05aa950d54200cc7ea5fb58d28/cryptography-45.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8978132287a9d3ad6b54fcd1e08548033cc09dc6aacacb6c004c73c3eb5d3ac3", upload-time = "2025-09-01T11:14:11.229Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/e4/b3e68a4ac363406a56cf7b741eeb80d05284d8c60ee1a55cdc7587e2a553/cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3", upload-time = "2025-09-01T11:14:12.924Z" },
-    { url = "https://files.pythonhosted.org/packages/22/49/2c93f3cd4e3efc8cb22b02678c1fad691cff9dd71bb889e030d100acbfe0/cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6", upload-time = "2025-09-01T11:14:14.431Z" },
-    { url = "https://files.pythonhosted.org/packages/04/19/030f400de0bccccc09aa262706d90f2ec23d56bc4eb4f4e8268d0ddf3fb8/cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd", upload-time = "2025-09-01T11:14:16.185Z" },
-    { url = "https://files.pythonhosted.org/packages/29/56/3034a3a353efa65116fa20eb3c990a8c9f0d3db4085429040a7eef9ada5f/cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8", upload-time = "2025-09-01T11:14:17.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/61/0ab90f421c6194705a99d0fa9f6ee2045d916e4455fdbb095a9c2c9a520f/cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443", upload-time = "2025-09-01T11:14:18.958Z" },
-    { url = "https://files.pythonhosted.org/packages/63/e8/c436233ddf19c5f15b25ace33979a9dd2e7aa1a59209a0ee8554179f1cc0/cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2", upload-time = "2025-09-01T11:14:20.954Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/4c/8f57f2500d0ccd2675c5d0cc462095adf3faa8c52294ba085c036befb901/cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691", upload-time = "2025-09-01T11:14:22.454Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/ac/59b7790b4ccaed739fc44775ce4645c9b8ce54cbec53edf16c74fd80cb2b/cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59", upload-time = "2025-09-01T11:14:24.287Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/d4f07ea21434bf891faa088a6ac15d6d98093a66e75e30ad08e88aa2b9ba/cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4", upload-time = "2025-09-01T11:14:25.679Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ac/924a723299848b4c741c1059752c7cfe09473b6fd77d2920398fc26bfb53/cryptography-45.0.7-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce7a453385e4c4693985b4a4a3533e041558851eae061a58a5405363b098fcd3", upload-time = "2025-09-01T11:14:27.1Z" },
-    { url = "https://files.pythonhosted.org/packages/83/dc/4dab2ff0a871cc2d81d3ae6d780991c0192b259c35e4d83fe1de18b20c70/cryptography-45.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b04f85ac3a90c227b6e5890acb0edbaf3140938dbecf07bff618bf3638578cf1", upload-time = "2025-09-01T11:14:28.58Z" },
-    { url = "https://files.pythonhosted.org/packages/12/dd/b2882b65db8fc944585d7fb00d67cf84a9cef4e77d9ba8f69082e911d0de/cryptography-45.0.7-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:48c41a44ef8b8c2e80ca4527ee81daa4c527df3ecbc9423c41a420a9559d0e27", upload-time = "2025-09-01T11:14:30.572Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/fa/1d5745d878048699b8eb87c984d4ccc5da4f5008dfd3ad7a94040caca23a/cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17", upload-time = "2025-09-01T11:14:32.046Z" },
-    { url = "https://files.pythonhosted.org/packages/36/8b/fc61f87931bc030598e1876c45b936867bb72777eac693e905ab89832670/cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b", upload-time = "2025-09-01T11:14:33.95Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/11/09700ddad7443ccb11d674efdbe9a832b4455dc1f16566d9bd3834922ce5/cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c", upload-time = "2025-09-01T11:14:35.343Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ed/8f4c1337e9d3b94d8e50ae0b08ad0304a5709d483bfcadfcc77a23dbcb52/cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5", upload-time = "2025-09-01T11:14:36.929Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/ff/026513ecad58dacd45d1d24ebe52b852165a26e287177de1d545325c0c25/cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90", upload-time = "2025-09-01T11:14:38.368Z" },
-    { url = "https://files.pythonhosted.org/packages/99/4e/49199a4c82946938a3e05d2e8ad9482484ba48bbc1e809e3d506c686d051/cryptography-45.0.7-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4a862753b36620af6fc54209264f92c716367f2f0ff4624952276a6bbd18cbde", upload-time = "2025-09-01T11:14:50.593Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ce/5f6ff59ea9c7779dba51b84871c19962529bdcc12e1a6ea172664916c550/cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:06ce84dc14df0bf6ea84666f958e6080cdb6fe1231be2a51f3fc1267d9f3fb34", upload-time = "2025-09-01T11:14:52.091Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/13/b3cfbd257ac96da4b88b46372e662009b7a16833bfc5da33bb97dd5631ae/cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d0c5c6bac22b177bf8da7435d9d27a6834ee130309749d162b26c3105c0795a9", upload-time = "2025-09-01T11:14:53.551Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c5/8c59d6b7c7b439ba4fc8d0cab868027fd095f215031bc123c3a070962912/cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:2f641b64acc00811da98df63df7d59fd4706c0df449da71cb7ac39a0732b40ae", upload-time = "2025-09-01T11:14:55.022Z" },
-    { url = "https://files.pythonhosted.org/packages/55/32/05385c86d6ca9ab0b4d5bb442d2e3d85e727939a11f3e163fc776ce5eb40/cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:f5414a788ecc6ee6bc58560e85ca624258a55ca434884445440a810796ea0e0b", upload-time = "2025-09-01T11:14:57.319Z" },
-    { url = "https://files.pythonhosted.org/packages/23/87/7ce86f3fa14bc11a5a48c30d8103c26e09b6465f8d8e9d74cf7a0714f043/cryptography-45.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:1f3d56f73595376f4244646dd5c5870c14c196949807be39e79e7bd9bac3da63", upload-time = "2025-09-01T11:14:58.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/925c0ac74362172ae4516000fe877912e33b5983df735ff290c653de4913/cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee", size = 7041105 },
+    { url = "https://files.pythonhosted.org/packages/fc/63/43641c5acce3a6105cf8bd5baeceeb1846bb63067d26dae3e5db59f1513a/cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6", size = 4205799 },
+    { url = "https://files.pythonhosted.org/packages/bc/29/c238dd9107f10bfde09a4d1c52fd38828b1aa353ced11f358b5dd2507d24/cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339", size = 4430504 },
+    { url = "https://files.pythonhosted.org/packages/62/62/24203e7cbcc9bd7c94739428cd30680b18ae6b18377ae66075c8e4771b1b/cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8", size = 4209542 },
+    { url = "https://files.pythonhosted.org/packages/cd/e3/e7de4771a08620eef2389b86cd87a2c50326827dea5528feb70595439ce4/cryptography-45.0.7-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:465ccac9d70115cd4de7186e60cfe989de73f7bb23e8a7aa45af18f7412e75bf", size = 3889244 },
+    { url = "https://files.pythonhosted.org/packages/96/b8/bca71059e79a0bb2f8e4ec61d9c205fbe97876318566cde3b5092529faa9/cryptography-45.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16ede8a4f7929b4b7ff3642eba2bf79aa1d71f24ab6ee443935c0d269b6bc513", size = 4461975 },
+    { url = "https://files.pythonhosted.org/packages/58/67/3f5b26937fe1218c40e95ef4ff8d23c8dc05aa950d54200cc7ea5fb58d28/cryptography-45.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8978132287a9d3ad6b54fcd1e08548033cc09dc6aacacb6c004c73c3eb5d3ac3", size = 4209082 },
+    { url = "https://files.pythonhosted.org/packages/0e/e4/b3e68a4ac363406a56cf7b741eeb80d05284d8c60ee1a55cdc7587e2a553/cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3", size = 4460397 },
+    { url = "https://files.pythonhosted.org/packages/22/49/2c93f3cd4e3efc8cb22b02678c1fad691cff9dd71bb889e030d100acbfe0/cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6", size = 4337244 },
+    { url = "https://files.pythonhosted.org/packages/04/19/030f400de0bccccc09aa262706d90f2ec23d56bc4eb4f4e8268d0ddf3fb8/cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd", size = 4568862 },
+    { url = "https://files.pythonhosted.org/packages/29/56/3034a3a353efa65116fa20eb3c990a8c9f0d3db4085429040a7eef9ada5f/cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8", size = 2936578 },
+    { url = "https://files.pythonhosted.org/packages/b3/61/0ab90f421c6194705a99d0fa9f6ee2045d916e4455fdbb095a9c2c9a520f/cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443", size = 3405400 },
+    { url = "https://files.pythonhosted.org/packages/63/e8/c436233ddf19c5f15b25ace33979a9dd2e7aa1a59209a0ee8554179f1cc0/cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2", size = 7021824 },
+    { url = "https://files.pythonhosted.org/packages/bc/4c/8f57f2500d0ccd2675c5d0cc462095adf3faa8c52294ba085c036befb901/cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691", size = 4202233 },
+    { url = "https://files.pythonhosted.org/packages/eb/ac/59b7790b4ccaed739fc44775ce4645c9b8ce54cbec53edf16c74fd80cb2b/cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59", size = 4423075 },
+    { url = "https://files.pythonhosted.org/packages/b8/56/d4f07ea21434bf891faa088a6ac15d6d98093a66e75e30ad08e88aa2b9ba/cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4", size = 4204517 },
+    { url = "https://files.pythonhosted.org/packages/e8/ac/924a723299848b4c741c1059752c7cfe09473b6fd77d2920398fc26bfb53/cryptography-45.0.7-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce7a453385e4c4693985b4a4a3533e041558851eae061a58a5405363b098fcd3", size = 3882893 },
+    { url = "https://files.pythonhosted.org/packages/83/dc/4dab2ff0a871cc2d81d3ae6d780991c0192b259c35e4d83fe1de18b20c70/cryptography-45.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b04f85ac3a90c227b6e5890acb0edbaf3140938dbecf07bff618bf3638578cf1", size = 4450132 },
+    { url = "https://files.pythonhosted.org/packages/12/dd/b2882b65db8fc944585d7fb00d67cf84a9cef4e77d9ba8f69082e911d0de/cryptography-45.0.7-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:48c41a44ef8b8c2e80ca4527ee81daa4c527df3ecbc9423c41a420a9559d0e27", size = 4204086 },
+    { url = "https://files.pythonhosted.org/packages/5d/fa/1d5745d878048699b8eb87c984d4ccc5da4f5008dfd3ad7a94040caca23a/cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17", size = 4449383 },
+    { url = "https://files.pythonhosted.org/packages/36/8b/fc61f87931bc030598e1876c45b936867bb72777eac693e905ab89832670/cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b", size = 4332186 },
+    { url = "https://files.pythonhosted.org/packages/0b/11/09700ddad7443ccb11d674efdbe9a832b4455dc1f16566d9bd3834922ce5/cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c", size = 4561639 },
+    { url = "https://files.pythonhosted.org/packages/71/ed/8f4c1337e9d3b94d8e50ae0b08ad0304a5709d483bfcadfcc77a23dbcb52/cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5", size = 2926552 },
+    { url = "https://files.pythonhosted.org/packages/bc/ff/026513ecad58dacd45d1d24ebe52b852165a26e287177de1d545325c0c25/cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90", size = 3392742 },
+    { url = "https://files.pythonhosted.org/packages/99/4e/49199a4c82946938a3e05d2e8ad9482484ba48bbc1e809e3d506c686d051/cryptography-45.0.7-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4a862753b36620af6fc54209264f92c716367f2f0ff4624952276a6bbd18cbde", size = 3584634 },
+    { url = "https://files.pythonhosted.org/packages/16/ce/5f6ff59ea9c7779dba51b84871c19962529bdcc12e1a6ea172664916c550/cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:06ce84dc14df0bf6ea84666f958e6080cdb6fe1231be2a51f3fc1267d9f3fb34", size = 4149533 },
+    { url = "https://files.pythonhosted.org/packages/ce/13/b3cfbd257ac96da4b88b46372e662009b7a16833bfc5da33bb97dd5631ae/cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d0c5c6bac22b177bf8da7435d9d27a6834ee130309749d162b26c3105c0795a9", size = 4385557 },
+    { url = "https://files.pythonhosted.org/packages/1c/c5/8c59d6b7c7b439ba4fc8d0cab868027fd095f215031bc123c3a070962912/cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:2f641b64acc00811da98df63df7d59fd4706c0df449da71cb7ac39a0732b40ae", size = 4149023 },
+    { url = "https://files.pythonhosted.org/packages/55/32/05385c86d6ca9ab0b4d5bb442d2e3d85e727939a11f3e163fc776ce5eb40/cryptography-45.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:f5414a788ecc6ee6bc58560e85ca624258a55ca434884445440a810796ea0e0b", size = 4385722 },
+    { url = "https://files.pythonhosted.org/packages/23/87/7ce86f3fa14bc11a5a48c30d8103c26e09b6465f8d8e9d74cf7a0714f043/cryptography-45.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:1f3d56f73595376f4244646dd5c5870c14c196949807be39e79e7bd9bac3da63", size = 3332908 },
 ]
 
 [[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", upload-time = "2023-10-07T05:32:18.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", upload-time = "2023-10-07T05:32:16.783Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321 },
 ]
 
 [[package]]
 name = "databricks"
 version = "0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/94/acee395ffab7057cb025a3d65e61bf686c09d1c00b41518a0a4de0c0f80d/databricks-0.2.tar.gz", hash = "sha256:f20074914eea742cdc5f0b60db18b2408c62d90b50013adf5614f00a2e042059", upload-time = "2018-11-15T17:21:26.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/94/acee395ffab7057cb025a3d65e61bf686c09d1c00b41518a0a4de0c0f80d/databricks-0.2.tar.gz", hash = "sha256:f20074914eea742cdc5f0b60db18b2408c62d90b50013adf5614f00a2e042059", size = 734 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/71/3a1f0cb5f5e3060054a48c17281aaf3e75a52e31e602d5e5769f94c16624/databricks-0.2-py2.py3-none-any.whl", hash = "sha256:2d4384b4d1f992ac9c94b0933a61082a61ee6bae5e95a208d1e843216d860adf", upload-time = "2018-11-15T17:21:25.469Z" },
+    { url = "https://files.pythonhosted.org/packages/97/71/3a1f0cb5f5e3060054a48c17281aaf3e75a52e31e602d5e5769f94c16624/databricks-0.2-py2.py3-none-any.whl", hash = "sha256:2d4384b4d1f992ac9c94b0933a61082a61ee6bae5e95a208d1e843216d860adf", size = 1244 },
 ]
 
 [[package]]
@@ -728,7 +728,7 @@ dependencies = [
     { name = "whenever" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/04/8beaa747f9f6e54b518d645714ec58ee8abce3574d784296d521cd9276ce/databricks_agents-1.4.0-py3-none-any.whl", hash = "sha256:54a888ec8af15da7c2df888e53280c8d1f43c0deb87b28781e28295ea7ea81a1", upload-time = "2025-08-20T19:09:32.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/04/8beaa747f9f6e54b518d645714ec58ee8abce3574d784296d521cd9276ce/databricks_agents-1.4.0-py3-none-any.whl", hash = "sha256:54a888ec8af15da7c2df888e53280c8d1f43c0deb87b28781e28295ea7ea81a1", size = 198890 },
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ dependencies = [
     { name = "six" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/0e/98c7f83421bcbc2d6d9dbb86968a212fb03d43c94b42b62962f8a7249e46/databricks_connect-14.3.2-py2.py3-none-any.whl", hash = "sha256:b607c2f00823df7568ad166fdd78df50dde8c0b3877dc649849bd970483dbf7f", upload-time = "2024-05-08T11:29:13.459Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0e/98c7f83421bcbc2d6d9dbb86968a212fb03d43c94b42b62962f8a7249e46/databricks_connect-14.3.2-py2.py3-none-any.whl", hash = "sha256:b607c2f00823df7568ad166fdd78df50dde8c0b3877dc649849bd970483dbf7f", size = 2211729 },
 ]
 
 [[package]]
@@ -760,9 +760,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/b3/41ff1c3afe092df9085e084e0dc81c45bca5ed65f7b60dc59df0ade43c76/databricks_sdk-0.102.0.tar.gz", hash = "sha256:8fa5f82317ee27cc46323c6e2543d2cfefb4468653f92ba558271043c6f72fb9", upload-time = "2026-03-19T08:15:54.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/b3/41ff1c3afe092df9085e084e0dc81c45bca5ed65f7b60dc59df0ade43c76/databricks_sdk-0.102.0.tar.gz", hash = "sha256:8fa5f82317ee27cc46323c6e2543d2cfefb4468653f92ba558271043c6f72fb9", size = 887450 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/8c/d082bd5f72d7613524d5b35dfe1f71732b2246be2704fad68cd0e3fdd020/databricks_sdk-0.102.0-py3-none-any.whl", hash = "sha256:75d1253276ee8f3dd5e7b00d62594b7051838435e618f74a8570a6dbd723ec12", upload-time = "2026-03-19T08:15:52.248Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8c/d082bd5f72d7613524d5b35dfe1f71732b2246be2704fad68cd0e3fdd020/databricks_sdk-0.102.0-py3-none-any.whl", hash = "sha256:75d1253276ee8f3dd5e7b00d62594b7051838435e618f74a8570a6dbd723ec12", size = 838533 },
 ]
 
 [package.optional-dependencies]
@@ -783,7 +783,7 @@ dependencies = [
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/f7/e4bb15a871fd6bf76869993d437b5da8e0306fb4153b84cfb18d8729082f/databricks_vectorsearch-0.64-py3-none-any.whl", hash = "sha256:a1133fd67bed800613720898c3b3a4bea2ff90fa8fd11f7e3cb413a77a494e3c", upload-time = "2026-01-22T00:29:50.528Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f7/e4bb15a871fd6bf76869993d437b5da8e0306fb4153b84cfb18d8729082f/databricks_vectorsearch-0.64-py3-none-any.whl", hash = "sha256:a1133fd67bed800613720898c3b3a4bea2ff90fa8fd11f7e3cb413a77a494e3c", size = 21030 },
 ]
 
 [[package]]
@@ -794,18 +794,18 @@ dependencies = [
     { name = "marshmallow" },
     { name = "typing-inspect" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", upload-time = "2024-06-09T16:20:19.103Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", upload-time = "2024-06-09T16:20:16.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686 },
 ]
 
 [[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", upload-time = "2021-03-08T10:59:26.269Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", upload-time = "2021-03-08T10:59:24.45Z" },
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604 },
 ]
 
 [[package]]
@@ -815,9 +815,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", upload-time = "2025-10-30T08:19:02.757Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", upload-time = "2025-10-30T08:19:00.758Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298 },
 ]
 
 [[package]]
@@ -827,36 +827,36 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", upload-time = "2020-04-20T14:23:38.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", upload-time = "2020-04-20T14:23:36.581Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178 },
 ]
 
 [[package]]
 name = "diskcache"
 version = "5.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", upload-time = "2023-08-31T06:12:00.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", upload-time = "2023-08-31T06:11:58.822Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550 },
 ]
 
 [[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", upload-time = "2023-12-24T09:54:32.31Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", upload-time = "2023-12-24T09:54:30.421Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
 ]
 
 [[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", upload-time = "2025-09-07T18:58:00.022Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", upload-time = "2025-09-07T18:57:58.071Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094 },
 ]
 
 [[package]]
@@ -868,27 +868,27 @@ dependencies = [
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", upload-time = "2024-05-23T11:13:57.216Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", upload-time = "2024-05-23T11:13:55.01Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774 },
 ]
 
 [[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", upload-time = "2025-07-21T07:35:01.868Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", upload-time = "2025-07-21T07:35:00.684Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896 },
 ]
 
 [[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", upload-time = "2025-05-17T13:52:37.26Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", upload-time = "2025-05-17T13:52:36.463Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922 },
 ]
 
 [[package]]
@@ -899,27 +899,27 @@ dependencies = [
     { name = "dnspython" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", upload-time = "2025-08-26T13:09:06.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", upload-time = "2025-08-26T13:09:05.858Z" },
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604 },
 ]
 
 [[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", upload-time = "2024-10-25T17:25:40.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", upload-time = "2024-10-25T17:25:39.051Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059 },
 ]
 
 [[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", upload-time = "2025-11-12T09:56:37.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", upload-time = "2025-11-12T09:56:36.333Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708 },
 ]
 
 [[package]]
@@ -933,18 +933,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/d4/811e7283aaaa84f1e7bd55fb642b58f8c01895e4884a9b7628cb55e00d63/fastapi-0.128.5.tar.gz", hash = "sha256:a7173579fc162d6471e3c6fbd9a4b7610c7a3b367bcacf6c4f90d5d022cab711", upload-time = "2026-02-08T10:22:30.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/d4/811e7283aaaa84f1e7bd55fb642b58f8c01895e4884a9b7628cb55e00d63/fastapi-0.128.5.tar.gz", hash = "sha256:a7173579fc162d6471e3c6fbd9a4b7610c7a3b367bcacf6c4f90d5d022cab711", size = 374636 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/e0/511972dba23ee76c0e9d09d1ae95e916fc8ebce5322b2b8b65a481428b10/fastapi-0.128.5-py3-none-any.whl", hash = "sha256:bceec0de8aa6564599c5bcc0593b0d287703562c848271fca8546fd2c87bf4dd", upload-time = "2026-02-08T10:22:28.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e0/511972dba23ee76c0e9d09d1ae95e916fc8ebce5322b2b8b65a481428b10/fastapi-0.128.5-py3-none-any.whl", hash = "sha256:bceec0de8aa6564599c5bcc0593b0d287703562c848271fca8546fd2c87bf4dd", size = 103677 },
 ]
 
 [[package]]
 name = "filelock"
 version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", upload-time = "2026-01-09T17:55:05.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", upload-time = "2026-01-09T17:55:04.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701 },
 ]
 
 [[package]]
@@ -959,9 +959,9 @@ dependencies = [
     { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87", upload-time = "2025-08-19T21:03:21.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87", size = 720160 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c", upload-time = "2025-08-19T21:03:19.499Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c", size = 103308 },
 ]
 
 [[package]]
@@ -972,9 +972,9 @@ dependencies = [
     { name = "flask" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/03/4e464a50860f9adf08b5c1d3479cb8ea1f12af2aa69535c7042c6e628135/flask_cors-6.0.5.tar.gz", hash = "sha256:30c5031552cd59f620ac0c8211dac45b345d3b2df310e7721879e4f46ef9c601", upload-time = "2026-06-08T20:20:17.765Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/03/4e464a50860f9adf08b5c1d3479cb8ea1f12af2aa69535c7042c6e628135/flask_cors-6.0.5.tar.gz", hash = "sha256:30c5031552cd59f620ac0c8211dac45b345d3b2df310e7721879e4f46ef9c601", size = 101386 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/55/5bb1a2d918e9f02f131e47a59032bae70e48050e986e941511fd737a935c/flask_cors-6.0.5-py3-none-any.whl", hash = "sha256:68fcf75693e961f3af26683b23c4b9a8fb6b64de17d20d0c37b95e8de7ab2ed8", upload-time = "2026-06-08T20:20:16.247Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5bb1a2d918e9f02f131e47a59032bae70e48050e986e941511fd737a935c/flask_cors-6.0.5-py3-none-any.whl", hash = "sha256:68fcf75693e961f3af26683b23c4b9a8fb6b64de17d20d0c37b95e8de7ab2ed8", size = 16692 },
 ]
 
 [[package]]
@@ -982,58 +982,67 @@ name = "flatbuffers"
 version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", upload-time = "2025-12-19T23:16:13.622Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661 },
 ]
 
 [[package]]
 name = "fonttools"
 version = "4.61.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/ca/cf17b88a8df95691275a3d77dc0a5ad9907f328ae53acbe6795da1b2f5ed/fonttools-4.61.1.tar.gz", hash = "sha256:6675329885c44657f826ef01d9e4fb33b9158e9d93c537d84ad8399539bc6f69", upload-time = "2025-12-12T17:31:24.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/ca/cf17b88a8df95691275a3d77dc0a5ad9907f328ae53acbe6795da1b2f5ed/fonttools-4.61.1.tar.gz", hash = "sha256:6675329885c44657f826ef01d9e4fb33b9158e9d93c537d84ad8399539bc6f69", size = 3565756 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/12/bf9f4eaa2fad039356cc627587e30ed008c03f1cebd3034376b5ee8d1d44/fonttools-4.61.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c6604b735bb12fef8e0efd5578c9fb5d3d8532d5001ea13a19cddf295673ee09", upload-time = "2025-12-12T17:29:46.675Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/49/4138d1acb6261499bedde1c07f8c2605d1d8f9d77a151e5507fd3ef084b6/fonttools-4.61.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5ce02f38a754f207f2f06557523cd39a06438ba3aafc0639c477ac409fc64e37", upload-time = "2025-12-12T17:29:48.769Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/fe/e6ce0fe20a40e03aef906af60aa87668696f9e4802fa283627d0b5ed777f/fonttools-4.61.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77efb033d8d7ff233385f30c62c7c79271c8885d5c9657d967ede124671bbdfb", upload-time = "2025-12-12T17:29:51.701Z" },
-    { url = "https://files.pythonhosted.org/packages/79/61/1ca198af22f7dd22c17ab86e9024ed3c06299cfdb08170640e9996d501a0/fonttools-4.61.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:75c1a6dfac6abd407634420c93864a1e274ebc1c7531346d9254c0d8f6ca00f9", upload-time = "2025-12-12T17:29:53.659Z" },
-    { url = "https://files.pythonhosted.org/packages/99/cc/fa1801e408586b5fce4da9f5455af8d770f4fc57391cd5da7256bb364d38/fonttools-4.61.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0de30bfe7745c0d1ffa2b0b7048fb7123ad0d71107e10ee090fa0b16b9452e87", upload-time = "2025-12-12T17:29:55.592Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/aa/b7aeafe65adb1b0a925f8f25725e09f078c635bc22754f3fecb7456955b0/fonttools-4.61.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:58b0ee0ab5b1fc9921eccfe11d1435added19d6494dde14e323f25ad2bc30c56", upload-time = "2025-12-12T17:29:57.861Z" },
-    { url = "https://files.pythonhosted.org/packages/99/f9/08ea7a38663328881384c6e7777bbefc46fd7d282adfd87a7d2b84ec9d50/fonttools-4.61.1-cp311-cp311-win32.whl", hash = "sha256:f79b168428351d11e10c5aeb61a74e1851ec221081299f4cf56036a95431c43a", upload-time = "2025-12-12T17:29:59.943Z" },
-    { url = "https://files.pythonhosted.org/packages/07/ad/37dd1ae5fa6e01612a1fbb954f0927681f282925a86e86198ccd7b15d515/fonttools-4.61.1-cp311-cp311-win_amd64.whl", hash = "sha256:fe2efccb324948a11dd09d22136fe2ac8a97d6c1347cf0b58a911dcd529f66b7", upload-time = "2025-12-12T17:30:02.254Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl", hash = "sha256:17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371", upload-time = "2025-12-12T17:31:21.03Z" },
+    { url = "https://files.pythonhosted.org/packages/69/12/bf9f4eaa2fad039356cc627587e30ed008c03f1cebd3034376b5ee8d1d44/fonttools-4.61.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c6604b735bb12fef8e0efd5578c9fb5d3d8532d5001ea13a19cddf295673ee09", size = 2852213 },
+    { url = "https://files.pythonhosted.org/packages/ac/49/4138d1acb6261499bedde1c07f8c2605d1d8f9d77a151e5507fd3ef084b6/fonttools-4.61.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5ce02f38a754f207f2f06557523cd39a06438ba3aafc0639c477ac409fc64e37", size = 2401689 },
+    { url = "https://files.pythonhosted.org/packages/e5/fe/e6ce0fe20a40e03aef906af60aa87668696f9e4802fa283627d0b5ed777f/fonttools-4.61.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77efb033d8d7ff233385f30c62c7c79271c8885d5c9657d967ede124671bbdfb", size = 5058809 },
+    { url = "https://files.pythonhosted.org/packages/79/61/1ca198af22f7dd22c17ab86e9024ed3c06299cfdb08170640e9996d501a0/fonttools-4.61.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:75c1a6dfac6abd407634420c93864a1e274ebc1c7531346d9254c0d8f6ca00f9", size = 5036039 },
+    { url = "https://files.pythonhosted.org/packages/99/cc/fa1801e408586b5fce4da9f5455af8d770f4fc57391cd5da7256bb364d38/fonttools-4.61.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0de30bfe7745c0d1ffa2b0b7048fb7123ad0d71107e10ee090fa0b16b9452e87", size = 5034714 },
+    { url = "https://files.pythonhosted.org/packages/bf/aa/b7aeafe65adb1b0a925f8f25725e09f078c635bc22754f3fecb7456955b0/fonttools-4.61.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:58b0ee0ab5b1fc9921eccfe11d1435added19d6494dde14e323f25ad2bc30c56", size = 5158648 },
+    { url = "https://files.pythonhosted.org/packages/99/f9/08ea7a38663328881384c6e7777bbefc46fd7d282adfd87a7d2b84ec9d50/fonttools-4.61.1-cp311-cp311-win32.whl", hash = "sha256:f79b168428351d11e10c5aeb61a74e1851ec221081299f4cf56036a95431c43a", size = 2280681 },
+    { url = "https://files.pythonhosted.org/packages/07/ad/37dd1ae5fa6e01612a1fbb954f0927681f282925a86e86198ccd7b15d515/fonttools-4.61.1-cp311-cp311-win_amd64.whl", hash = "sha256:fe2efccb324948a11dd09d22136fe2ac8a97d6c1347cf0b58a911dcd529f66b7", size = 2331951 },
+    { url = "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl", hash = "sha256:17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371", size = 1148996 },
 ]
 
 [[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", upload-time = "2025-10-06T05:38:17.865Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", upload-time = "2025-10-06T05:35:45.98Z" },
-    { url = "https://files.pythonhosted.org/packages/df/b5/7610b6bd13e4ae77b96ba85abea1c8cb249683217ef09ac9e0ae93f25a91/frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9", upload-time = "2025-10-06T05:35:47.009Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ef/0e8f1fe32f8a53dd26bdd1f9347efe0778b0fddf62789ea683f4cc7d787d/frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93", upload-time = "2025-10-06T05:35:48.38Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b1/71a477adc7c36e5fb628245dfbdea2166feae310757dea848d02bd0689fd/frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f", upload-time = "2025-10-06T05:35:49.97Z" },
-    { url = "https://files.pythonhosted.org/packages/45/7e/afe40eca3a2dc19b9904c0f5d7edfe82b5304cb831391edec0ac04af94c2/frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695", upload-time = "2025-10-06T05:35:51.729Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/aa/7416eac95603ce428679d273255ffc7c998d4132cfae200103f164b108aa/frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52", upload-time = "2025-10-06T05:35:53.246Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/3d/2a2d1f683d55ac7e3875e4263d28410063e738384d3adc294f5ff3d7105e/frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581", upload-time = "2025-10-06T05:35:54.497Z" },
-    { url = "https://files.pythonhosted.org/packages/78/1e/2d5565b589e580c296d3bb54da08d206e797d941a83a6fdea42af23be79c/frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567", upload-time = "2025-10-06T05:35:55.861Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c3/65872fcf1d326a7f101ad4d86285c403c87be7d832b7470b77f6d2ed5ddc/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b", upload-time = "2025-10-06T05:35:57.399Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/76/ac9ced601d62f6956f03cc794f9e04c81719509f85255abf96e2510f4265/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92", upload-time = "2025-10-06T05:35:58.563Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/49/ecccb5f2598daf0b4a1415497eba4c33c1e8ce07495eb07d2860c731b8d5/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d", upload-time = "2025-10-06T05:35:59.719Z" },
-    { url = "https://files.pythonhosted.org/packages/53/4b/ddf24113323c0bbcc54cb38c8b8916f1da7165e07b8e24a717b4a12cbf10/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd", upload-time = "2025-10-06T05:36:00.959Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/fb/9b9a084d73c67175484ba2789a59f8eebebd0827d186a8102005ce41e1ba/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967", upload-time = "2025-10-06T05:36:02.22Z" },
-    { url = "https://files.pythonhosted.org/packages/95/a3/c8fb25aac55bf5e12dae5c5aa6a98f85d436c1dc658f21c3ac73f9fa95e5/frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25", upload-time = "2025-10-06T05:36:03.409Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/f5/603d0d6a02cfd4c8f2a095a54672b3cf967ad688a60fb9faf04fc4887f65/frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b", upload-time = "2025-10-06T05:36:04.368Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/16/c2c9ab44e181f043a86f9a8f84d5124b62dbcb3a02c0977ec72b9ac1d3e0/frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a", upload-time = "2025-10-06T05:36:05.669Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", upload-time = "2025-10-06T05:38:16.721Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", size = 86912 },
+    { url = "https://files.pythonhosted.org/packages/df/b5/7610b6bd13e4ae77b96ba85abea1c8cb249683217ef09ac9e0ae93f25a91/frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9", size = 50046 },
+    { url = "https://files.pythonhosted.org/packages/6e/ef/0e8f1fe32f8a53dd26bdd1f9347efe0778b0fddf62789ea683f4cc7d787d/frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93", size = 50119 },
+    { url = "https://files.pythonhosted.org/packages/11/b1/71a477adc7c36e5fb628245dfbdea2166feae310757dea848d02bd0689fd/frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f", size = 231067 },
+    { url = "https://files.pythonhosted.org/packages/45/7e/afe40eca3a2dc19b9904c0f5d7edfe82b5304cb831391edec0ac04af94c2/frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695", size = 233160 },
+    { url = "https://files.pythonhosted.org/packages/a6/aa/7416eac95603ce428679d273255ffc7c998d4132cfae200103f164b108aa/frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52", size = 228544 },
+    { url = "https://files.pythonhosted.org/packages/8b/3d/2a2d1f683d55ac7e3875e4263d28410063e738384d3adc294f5ff3d7105e/frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581", size = 243797 },
+    { url = "https://files.pythonhosted.org/packages/78/1e/2d5565b589e580c296d3bb54da08d206e797d941a83a6fdea42af23be79c/frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567", size = 247923 },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/65872fcf1d326a7f101ad4d86285c403c87be7d832b7470b77f6d2ed5ddc/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b", size = 230886 },
+    { url = "https://files.pythonhosted.org/packages/a0/76/ac9ced601d62f6956f03cc794f9e04c81719509f85255abf96e2510f4265/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92", size = 245731 },
+    { url = "https://files.pythonhosted.org/packages/b9/49/ecccb5f2598daf0b4a1415497eba4c33c1e8ce07495eb07d2860c731b8d5/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d", size = 241544 },
+    { url = "https://files.pythonhosted.org/packages/53/4b/ddf24113323c0bbcc54cb38c8b8916f1da7165e07b8e24a717b4a12cbf10/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd", size = 241806 },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/9b9a084d73c67175484ba2789a59f8eebebd0827d186a8102005ce41e1ba/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967", size = 229382 },
+    { url = "https://files.pythonhosted.org/packages/95/a3/c8fb25aac55bf5e12dae5c5aa6a98f85d436c1dc658f21c3ac73f9fa95e5/frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25", size = 39647 },
+    { url = "https://files.pythonhosted.org/packages/0a/f5/603d0d6a02cfd4c8f2a095a54672b3cf967ad688a60fb9faf04fc4887f65/frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b", size = 44064 },
+    { url = "https://files.pythonhosted.org/packages/5d/16/c2c9ab44e181f043a86f9a8f84d5124b62dbcb3a02c0977ec72b9ac1d3e0/frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a", size = 39937 },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409 },
 ]
 
 [[package]]
 name = "fsspec"
 version = "2026.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", upload-time = "2026-02-05T21:50:53.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", upload-time = "2026-02-05T21:50:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505 },
+]
+
+[[package]]
+name = "gepa"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/56/925779e5690971f1b022f7d107caf015c33ec09560261273ec137e23a8f2/gepa-0.1.4.tar.gz", hash = "sha256:6dd153a676ae5481764860d19286a9c0e8ddb5ef70d7f13044faf24978bdb6b8", size = 351343 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/77/5b3a281cfd9caaa9e68349b434cf27f1ca448003ee0067a1ae2184dc52d1/gepa-0.1.4-py3-none-any.whl", hash = "sha256:12b971039599625c156d2231f6d72a29c31a22e9c237689459b5f1a3c353f532", size = 290167 },
 ]
 
 [[package]]
@@ -1043,9 +1052,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "smmap" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", upload-time = "2025-01-02T07:20:46.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", upload-time = "2025-01-02T07:20:43.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794 },
 ]
 
 [[package]]
@@ -1055,9 +1064,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620 },
 ]
 
 [[package]]
@@ -1071,9 +1080,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/10/05572d33273292bac49c2d1785925f7bc3ff2fe50e3044cf1062c1dde32e/google_api_core-2.29.0.tar.gz", hash = "sha256:84181be0f8e6b04006df75ddfe728f24489f0af57c96a529ff7cf45bc28797f7", upload-time = "2026-01-08T22:21:39.269Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/10/05572d33273292bac49c2d1785925f7bc3ff2fe50e3044cf1062c1dde32e/google_api_core-2.29.0.tar.gz", hash = "sha256:84181be0f8e6b04006df75ddfe728f24489f0af57c96a529ff7cf45bc28797f7", size = 177828 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/b6/85c4d21067220b9a78cfb81f516f9725ea6befc1544ec9bd2c1acd97c324/google_api_core-2.29.0-py3-none-any.whl", hash = "sha256:d30bc60980daa36e314b5d5a3e5958b0200cb44ca8fa1be2b614e932b75a3ea9", upload-time = "2026-01-08T22:21:36.093Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b6/85c4d21067220b9a78cfb81f516f9725ea6befc1544ec9bd2c1acd97c324/google_api_core-2.29.0-py3-none-any.whl", hash = "sha256:d30bc60980daa36e314b5d5a3e5958b0200cb44ca8fa1be2b614e932b75a3ea9", size = 173906 },
 ]
 
 [[package]]
@@ -1087,9 +1096,9 @@ dependencies = [
     { name = "httplib2" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/f8/0783aeca3410ee053d4dd1fccafd85197847b8f84dd038e036634605d083/google_api_python_client-2.189.0.tar.gz", hash = "sha256:45f2d8559b5c895dde6ad3fb33de025f5cb2c197fa5862f18df7f5295a172741", upload-time = "2026-02-03T19:24:55.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/f8/0783aeca3410ee053d4dd1fccafd85197847b8f84dd038e036634605d083/google_api_python_client-2.189.0.tar.gz", hash = "sha256:45f2d8559b5c895dde6ad3fb33de025f5cb2c197fa5862f18df7f5295a172741", size = 13979470 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/44/3677ff27998214f2fa7957359da48da378a0ffff1bd0bdaba42e752bc13e/google_api_python_client-2.189.0-py3-none-any.whl", hash = "sha256:a258c09660a49c6159173f8bbece171278e917e104a11f0640b34751b79c8a1a", upload-time = "2026-02-03T19:24:52.845Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/3677ff27998214f2fa7957359da48da378a0ffff1bd0bdaba42e752bc13e/google_api_python_client-2.189.0-py3-none-any.whl", hash = "sha256:a258c09660a49c6159173f8bbece171278e917e104a11f0640b34751b79c8a1a", size = 14547633 },
 ]
 
 [[package]]
@@ -1101,9 +1110,9 @@ dependencies = [
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", upload-time = "2026-01-26T19:22:47.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", upload-time = "2026-01-26T19:22:45.099Z" },
+    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499 },
 ]
 
 [[package]]
@@ -1114,9 +1123,9 @@ dependencies = [
     { name = "google-auth" },
     { name = "httplib2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/ad/c1f2b1175096a8d04cf202ad5ea6065f108d26be6fc7215876bde4a7981d/google_auth_httplib2-0.3.0.tar.gz", hash = "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b", upload-time = "2025-12-15T22:13:51.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/ad/c1f2b1175096a8d04cf202ad5ea6065f108d26be6fc7215876bde4a7981d/google_auth_httplib2-0.3.0.tar.gz", hash = "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b", size = 11134 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/d5/3c97526c8796d3caf5f4b3bed2b05e8a7102326f00a334e7a438237f3b22/google_auth_httplib2-0.3.0-py3-none-any.whl", hash = "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776", upload-time = "2025-12-15T22:13:51.048Z" },
+    { url = "https://files.pythonhosted.org/packages/99/d5/3c97526c8796d3caf5f4b3bed2b05e8a7102326f00a334e7a438237f3b22/google_auth_httplib2-0.3.0-py3-none-any.whl", hash = "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776", size = 9529 },
 ]
 
 [[package]]
@@ -1126,9 +1135,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", upload-time = "2025-11-06T18:29:24.087Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", upload-time = "2025-11-06T18:29:13.14Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515 },
 ]
 
 [[package]]
@@ -1141,18 +1150,18 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/f6/bf62ff950c317ed03e77f3f6ddd7e34aaa98fe89d79ebd660c55343d8054/graphene-3.4.3.tar.gz", hash = "sha256:2a3786948ce75fe7e078443d37f609cbe5bb36ad8d6b828740ad3b95ed1a0aaa", upload-time = "2024-11-09T20:44:25.757Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/f6/bf62ff950c317ed03e77f3f6ddd7e34aaa98fe89d79ebd660c55343d8054/graphene-3.4.3.tar.gz", hash = "sha256:2a3786948ce75fe7e078443d37f609cbe5bb36ad8d6b828740ad3b95ed1a0aaa", size = 44739 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/e0/61d8e98007182e6b2aca7cf65904721fb2e4bce0192272ab9cb6f69d8812/graphene-3.4.3-py2.py3-none-any.whl", hash = "sha256:820db6289754c181007a150db1f7fff544b94142b556d12e3ebc777a7bf36c71", upload-time = "2024-11-09T20:44:23.851Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e0/61d8e98007182e6b2aca7cf65904721fb2e4bce0192272ab9cb6f69d8812/graphene-3.4.3-py2.py3-none-any.whl", hash = "sha256:820db6289754c181007a150db1f7fff544b94142b556d12e3ebc777a7bf36c71", size = 114894 },
 ]
 
 [[package]]
 name = "graphql-core"
 version = "3.2.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/9b/037a640a2983b09aed4a823f9cf1729e6d780b0671f854efa4727a7affbe/graphql_core-3.2.7.tar.gz", hash = "sha256:27b6904bdd3b43f2a0556dad5d579bdfdeab1f38e8e8788e555bdcb586a6f62c", upload-time = "2025-11-01T22:30:40.436Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/9b/037a640a2983b09aed4a823f9cf1729e6d780b0671f854efa4727a7affbe/graphql_core-3.2.7.tar.gz", hash = "sha256:27b6904bdd3b43f2a0556dad5d579bdfdeab1f38e8e8788e555bdcb586a6f62c", size = 513484 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/14/933037032608787fb92e365883ad6a741c235e0ff992865ec5d904a38f1e/graphql_core-3.2.7-py3-none-any.whl", hash = "sha256:17fc8f3ca4a42913d8e24d9ac9f08deddf0a0b2483076575757f6c412ead2ec0", upload-time = "2025-11-01T22:30:38.912Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/14/933037032608787fb92e365883ad6a741c235e0ff992865ec5d904a38f1e/graphql_core-3.2.7-py3-none-any.whl", hash = "sha256:17fc8f3ca4a42913d8e24d9ac9f08deddf0a0b2483076575757f6c412ead2ec0", size = 207262 },
 ]
 
 [[package]]
@@ -1162,26 +1171,26 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "graphql-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/13/98fbf8d67552f102488ffc16c6f559ce71ea15f6294728d33928ab5ff14d/graphql-relay-3.2.0.tar.gz", hash = "sha256:1ff1c51298356e481a0be009ccdff249832ce53f30559c1338f22a0e0d17250c", upload-time = "2022-04-16T11:03:45.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/13/98fbf8d67552f102488ffc16c6f559ce71ea15f6294728d33928ab5ff14d/graphql-relay-3.2.0.tar.gz", hash = "sha256:1ff1c51298356e481a0be009ccdff249832ce53f30559c1338f22a0e0d17250c", size = 50027 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/16/a4cf06adbc711bd364a73ce043b0b08d8fa5aae3df11b6ee4248bcdad2e0/graphql_relay-3.2.0-py3-none-any.whl", hash = "sha256:c9b22bd28b170ba1fe674c74384a8ff30a76c8e26f88ac3aa1584dd3179953e5", upload-time = "2022-04-16T11:03:43.895Z" },
+    { url = "https://files.pythonhosted.org/packages/74/16/a4cf06adbc711bd364a73ce043b0b08d8fa5aae3df11b6ee4248bcdad2e0/graphql_relay-3.2.0-py3-none-any.whl", hash = "sha256:c9b22bd28b170ba1fe674c74384a8ff30a76c8e26f88ac3aa1584dd3179953e5", size = 16940 },
 ]
 
 [[package]]
 name = "greenlet"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/99/1cd3411c56a410994669062bd73dd58270c00cc074cac15f385a1fd91f8a/greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98", upload-time = "2026-01-23T15:31:02.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/99/1cd3411c56a410994669062bd73dd58270c00cc074cac15f385a1fd91f8a/greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98", size = 184690 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", upload-time = "2026-01-23T15:31:02.891Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", upload-time = "2026-01-23T16:00:56.213Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", upload-time = "2026-01-23T16:05:26.365Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", upload-time = "2026-01-23T16:15:53.456Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", upload-time = "2026-01-23T15:32:49.411Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", upload-time = "2026-01-23T16:04:20.867Z" },
-    { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", upload-time = "2026-01-23T15:33:45.743Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/54/dcf9f737b96606f82f8dd05becfb8d238db0633dd7397d542a296fe9cad3/greenlet-3.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:32e4ca9777c5addcbf42ff3915d99030d8e00173a56f80001fb3875998fe410b", upload-time = "2026-01-23T15:36:50.422Z" },
-    { url = "https://files.pythonhosted.org/packages/91/37/61e1015cf944ddd2337447d8e97fb423ac9bc21f9963fb5f206b53d65649/greenlet-3.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:da19609432f353fed186cc1b85e9440db93d489f198b4bdf42ae19cc9d9ac9b4", upload-time = "2026-01-23T15:33:17.298Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974 },
+    { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175 },
+    { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401 },
+    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", size = 601161 },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", size = 590272 },
+    { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", size = 1550729 },
+    { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", size = 1615552 },
+    { url = "https://files.pythonhosted.org/packages/1f/54/dcf9f737b96606f82f8dd05becfb8d238db0633dd7397d542a296fe9cad3/greenlet-3.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:32e4ca9777c5addcbf42ff3915d99030d8e00173a56f80001fb3875998fe410b", size = 226462 },
+    { url = "https://files.pythonhosted.org/packages/91/37/61e1015cf944ddd2337447d8e97fb423ac9bc21f9963fb5f206b53d65649/greenlet-3.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:da19609432f353fed186cc1b85e9440db93d489f198b4bdf42ae19cc9d9ac9b4", size = 225715 },
 ]
 
 [[package]]
@@ -1191,18 +1200,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", upload-time = "2026-02-06T09:57:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", upload-time = "2026-02-06T09:55:01.989Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", upload-time = "2026-02-06T09:55:04.462Z" },
-    { url = "https://files.pythonhosted.org/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", upload-time = "2026-02-06T09:55:07.111Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/52/e7c1f3688f949058e19a011c4e0dec973da3d0ae5e033909677f967ae1f4/grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e", upload-time = "2026-02-06T09:55:10.016Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/61/8ac32517c1e856677282c34f2e7812d6c328fa02b8f4067ab80e77fdc9c9/grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303", upload-time = "2026-02-06T09:55:12.207Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/98/b8ee0158199250220734f620b12e4a345955ac7329cfd908d0bf0fda77f0/grpcio-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f12857d24d98441af6a1d5c87442d624411db486f7ba12550b07788f74b67b04", upload-time = "2026-02-06T09:55:15.044Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/0f/7b72762e0d8840b58032a56fdbd02b78fc645b9fa993d71abf04edbc54f4/grpcio-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5397fff416b79e4b284959642a4e95ac4b0f1ece82c9993658e0e477d40551ec", upload-time = "2026-02-06T09:55:17.276Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ae/ae4ce56bc5bb5caa3a486d60f5f6083ac3469228faa734362487176c15c5/grpcio-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbe6e89c7ffb48518384068321621b2a69cab509f58e40e4399fdd378fa6d074", upload-time = "2026-02-06T09:55:19.545Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/6e/8052e3a28eb6a820c372b2eb4b5e32d195c661e137d3eca94d534a4cfd8a/grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856", upload-time = "2026-02-06T09:55:21.521Z" },
-    { url = "https://files.pythonhosted.org/packages/08/62/f22c98c5265dfad327251fa2f840b591b1df5f5e15d88b19c18c86965b27/grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558", upload-time = "2026-02-06T09:55:24.107Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", size = 5951525 },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", size = 11830418 },
+    { url = "https://files.pythonhosted.org/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", size = 6524477 },
+    { url = "https://files.pythonhosted.org/packages/8d/52/e7c1f3688f949058e19a011c4e0dec973da3d0ae5e033909677f967ae1f4/grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e", size = 7198266 },
+    { url = "https://files.pythonhosted.org/packages/e5/61/8ac32517c1e856677282c34f2e7812d6c328fa02b8f4067ab80e77fdc9c9/grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303", size = 6730552 },
+    { url = "https://files.pythonhosted.org/packages/bd/98/b8ee0158199250220734f620b12e4a345955ac7329cfd908d0bf0fda77f0/grpcio-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f12857d24d98441af6a1d5c87442d624411db486f7ba12550b07788f74b67b04", size = 7304296 },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/7b72762e0d8840b58032a56fdbd02b78fc645b9fa993d71abf04edbc54f4/grpcio-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5397fff416b79e4b284959642a4e95ac4b0f1ece82c9993658e0e477d40551ec", size = 8288298 },
+    { url = "https://files.pythonhosted.org/packages/24/ae/ae4ce56bc5bb5caa3a486d60f5f6083ac3469228faa734362487176c15c5/grpcio-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbe6e89c7ffb48518384068321621b2a69cab509f58e40e4399fdd378fa6d074", size = 7730953 },
+    { url = "https://files.pythonhosted.org/packages/b5/6e/8052e3a28eb6a820c372b2eb4b5e32d195c661e137d3eca94d534a4cfd8a/grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856", size = 4076503 },
+    { url = "https://files.pythonhosted.org/packages/08/62/f22c98c5265dfad327251fa2f840b591b1df5f5e15d88b19c18c86965b27/grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558", size = 4799767 },
 ]
 
 [[package]]
@@ -1214,9 +1223,9 @@ dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/d1/2397797c810020eac424e1aac10fbdc5edb6b9b4ad6617e0ed53ca907653/grpcio_status-1.70.0.tar.gz", hash = "sha256:0e7b42816512433b18b9d764285ff029bde059e9d41f8fe10a60631bd8348101", upload-time = "2025-01-23T18:00:33.637Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/d1/2397797c810020eac424e1aac10fbdc5edb6b9b4ad6617e0ed53ca907653/grpcio_status-1.70.0.tar.gz", hash = "sha256:0e7b42816512433b18b9d764285ff029bde059e9d41f8fe10a60631bd8348101", size = 13681 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/34/49e558040e069feebac70cdd1b605f38738c0277ac5d38e2ce3d03e1b1ec/grpcio_status-1.70.0-py3-none-any.whl", hash = "sha256:fc5a2ae2b9b1c1969cc49f3262676e6854aa2398ec69cb5bd6c47cd501904a85", upload-time = "2025-01-23T17:57:35.392Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/34/49e558040e069feebac70cdd1b605f38738c0277ac5d38e2ce3d03e1b1ec/grpcio_status-1.70.0-py3-none-any.whl", hash = "sha256:fc5a2ae2b9b1c1969cc49f3262676e6854aa2398ec69cb5bd6c47cd501904a85", size = 14429 },
 ]
 
 [[package]]
@@ -1226,33 +1235,33 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", upload-time = "2024-08-10T20:25:27.378Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", upload-time = "2024-08-10T20:25:24.996Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029 },
 ]
 
 [[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", upload-time = "2025-04-24T03:35:25.427Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", upload-time = "2025-04-24T03:35:24.344Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
 ]
 
 [[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099 },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178 },
+    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214 },
+    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054 },
+    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812 },
+    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920 },
+    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735 },
 ]
 
 [[package]]
@@ -1263,9 +1272,9 @@ dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
 ]
 
 [[package]]
@@ -1275,24 +1284,24 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099 },
 ]
 
 [[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", upload-time = "2025-10-10T03:55:08.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", upload-time = "2025-10-10T03:54:31.002Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", upload-time = "2025-10-10T03:54:31.941Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", upload-time = "2025-10-10T03:54:33.176Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", upload-time = "2025-10-10T03:54:34.226Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", upload-time = "2025-10-10T03:54:35.942Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", upload-time = "2025-10-10T03:54:37.1Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", upload-time = "2025-10-10T03:54:38.421Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521 },
+    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375 },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621 },
+    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954 },
+    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175 },
+    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310 },
+    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875 },
 ]
 
 [[package]]
@@ -1305,9 +1314,9 @@ dependencies = [
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [package.optional-dependencies]
@@ -1319,18 +1328,18 @@ zstd = [
 name = "httpx-sse"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", upload-time = "2023-12-22T08:01:21.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", upload-time = "2023-12-22T08:01:19.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
 ]
 
 [[package]]
 name = "huey"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/cb/58f229149944602917a976d533d3fe7d54770d6ea18df5931e3f4f313fa0/huey-3.0.3.tar.gz", hash = "sha256:1a17fef95fc8432f75413f1b77439cef5f3493c1ddbfba9151756b31a1b2dad3", upload-time = "2026-06-12T01:53:55.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/cb/58f229149944602917a976d533d3fe7d54770d6ea18df5931e3f4f313fa0/huey-3.0.3.tar.gz", hash = "sha256:1a17fef95fc8432f75413f1b77439cef5f3493c1ddbfba9151756b31a1b2dad3", size = 263604 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/82/f85d8918949786420716a5e421525ab12aa084bcbe32d86c9743e50bcf3d/huey-3.0.3-py3-none-any.whl", hash = "sha256:d1c687734778b8282c035a943eead8368c1736bb28abc006596fbbc01bdc96dc", upload-time = "2026-06-12T01:53:53.981Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/82/f85d8918949786420716a5e421525ab12aa084bcbe32d86c9743e50bcf3d/huey-3.0.3-py3-none-any.whl", hash = "sha256:d1c687734778b8282c035a943eead8368c1736bb28abc006596fbbc01bdc96dc", size = 94945 },
 ]
 
 [[package]]
@@ -1347,18 +1356,18 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", upload-time = "2026-02-06T09:24:13.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", upload-time = "2026-02-06T09:24:11.133Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395 },
 ]
 
 [[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008 },
 ]
 
 [[package]]
@@ -1368,27 +1377,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", upload-time = "2025-12-21T10:00:19.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", upload-time = "2025-12-21T10:00:18.329Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865 },
 ]
 
 [[package]]
 name = "importlib-resources"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", upload-time = "2025-01-03T18:51:56.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", upload-time = "2025-01-03T18:51:54.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461 },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", upload-time = "2025-10-18T21:55:43.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", upload-time = "2025-10-18T21:55:41.639Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
 ]
 
 [[package]]
@@ -1408,27 +1417,27 @@ dependencies = [
     { name = "tenacity" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/a4/832cfb15420360e26d2d85bd9d5fe1e4b839d52587574d389bc31284bf6f/instructor-1.15.1.tar.gz", hash = "sha256:c72406469d9025b742e83cf0c13e914b317db2089d08d889944e74fcd659ef94", upload-time = "2026-04-03T01:51:30.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a4/832cfb15420360e26d2d85bd9d5fe1e4b839d52587574d389bc31284bf6f/instructor-1.15.1.tar.gz", hash = "sha256:c72406469d9025b742e83cf0c13e914b317db2089d08d889944e74fcd659ef94", size = 69948370 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/c8/36c5d9b80aaf40ba9a7084a8fc18c967db6bf248a4cc8d0f0816b14284be/instructor-1.15.1-py3-none-any.whl", hash = "sha256:be81d17ba2b154a04ab4720808f24f9d6b598f80992f82eaf9cc79006099cf6c", upload-time = "2026-04-03T01:51:23.098Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c8/36c5d9b80aaf40ba9a7084a8fc18c967db6bf248a4cc8d0f0816b14284be/instructor-1.15.1-py3-none-any.whl", hash = "sha256:be81d17ba2b154a04ab4720808f24f9d6b598f80992f82eaf9cc79006099cf6c", size = 178156 },
 ]
 
 [[package]]
 name = "isort"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", upload-time = "2025-10-11T13:30:59.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", upload-time = "2025-10-11T13:30:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672 },
 ]
 
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", upload-time = "2024-04-16T21:28:15.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", upload-time = "2024-04-16T21:28:14.499Z" },
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234 },
 ]
 
 [[package]]
@@ -1438,65 +1447,65 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", upload-time = "2025-03-05T20:05:02.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", upload-time = "2025-03-05T20:05:00.369Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]
 name = "jiter"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/9d/ae7ddb4b8ab3fb1b51faf4deb36cb48a4fbbd7cb36bad6a5fca4741306f7/jiter-0.10.0.tar.gz", hash = "sha256:07a7142c38aacc85194391108dc91b5b57093c978a9932bd86a36862759d9500", upload-time = "2025-05-18T19:04:59.73Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/9d/ae7ddb4b8ab3fb1b51faf4deb36cb48a4fbbd7cb36bad6a5fca4741306f7/jiter-0.10.0.tar.gz", hash = "sha256:07a7142c38aacc85194391108dc91b5b57093c978a9932bd86a36862759d9500", size = 162759 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/dd/6cefc6bd68b1c3c979cecfa7029ab582b57690a31cd2f346c4d0ce7951b6/jiter-0.10.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3bebe0c558e19902c96e99217e0b8e8b17d570906e72ed8a87170bc290b1e978", upload-time = "2025-05-18T19:03:25.942Z" },
-    { url = "https://files.pythonhosted.org/packages/be/cf/fc33f5159ce132be1d8dd57251a1ec7a631c7df4bd11e1cd198308c6ae32/jiter-0.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:558cc7e44fd8e507a236bee6a02fa17199ba752874400a0ca6cd6e2196cdb7dc", upload-time = "2025-05-18T19:03:27.255Z" },
-    { url = "https://files.pythonhosted.org/packages/68/a4/da3f150cf1d51f6c472616fb7650429c7ce053e0c962b41b68557fdf6379/jiter-0.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d613e4b379a07d7c8453c5712ce7014e86c6ac93d990a0b8e7377e18505e98d", upload-time = "2025-05-18T19:03:28.63Z" },
-    { url = "https://files.pythonhosted.org/packages/84/34/6e8d412e60ff06b186040e77da5f83bc158e9735759fcae65b37d681f28b/jiter-0.10.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f62cf8ba0618eda841b9bf61797f21c5ebd15a7a1e19daab76e4e4b498d515b2", upload-time = "2025-05-18T19:03:30.292Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d9/9ee86173aae4576c35a2f50ae930d2ccb4c4c236f6cb9353267aa1d626b7/jiter-0.10.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:919d139cdfa8ae8945112398511cb7fca58a77382617d279556b344867a37e61", upload-time = "2025-05-18T19:03:31.654Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/2c/f955de55e74771493ac9e188b0f731524c6a995dffdcb8c255b89c6fb74b/jiter-0.10.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13ddbc6ae311175a3b03bd8994881bc4635c923754932918e18da841632349db", upload-time = "2025-05-18T19:03:33.184Z" },
-    { url = "https://files.pythonhosted.org/packages/81/5a/0e73541b6edd3f4aada586c24e50626c7815c561a7ba337d6a7eb0a915b4/jiter-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c440ea003ad10927a30521a9062ce10b5479592e8a70da27f21eeb457b4a9c5", upload-time = "2025-05-18T19:03:34.965Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c0/61eeec33b8c75b31cae42be14d44f9e6fe3ac15a4e58010256ac3abf3638/jiter-0.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dc347c87944983481e138dea467c0551080c86b9d21de6ea9306efb12ca8f606", upload-time = "2025-05-18T19:03:36.436Z" },
-    { url = "https://files.pythonhosted.org/packages/41/22/5beb5ee4ad4ef7d86f5ea5b4509f680a20706c4a7659e74344777efb7739/jiter-0.10.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:13252b58c1f4d8c5b63ab103c03d909e8e1e7842d302473f482915d95fefd605", upload-time = "2025-05-18T19:03:38.168Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/10/768e8818538e5817c637b0df52e54366ec4cebc3346108a4457ea7a98f32/jiter-0.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7d1bbf3c465de4a24ab12fb7766a0003f6f9bce48b8b6a886158c4d569452dc5", upload-time = "2025-05-18T19:03:39.577Z" },
-    { url = "https://files.pythonhosted.org/packages/73/6d/29b7c2dc76ce93cbedabfd842fc9096d01a0550c52692dfc33d3cc889815/jiter-0.10.0-cp311-cp311-win32.whl", hash = "sha256:db16e4848b7e826edca4ccdd5b145939758dadf0dc06e7007ad0e9cfb5928ae7", upload-time = "2025-05-18T19:03:41.271Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c9/d394706deb4c660137caf13e33d05a031d734eb99c051142e039d8ceb794/jiter-0.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:9c9c1d5f10e18909e993f9641f12fe1c77b3e9b533ee94ffa970acc14ded3812", upload-time = "2025-05-18T19:03:42.918Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dd/6cefc6bd68b1c3c979cecfa7029ab582b57690a31cd2f346c4d0ce7951b6/jiter-0.10.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3bebe0c558e19902c96e99217e0b8e8b17d570906e72ed8a87170bc290b1e978", size = 317473 },
+    { url = "https://files.pythonhosted.org/packages/be/cf/fc33f5159ce132be1d8dd57251a1ec7a631c7df4bd11e1cd198308c6ae32/jiter-0.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:558cc7e44fd8e507a236bee6a02fa17199ba752874400a0ca6cd6e2196cdb7dc", size = 321971 },
+    { url = "https://files.pythonhosted.org/packages/68/a4/da3f150cf1d51f6c472616fb7650429c7ce053e0c962b41b68557fdf6379/jiter-0.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d613e4b379a07d7c8453c5712ce7014e86c6ac93d990a0b8e7377e18505e98d", size = 345574 },
+    { url = "https://files.pythonhosted.org/packages/84/34/6e8d412e60ff06b186040e77da5f83bc158e9735759fcae65b37d681f28b/jiter-0.10.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f62cf8ba0618eda841b9bf61797f21c5ebd15a7a1e19daab76e4e4b498d515b2", size = 371028 },
+    { url = "https://files.pythonhosted.org/packages/fb/d9/9ee86173aae4576c35a2f50ae930d2ccb4c4c236f6cb9353267aa1d626b7/jiter-0.10.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:919d139cdfa8ae8945112398511cb7fca58a77382617d279556b344867a37e61", size = 491083 },
+    { url = "https://files.pythonhosted.org/packages/d9/2c/f955de55e74771493ac9e188b0f731524c6a995dffdcb8c255b89c6fb74b/jiter-0.10.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13ddbc6ae311175a3b03bd8994881bc4635c923754932918e18da841632349db", size = 388821 },
+    { url = "https://files.pythonhosted.org/packages/81/5a/0e73541b6edd3f4aada586c24e50626c7815c561a7ba337d6a7eb0a915b4/jiter-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c440ea003ad10927a30521a9062ce10b5479592e8a70da27f21eeb457b4a9c5", size = 352174 },
+    { url = "https://files.pythonhosted.org/packages/1c/c0/61eeec33b8c75b31cae42be14d44f9e6fe3ac15a4e58010256ac3abf3638/jiter-0.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dc347c87944983481e138dea467c0551080c86b9d21de6ea9306efb12ca8f606", size = 391869 },
+    { url = "https://files.pythonhosted.org/packages/41/22/5beb5ee4ad4ef7d86f5ea5b4509f680a20706c4a7659e74344777efb7739/jiter-0.10.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:13252b58c1f4d8c5b63ab103c03d909e8e1e7842d302473f482915d95fefd605", size = 523741 },
+    { url = "https://files.pythonhosted.org/packages/ea/10/768e8818538e5817c637b0df52e54366ec4cebc3346108a4457ea7a98f32/jiter-0.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7d1bbf3c465de4a24ab12fb7766a0003f6f9bce48b8b6a886158c4d569452dc5", size = 514527 },
+    { url = "https://files.pythonhosted.org/packages/73/6d/29b7c2dc76ce93cbedabfd842fc9096d01a0550c52692dfc33d3cc889815/jiter-0.10.0-cp311-cp311-win32.whl", hash = "sha256:db16e4848b7e826edca4ccdd5b145939758dadf0dc06e7007ad0e9cfb5928ae7", size = 210765 },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/d394706deb4c660137caf13e33d05a031d734eb99c051142e039d8ceb794/jiter-0.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:9c9c1d5f10e18909e993f9641f12fe1c77b3e9b533ee94ffa970acc14ded3812", size = 209234 },
 ]
 
 [[package]]
 name = "jmespath"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", upload-time = "2026-01-22T16:35:26.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", upload-time = "2026-01-22T16:35:24.919Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419 },
 ]
 
 [[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", upload-time = "2025-12-15T08:41:46.427Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", upload-time = "2025-12-15T08:41:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071 },
 ]
 
 [[package]]
 name = "json-repair"
 version = "0.25.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/60/484ee009c1867ddc5ffe0ff2131b82e80bbf13fdb59f3d93834f98e56a9f/json_repair-0.25.3.tar.gz", hash = "sha256:4ee970581a05b0b258b749eb8bcac21de380edda97c3717a4edfafc519ec21a4", upload-time = "2024-07-10T13:42:18.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/60/484ee009c1867ddc5ffe0ff2131b82e80bbf13fdb59f3d93834f98e56a9f/json_repair-0.25.3.tar.gz", hash = "sha256:4ee970581a05b0b258b749eb8bcac21de380edda97c3717a4edfafc519ec21a4", size = 20619 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/9e/2ab68cc0ff030e1ef78329d7b933473d3ad2c7d0e66aede6a7c87f74753c/json_repair-0.25.3-py3-none-any.whl", hash = "sha256:f00b510dd21b31ebe72581bdb07e66381df2883d6f640c89605e482882c12b17", upload-time = "2024-07-10T13:42:16.918Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/2ab68cc0ff030e1ef78329d7b933473d3ad2c7d0e66aede6a7c87f74753c/json_repair-0.25.3-py3-none-any.whl", hash = "sha256:f00b510dd21b31ebe72581bdb07e66381df2883d6f640c89605e482882c12b17", size = 12812 },
 ]
 
 [[package]]
 name = "json5"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/3d/bbe62f3d0c05a689c711cff57b2e3ac3d3e526380adb7c781989f075115c/json5-0.10.0.tar.gz", hash = "sha256:e66941c8f0a02026943c52c2eb34ebeb2a6f819a0be05920a6f5243cd30fd559", upload-time = "2024-11-26T19:56:37.823Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/3d/bbe62f3d0c05a689c711cff57b2e3ac3d3e526380adb7c781989f075115c/json5-0.10.0.tar.gz", hash = "sha256:e66941c8f0a02026943c52c2eb34ebeb2a6f819a0be05920a6f5243cd30fd559", size = 48202 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/42/797895b952b682c3dafe23b1834507ee7f02f4d6299b65aaa61425763278/json5-0.10.0-py3-none-any.whl", hash = "sha256:19b23410220a7271e8377f81ba8aacba2fdd56947fbb137ee5977cbe1f5e8dfa", upload-time = "2024-11-26T19:56:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/42/797895b952b682c3dafe23b1834507ee7f02f4d6299b65aaa61425763278/json5-0.10.0-py3-none-any.whl", hash = "sha256:19b23410220a7271e8377f81ba8aacba2fdd56947fbb137ee5977cbe1f5e8dfa", size = 34049 },
 ]
 
 [[package]]
@@ -1506,27 +1515,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpointer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", upload-time = "2023-06-26T12:07:29.144Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", upload-time = "2023-06-16T21:01:28.466Z" },
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898 },
 ]
 
 [[package]]
 name = "jsonpointer"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", upload-time = "2024-06-10T19:24:42.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", upload-time = "2024-06-10T19:24:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595 },
 ]
 
 [[package]]
 name = "jsonref"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", upload-time = "2023-01-16T16:10:04.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", upload-time = "2023-01-16T16:10:02.255Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425 },
 ]
 
 [[package]]
@@ -1539,9 +1548,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", upload-time = "2026-01-07T13:41:07.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", upload-time = "2026-01-07T13:41:05.306Z" },
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630 },
 ]
 
 [[package]]
@@ -1551,9 +1560,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", upload-time = "2025-09-08T01:34:59.186Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", upload-time = "2025-09-08T01:34:57.871Z" },
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437 },
 ]
 
 [[package]]
@@ -1577,6 +1586,7 @@ dependencies = [
     { name = "databricks-vectorsearch" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "gepa" },
     { name = "google-api-python-client" },
     { name = "greenlet" },
     { name = "grpcio-status" },
@@ -1648,6 +1658,7 @@ requires-dist = [
     { name = "databricks-vectorsearch" },
     { name = "email-validator" },
     { name = "fastapi", specifier = ">=0.110.0" },
+    { name = "gepa", specifier = ">=0.1.4" },
     { name = "google-api-python-client" },
     { name = "greenlet", specifier = ">=3.0.3" },
     { name = "grpcio-status", specifier = ">=1.62.0,<1.71.0" },
@@ -1706,26 +1717,26 @@ dev = [
 name = "kiwisolver"
 version = "1.4.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/3c/85844f1b0feb11ee581ac23fe5fce65cd049a200c1446708cc1b7f922875/kiwisolver-1.4.9.tar.gz", hash = "sha256:c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d", upload-time = "2025-08-10T21:27:49.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/3c/85844f1b0feb11ee581ac23fe5fce65cd049a200c1446708cc1b7f922875/kiwisolver-1.4.9.tar.gz", hash = "sha256:c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d", size = 97564 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/ab/c80b0d5a9d8a1a65f4f815f2afff9798b12c3b9f31f1d304dd233dd920e2/kiwisolver-1.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eb14a5da6dc7642b0f3a18f13654847cd8b7a2550e2645a5bda677862b03ba16", upload-time = "2025-08-10T21:25:53.403Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c0/27fe1a68a39cf62472a300e2879ffc13c0538546c359b86f149cc19f6ac3/kiwisolver-1.4.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:39a219e1c81ae3b103643d2aedb90f1ef22650deb266ff12a19e7773f3e5f089", upload-time = "2025-08-10T21:25:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/31/a2/a12a503ac1fd4943c50f9822678e8015a790a13b5490354c68afb8489814/kiwisolver-1.4.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2405a7d98604b87f3fc28b1716783534b1b4b8510d8142adca34ee0bc3c87543", upload-time = "2025-08-10T21:25:55.76Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e1/e533435c0be77c3f64040d68d7a657771194a63c279f55573188161e81ca/kiwisolver-1.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dc1ae486f9abcef254b5618dfb4113dd49f94c68e3e027d03cf0143f3f772b61", upload-time = "2025-08-10T21:25:56.861Z" },
-    { url = "https://files.pythonhosted.org/packages/67/1e/51b73c7347f9aabdc7215aa79e8b15299097dc2f8e67dee2b095faca9cb0/kiwisolver-1.4.9-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a1f570ce4d62d718dce3f179ee78dac3b545ac16c0c04bb363b7607a949c0d1", upload-time = "2025-08-10T21:25:58.246Z" },
-    { url = "https://files.pythonhosted.org/packages/21/aa/72a1c5d1e430294f2d32adb9542719cfb441b5da368d09d268c7757af46c/kiwisolver-1.4.9-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb27e7b78d716c591e88e0a09a2139c6577865d7f2e152488c2cc6257f460872", upload-time = "2025-08-10T21:25:59.857Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/af/db1509a9e79dbf4c260ce0cfa3903ea8945f6240e9e59d1e4deb731b1a40/kiwisolver-1.4.9-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:15163165efc2f627eb9687ea5f3a28137217d217ac4024893d753f46bce9de26", upload-time = "2025-08-10T21:26:01.105Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/f2/3ea5ee5d52abacdd12013a94130436e19969fa183faa1e7c7fbc89e9a42f/kiwisolver-1.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bdee92c56a71d2b24c33a7d4c2856bd6419d017e08caa7802d2963870e315028", upload-time = "2025-08-10T21:26:02.675Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9b/1efdd3013c2d9a2566aa6a337e9923a00590c516add9a1e89a768a3eb2fc/kiwisolver-1.4.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:412f287c55a6f54b0650bd9b6dce5aceddb95864a1a90c87af16979d37c89771", upload-time = "2025-08-10T21:26:04.009Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e5/cfdc36109ae4e67361f9bc5b41323648cb24a01b9ade18784657e022e65f/kiwisolver-1.4.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2c93f00dcba2eea70af2be5f11a830a742fe6b579a1d4e00f47760ef13be247a", upload-time = "2025-08-10T21:26:05.317Z" },
-    { url = "https://files.pythonhosted.org/packages/62/86/b589e5e86c7610842213994cdea5add00960076bef4ae290c5fa68589cac/kiwisolver-1.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f117e1a089d9411663a3207ba874f31be9ac8eaa5b533787024dc07aeb74f464", upload-time = "2025-08-10T21:26:06.686Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/c6/f8df8509fd1eee6c622febe54384a96cfaf4d43bf2ccec7a0cc17e4715c9/kiwisolver-1.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:be6a04e6c79819c9a8c2373317d19a96048e5a3f90bec587787e86a1153883c2", upload-time = "2025-08-10T21:26:07.94Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/2d/16e0581daafd147bc11ac53f032a2b45eabac897f42a338d0a13c1e5c436/kiwisolver-1.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:0ae37737256ba2de764ddc12aed4956460277f00c4996d51a197e72f62f5eec7", upload-time = "2025-08-10T21:26:09.048Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/0f/36d89194b5a32c054ce93e586d4049b6c2c22887b0eb229c61c68afd3078/kiwisolver-1.4.9-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:720e05574713db64c356e86732c0f3c5252818d05f9df320f0ad8380641acea5", upload-time = "2025-08-10T21:27:43.287Z" },
-    { url = "https://files.pythonhosted.org/packages/52/ba/4ed75f59e4658fd21fe7dde1fee0ac397c678ec3befba3fe6482d987af87/kiwisolver-1.4.9-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:17680d737d5335b552994a2008fab4c851bcd7de33094a82067ef3a576ff02fa", upload-time = "2025-08-10T21:27:44.314Z" },
-    { url = "https://files.pythonhosted.org/packages/33/01/a8ea7c5ea32a9b45ceeaee051a04c8ed4320f5add3c51bfa20879b765b70/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85b5352f94e490c028926ea567fc569c52ec79ce131dadb968d3853e809518c2", upload-time = "2025-08-10T21:27:45.369Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/dbd2ecdce306f1d07a1aaf324817ee993aab7aee9db47ceac757deabafbe/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:464415881e4801295659462c49461a24fb107c140de781d55518c4b80cb6790f", upload-time = "2025-08-10T21:27:46.376Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e9/0d4add7873a73e462aeb45c036a2dead2562b825aa46ba326727b3f31016/kiwisolver-1.4.9-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fb940820c63a9590d31d88b815e7a3aa5915cad3ce735ab45f0c730b39547de1", upload-time = "2025-08-10T21:27:48.236Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/c80b0d5a9d8a1a65f4f815f2afff9798b12c3b9f31f1d304dd233dd920e2/kiwisolver-1.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eb14a5da6dc7642b0f3a18f13654847cd8b7a2550e2645a5bda677862b03ba16", size = 124167 },
+    { url = "https://files.pythonhosted.org/packages/a0/c0/27fe1a68a39cf62472a300e2879ffc13c0538546c359b86f149cc19f6ac3/kiwisolver-1.4.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:39a219e1c81ae3b103643d2aedb90f1ef22650deb266ff12a19e7773f3e5f089", size = 66579 },
+    { url = "https://files.pythonhosted.org/packages/31/a2/a12a503ac1fd4943c50f9822678e8015a790a13b5490354c68afb8489814/kiwisolver-1.4.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2405a7d98604b87f3fc28b1716783534b1b4b8510d8142adca34ee0bc3c87543", size = 65309 },
+    { url = "https://files.pythonhosted.org/packages/66/e1/e533435c0be77c3f64040d68d7a657771194a63c279f55573188161e81ca/kiwisolver-1.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dc1ae486f9abcef254b5618dfb4113dd49f94c68e3e027d03cf0143f3f772b61", size = 1435596 },
+    { url = "https://files.pythonhosted.org/packages/67/1e/51b73c7347f9aabdc7215aa79e8b15299097dc2f8e67dee2b095faca9cb0/kiwisolver-1.4.9-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a1f570ce4d62d718dce3f179ee78dac3b545ac16c0c04bb363b7607a949c0d1", size = 1246548 },
+    { url = "https://files.pythonhosted.org/packages/21/aa/72a1c5d1e430294f2d32adb9542719cfb441b5da368d09d268c7757af46c/kiwisolver-1.4.9-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb27e7b78d716c591e88e0a09a2139c6577865d7f2e152488c2cc6257f460872", size = 1263618 },
+    { url = "https://files.pythonhosted.org/packages/a3/af/db1509a9e79dbf4c260ce0cfa3903ea8945f6240e9e59d1e4deb731b1a40/kiwisolver-1.4.9-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:15163165efc2f627eb9687ea5f3a28137217d217ac4024893d753f46bce9de26", size = 1317437 },
+    { url = "https://files.pythonhosted.org/packages/e0/f2/3ea5ee5d52abacdd12013a94130436e19969fa183faa1e7c7fbc89e9a42f/kiwisolver-1.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bdee92c56a71d2b24c33a7d4c2856bd6419d017e08caa7802d2963870e315028", size = 2195742 },
+    { url = "https://files.pythonhosted.org/packages/6f/9b/1efdd3013c2d9a2566aa6a337e9923a00590c516add9a1e89a768a3eb2fc/kiwisolver-1.4.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:412f287c55a6f54b0650bd9b6dce5aceddb95864a1a90c87af16979d37c89771", size = 2290810 },
+    { url = "https://files.pythonhosted.org/packages/fb/e5/cfdc36109ae4e67361f9bc5b41323648cb24a01b9ade18784657e022e65f/kiwisolver-1.4.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2c93f00dcba2eea70af2be5f11a830a742fe6b579a1d4e00f47760ef13be247a", size = 2461579 },
+    { url = "https://files.pythonhosted.org/packages/62/86/b589e5e86c7610842213994cdea5add00960076bef4ae290c5fa68589cac/kiwisolver-1.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f117e1a089d9411663a3207ba874f31be9ac8eaa5b533787024dc07aeb74f464", size = 2268071 },
+    { url = "https://files.pythonhosted.org/packages/3b/c6/f8df8509fd1eee6c622febe54384a96cfaf4d43bf2ccec7a0cc17e4715c9/kiwisolver-1.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:be6a04e6c79819c9a8c2373317d19a96048e5a3f90bec587787e86a1153883c2", size = 73840 },
+    { url = "https://files.pythonhosted.org/packages/e2/2d/16e0581daafd147bc11ac53f032a2b45eabac897f42a338d0a13c1e5c436/kiwisolver-1.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:0ae37737256ba2de764ddc12aed4956460277f00c4996d51a197e72f62f5eec7", size = 65159 },
+    { url = "https://files.pythonhosted.org/packages/a3/0f/36d89194b5a32c054ce93e586d4049b6c2c22887b0eb229c61c68afd3078/kiwisolver-1.4.9-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:720e05574713db64c356e86732c0f3c5252818d05f9df320f0ad8380641acea5", size = 60104 },
+    { url = "https://files.pythonhosted.org/packages/52/ba/4ed75f59e4658fd21fe7dde1fee0ac397c678ec3befba3fe6482d987af87/kiwisolver-1.4.9-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:17680d737d5335b552994a2008fab4c851bcd7de33094a82067ef3a576ff02fa", size = 58592 },
+    { url = "https://files.pythonhosted.org/packages/33/01/a8ea7c5ea32a9b45ceeaee051a04c8ed4320f5add3c51bfa20879b765b70/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85b5352f94e490c028926ea567fc569c52ec79ce131dadb968d3853e809518c2", size = 80281 },
+    { url = "https://files.pythonhosted.org/packages/da/e3/dbd2ecdce306f1d07a1aaf324817ee993aab7aee9db47ceac757deabafbe/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:464415881e4801295659462c49461a24fb107c140de781d55518c4b80cb6790f", size = 78009 },
+    { url = "https://files.pythonhosted.org/packages/da/e9/0d4add7873a73e462aeb45c036a2dead2562b825aa46ba326727b3f31016/kiwisolver-1.4.9-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fb940820c63a9590d31d88b815e7a3aa5915cad3ce735ab45f0c730b39547de1", size = 73929 },
 ]
 
 [[package]]
@@ -1743,9 +1754,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", upload-time = "2026-01-16T01:05:27.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", upload-time = "2026-01-16T01:05:25.991Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602 },
 ]
 
 [[package]]
@@ -1755,9 +1766,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/90/ab4062f609a1749a7b587d7fd91ddbfa0c107e6aad925bd36367eeeba2f9/lance_namespace-0.7.1.tar.gz", hash = "sha256:739c3c5b021c1582223a23056af085575a6f8bd577e744bafbafc4db76f89f22", upload-time = "2026-04-24T06:30:01.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/90/ab4062f609a1749a7b587d7fd91ddbfa0c107e6aad925bd36367eeeba2f9/lance_namespace-0.7.1.tar.gz", hash = "sha256:739c3c5b021c1582223a23056af085575a6f8bd577e744bafbafc4db76f89f22", size = 10523 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a3/c1d804a1bcd05d2a84dbc5d1b6795599fcee1866e322be55c18cbe109229/lance_namespace-0.7.1-py3-none-any.whl", hash = "sha256:c050c4a2bcd27a75551268449b74a8ac23dde4077f9bf7df460d52c50355d5f0", upload-time = "2026-04-24T06:29:58.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a3/c1d804a1bcd05d2a84dbc5d1b6795599fcee1866e322be55c18cbe109229/lance_namespace-0.7.1-py3-none-any.whl", hash = "sha256:c050c4a2bcd27a75551268449b74a8ac23dde4077f9bf7df460d52c50355d5f0", size = 12354 },
 ]
 
 [[package]]
@@ -1770,9 +1781,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/e8/7a1ad66f0bf268f6e83769eb7139d7c4865e890a241c8e35ee67a5147da6/lance_namespace_urllib3_client-0.7.1.tar.gz", hash = "sha256:eb49cebd36b94d892de9c6fa1157df5021ff451549fc9dab11ba572e8e38a2ab", upload-time = "2026-04-24T06:30:02.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/e8/7a1ad66f0bf268f6e83769eb7139d7c4865e890a241c8e35ee67a5147da6/lance_namespace_urllib3_client-0.7.1.tar.gz", hash = "sha256:eb49cebd36b94d892de9c6fa1157df5021ff451549fc9dab11ba572e8e38a2ab", size = 183789 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/9d/ca5d723cb52bbf18bf7aeea017689e8c156193deb0c2e959ca5f4f62078a/lance_namespace_urllib3_client-0.7.1-py3-none-any.whl", hash = "sha256:b7c02fa5c79ff176a898062a4cd1a13909a6d7c591bf56e8715d5af10d4ea919", upload-time = "2026-04-24T06:29:59.687Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9d/ca5d723cb52bbf18bf7aeea017689e8c156193deb0c2e959ca5f4f62078a/lance_namespace_urllib3_client-0.7.1-py3-none-any.whl", hash = "sha256:b7c02fa5c79ff176a898062a4cd1a13909a6d7c591bf56e8715d5af10d4ea919", size = 314229 },
 ]
 
 [[package]]
@@ -1790,12 +1801,12 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/2f/1577778ad57dba0c55dc13d87230583e14541c82562483ecf8bb2f8e8a00/lancedb-0.30.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:be2a9a43a65c330ccfd08115afb26106cd8d16788522fe7693d3a1f4e01ad321", upload-time = "2026-03-16T23:03:04.551Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ca/8c2a04ce499a2a97d1a0de2b7e84fa8166f988a9a495e1ada860110489c2/lancedb-0.30.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be6a4ba2a1799a426cbf2ba5ea2559a7389a569e9a31f2409d531ceb59d42f35", upload-time = "2026-03-16T23:11:01.352Z" },
-    { url = "https://files.pythonhosted.org/packages/16/68/e01bf7837454a5ce9e2f6773905e07b09a949bc88136c0773c8166ed7729/lancedb-0.30.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a967ec05f9930770aeb077bc5579769b1bedf559fcd03a592d9644084625918", upload-time = "2026-03-16T23:14:39.18Z" },
-    { url = "https://files.pythonhosted.org/packages/43/d1/9085ad17abd98f3a180d7860df3190b2d76f99f533c76d7c7494cec4139d/lancedb-0.30.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:05c66f40f7d4f6f24208e786c40f84b87b1b8e55505305849dd3fed3b78431a3", upload-time = "2026-03-16T23:11:00.837Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/69/504ee25c57c3f23c80276b5b7b5e4c0f98a5197a7e9e51d3c50500d2b53a/lancedb-0.30.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:bdcd27d98554ed11b6f345b14d1307b0e2332d5654767e9ee2e23d9b2d6513d1", upload-time = "2026-03-16T23:15:00.474Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/85/d5550f22023e672af1945394f7a06a578fcab2980ecc6666acef3428a771/lancedb-0.30.0-cp39-abi3-win_amd64.whl", hash = "sha256:4751ff0446b90be4d4dccfe05f6c105f403a05f3b8531ab99eedc1c656aca950", upload-time = "2026-03-16T23:43:23.89Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2f/1577778ad57dba0c55dc13d87230583e14541c82562483ecf8bb2f8e8a00/lancedb-0.30.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:be2a9a43a65c330ccfd08115afb26106cd8d16788522fe7693d3a1f4e01ad321", size = 41959907 },
+    { url = "https://files.pythonhosted.org/packages/f1/ca/8c2a04ce499a2a97d1a0de2b7e84fa8166f988a9a495e1ada860110489c2/lancedb-0.30.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be6a4ba2a1799a426cbf2ba5ea2559a7389a569e9a31f2409d531ceb59d42f35", size = 43873070 },
+    { url = "https://files.pythonhosted.org/packages/16/68/e01bf7837454a5ce9e2f6773905e07b09a949bc88136c0773c8166ed7729/lancedb-0.30.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a967ec05f9930770aeb077bc5579769b1bedf559fcd03a592d9644084625918", size = 46891197 },
+    { url = "https://files.pythonhosted.org/packages/43/d1/9085ad17abd98f3a180d7860df3190b2d76f99f533c76d7c7494cec4139d/lancedb-0.30.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:05c66f40f7d4f6f24208e786c40f84b87b1b8e55505305849dd3fed3b78431a3", size = 43877660 },
+    { url = "https://files.pythonhosted.org/packages/ea/69/504ee25c57c3f23c80276b5b7b5e4c0f98a5197a7e9e51d3c50500d2b53a/lancedb-0.30.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:bdcd27d98554ed11b6f345b14d1307b0e2332d5654767e9ee2e23d9b2d6513d1", size = 46932144 },
+    { url = "https://files.pythonhosted.org/packages/2c/85/d5550f22023e672af1945394f7a06a578fcab2980ecc6666acef3428a771/lancedb-0.30.0-cp39-abi3-win_amd64.whl", hash = "sha256:4751ff0446b90be4d4dccfe05f6c105f403a05f3b8531ab99eedc1c656aca950", size = 51121310 },
 ]
 
 [[package]]
@@ -1807,9 +1818,9 @@ dependencies = [
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", upload-time = "2026-04-03T14:26:03.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", upload-time = "2026-04-03T14:26:02.557Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714 },
 ]
 
 [[package]]
@@ -1826,9 +1837,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/fe/abeae8d0d2899e191d67c6c7f065f7e52a953f30b21ef327fa49084e4af9/langchain_core-1.3.1.tar.gz", hash = "sha256:41b384055799f93f34520df6bf7b80e2e5e23153cdfd46874251c6c9916ea030", upload-time = "2026-04-23T18:54:01.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/fe/abeae8d0d2899e191d67c6c7f065f7e52a953f30b21ef327fa49084e4af9/langchain_core-1.3.1.tar.gz", hash = "sha256:41b384055799f93f34520df6bf7b80e2e5e23153cdfd46874251c6c9916ea030", size = 862403 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/c2/8493be505921857988db068b7c027f28a9b1587b4425c6a32b1221c9c9fe/langchain_core-1.3.1-py3-none-any.whl", hash = "sha256:8b13d19d3bed3f4768df12c7f6932d2ada715f3ac9fd020c63d28c693968269e", upload-time = "2026-04-23T18:53:59.94Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/8493be505921857988db068b7c027f28a9b1587b4425c6a32b1221c9c9fe/langchain_core-1.3.1-py3-none-any.whl", hash = "sha256:8b13d19d3bed3f4768df12c7f6932d2ada715f3ac9fd020c63d28c693968269e", size = 515879 },
 ]
 
 [[package]]
@@ -1840,9 +1851,9 @@ dependencies = [
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/69/0ea9dabd903f750315ab31b8b85dad64f2927e56ddc26252dfe4e4ac2c40/langchain_openai-1.2.0.tar.gz", hash = "sha256:e88edf16002b9ed8e206161181c8a6fb2b3662da23195e0a844d040c3f93ab10", upload-time = "2026-04-23T00:43:35.31Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/69/0ea9dabd903f750315ab31b8b85dad64f2927e56ddc26252dfe4e4ac2c40/langchain_openai-1.2.0.tar.gz", hash = "sha256:e88edf16002b9ed8e206161181c8a6fb2b3662da23195e0a844d040c3f93ab10", size = 1136352 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/7b/e8c3beeab0ca042529533072ebee69c66327c1805b3133531b58c422baab/langchain_openai-1.2.0-py3-none-any.whl", hash = "sha256:b3ed14dc48e40890605136f26c6b07e8f293987d95e734ab67cbfa572c523456", upload-time = "2026-04-23T00:43:34.135Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7b/e8c3beeab0ca042529533072ebee69c66327c1805b3133531b58c422baab/langchain_openai-1.2.0-py3-none-any.whl", hash = "sha256:b3ed14dc48e40890605136f26c6b07e8f293987d95e734ab67cbfa572c523456", size = 98592 },
 ]
 
 [[package]]
@@ -1852,9 +1863,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", upload-time = "2026-04-16T14:20:39.162Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", upload-time = "2026-04-16T14:20:38.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", size = 35903 },
 ]
 
 [[package]]
@@ -1869,9 +1880,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/d5/9d9c65d5500a1ca7ea63d6d65aecfb248037018a74d7d4ef52e276bb4e4b/langgraph-1.1.9.tar.gz", hash = "sha256:bc5a49d5a5e71fda1f9c53c06c62f4caec9a95545b739d130a58b6ab3269e274", upload-time = "2026-04-21T13:43:06.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/d5/9d9c65d5500a1ca7ea63d6d65aecfb248037018a74d7d4ef52e276bb4e4b/langgraph-1.1.9.tar.gz", hash = "sha256:bc5a49d5a5e71fda1f9c53c06c62f4caec9a95545b739d130a58b6ab3269e274", size = 560717 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/58/0380420e66619d12c992c1f8cfda0c7a04e8f0fe8a84752245b9e7b1cba7/langgraph-1.1.9-py3-none-any.whl", hash = "sha256:7db13ceecde4ea643df6c097dcc9e534895dcd9fcc6500eeff2f2cde0fab16b2", upload-time = "2026-04-21T13:43:05.513Z" },
+    { url = "https://files.pythonhosted.org/packages/16/58/0380420e66619d12c992c1f8cfda0c7a04e8f0fe8a84752245b9e7b1cba7/langgraph-1.1.9-py3-none-any.whl", hash = "sha256:7db13ceecde4ea643df6c097dcc9e534895dcd9fcc6500eeff2f2cde0fab16b2", size = 173744 },
 ]
 
 [[package]]
@@ -1882,9 +1893,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/f2/cf8086e1f1a3358d9228805614e72602c281b18307f3fae64a5b854aad2d/langgraph_checkpoint-4.0.2.tar.gz", hash = "sha256:4f6f99cba8e272deabf81b2d8cdc96582af07a57a6ad591cdf216bb310497039", upload-time = "2026-04-15T21:03:00.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/f2/cf8086e1f1a3358d9228805614e72602c281b18307f3fae64a5b854aad2d/langgraph_checkpoint-4.0.2.tar.gz", hash = "sha256:4f6f99cba8e272deabf81b2d8cdc96582af07a57a6ad591cdf216bb310497039", size = 160810 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/5a/6dba29dd89b0a46ae21c707da0f9d17e94f27d3e481ed15bc99d6bd20aa6/langgraph_checkpoint-4.0.2-py3-none-any.whl", hash = "sha256:59b0f29216128a629c58dd07c98aa004f82f51805d5573126ffb419b753ff253", upload-time = "2026-04-15T21:02:59.096Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5a/6dba29dd89b0a46ae21c707da0f9d17e94f27d3e481ed15bc99d6bd20aa6/langgraph_checkpoint-4.0.2-py3-none-any.whl", hash = "sha256:59b0f29216128a629c58dd07c98aa004f82f51805d5573126ffb419b753ff253", size = 51000 },
 ]
 
 [[package]]
@@ -1895,9 +1906,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/01471b1b5601f2e9c9a69c39fc9a2fb8611613ede0002e5a2b81c0acd850/langgraph_prebuilt-1.0.10.tar.gz", hash = "sha256:5a6fc513f8907074563b6218ff991c4ed9db19ac63101314919686e8029ddb07", upload-time = "2026-04-17T17:59:45.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/01471b1b5601f2e9c9a69c39fc9a2fb8611613ede0002e5a2b81c0acd850/langgraph_prebuilt-1.0.10.tar.gz", hash = "sha256:5a6fc513f8907074563b6218ff991c4ed9db19ac63101314919686e8029ddb07", size = 169769 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/49/d073375beabdc6955df6cbe570ba7786836bd4c817ae998955d35037f2fd/langgraph_prebuilt-1.0.10-py3-none-any.whl", hash = "sha256:e3baa1977d819982e690a357ba5bb77ccc1d4d8d4a029c48e502a3b6d171185f", upload-time = "2026-04-17T17:59:44.395Z" },
+    { url = "https://files.pythonhosted.org/packages/50/49/d073375beabdc6955df6cbe570ba7786836bd4c817ae998955d35037f2fd/langgraph_prebuilt-1.0.10-py3-none-any.whl", hash = "sha256:e3baa1977d819982e690a357ba5bb77ccc1d4d8d4a029c48e502a3b6d171185f", size = 36086 },
 ]
 
 [[package]]
@@ -1908,9 +1919,9 @@ dependencies = [
     { name = "httpx" },
     { name = "orjson" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/db/77a45127dddcfea5e4256ba916182903e4c31dc4cfca305b8c386f0a9e53/langgraph_sdk-0.3.13.tar.gz", hash = "sha256:419ca5663eec3cec192ad194ac0647c0c826866b446073eb40f384f950986cd5", upload-time = "2026-04-07T20:34:18.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/db/77a45127dddcfea5e4256ba916182903e4c31dc4cfca305b8c386f0a9e53/langgraph_sdk-0.3.13.tar.gz", hash = "sha256:419ca5663eec3cec192ad194ac0647c0c826866b446073eb40f384f950986cd5", size = 196360 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ef/64d64e9f8eea47ce7b939aa6da6863b674c8d418647813c20111645fcc62/langgraph_sdk-0.3.13-py3-none-any.whl", hash = "sha256:aee09e345c90775f6de9d6f4c7b847cfc652e49055c27a2aed0d981af2af3bd0", upload-time = "2026-04-07T20:34:17.866Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ef/64d64e9f8eea47ce7b939aa6da6863b674c8d418647813c20111645fcc62/langgraph_sdk-0.3.13-py3-none-any.whl", hash = "sha256:aee09e345c90775f6de9d6f4c7b847cfc652e49055c27a2aed0d981af2af3bd0", size = 96668 },
 ]
 
 [[package]]
@@ -1928,28 +1939,28 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/e0/463a70b43d6755b01598bb59932eec8e2029afcab455b5312c318ac457b5/langsmith-0.6.9.tar.gz", hash = "sha256:aae04cec6e6d8e133f63ba71c332ce0fbd2cda95260db7746ff4c3b6a3c41db1", upload-time = "2026-02-05T20:10:55.629Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/e0/463a70b43d6755b01598bb59932eec8e2029afcab455b5312c318ac457b5/langsmith-0.6.9.tar.gz", hash = "sha256:aae04cec6e6d8e133f63ba71c332ce0fbd2cda95260db7746ff4c3b6a3c41db1", size = 973557 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/8e/063e09c5e8a3dcd77e2a8f0bff3f71c1c52a9d238da1bcafd2df3281da17/langsmith-0.6.9-py3-none-any.whl", hash = "sha256:86ba521e042397f6fbb79d63991df9d5f7b6a6dd6a6323d4f92131291478dcff", upload-time = "2026-02-05T20:10:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8e/063e09c5e8a3dcd77e2a8f0bff3f71c1c52a9d238da1bcafd2df3281da17/langsmith-0.6.9-py3-none-any.whl", hash = "sha256:86ba521e042397f6fbb79d63991df9d5f7b6a6dd6a6323d4f92131291478dcff", size = 319228 },
 ]
 
 [[package]]
 name = "librt"
 version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/24/5f3646ff414285e0f7708fa4e946b9bf538345a41d1c375c439467721a5e/librt-0.7.8.tar.gz", hash = "sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862", upload-time = "2026-01-14T12:56:16.876Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/24/5f3646ff414285e0f7708fa4e946b9bf538345a41d1c375c439467721a5e/librt-0.7.8.tar.gz", hash = "sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862", size = 148323 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/a3/87ea9c1049f2c781177496ebee29430e4631f439b8553a4969c88747d5d8/librt-0.7.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3e9c11aa260c31493d4b3197d1e28dd07768594a4f92bec4506849d736248f", upload-time = "2026-01-14T12:54:54.156Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/4a/23bcef149f37f771ad30203d561fcfd45b02bc54947b91f7a9ac34815747/librt-0.7.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ddb52499d0b3ed4aa88746aaf6f36a08314677d5c346234c3987ddc506404eac", upload-time = "2026-01-14T12:54:55.978Z" },
-    { url = "https://files.pythonhosted.org/packages/22/6e/46eb9b85c1b9761e0f42b6e6311e1cc544843ac897457062b9d5d0b21df4/librt-0.7.8-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e9c0afebbe6ce177ae8edba0c7c4d626f2a0fc12c33bb993d163817c41a7a05c", upload-time = "2026-01-14T12:54:57.311Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/3f/aa7c7f6829fb83989feb7ba9aa11c662b34b4bd4bd5b262f2876ba3db58d/librt-0.7.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:631599598e2c76ded400c0a8722dec09217c89ff64dc54b060f598ed68e7d2a8", upload-time = "2026-01-14T12:54:59.089Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/2d/d57d154b40b11f2cb851c4df0d4c4456bacd9b1ccc4ecb593ddec56c1a8b/librt-0.7.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c1ba843ae20db09b9d5c80475376168feb2640ce91cd9906414f23cc267a1ff", upload-time = "2026-01-14T12:55:00.141Z" },
-    { url = "https://files.pythonhosted.org/packages/59/f9/36c4dad00925c16cd69d744b87f7001792691857d3b79187e7a673e812fb/librt-0.7.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b5b007bb22ea4b255d3ee39dfd06d12534de2fcc3438567d9f48cdaf67ae1ae3", upload-time = "2026-01-14T12:55:01.303Z" },
-    { url = "https://files.pythonhosted.org/packages/23/9b/8a9889d3df5efb67695a67785028ccd58e661c3018237b73ad081691d0cb/librt-0.7.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dbd79caaf77a3f590cbe32dc2447f718772d6eea59656a7dcb9311161b10fa75", upload-time = "2026-01-14T12:55:02.492Z" },
-    { url = "https://files.pythonhosted.org/packages/43/64/54d6ef11afca01fef8af78c230726a9394759f2addfbf7afc5e3cc032a45/librt-0.7.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:87808a8d1e0bd62a01cafc41f0fd6818b5a5d0ca0d8a55326a81643cdda8f873", upload-time = "2026-01-14T12:55:03.919Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/29/73e7ed2991330b28919387656f54109139b49e19cd72902f466bd44415fd/librt-0.7.8-cp311-cp311-win32.whl", hash = "sha256:31724b93baa91512bd0a376e7cf0b59d8b631ee17923b1218a65456fa9bda2e7", upload-time = "2026-01-14T12:55:04.996Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/de/66766ff48ed02b4d78deea30392ae200bcbd99ae61ba2418b49fd50a4831/librt-0.7.8-cp311-cp311-win_amd64.whl", hash = "sha256:978e8b5f13e52cf23a9e80f3286d7546baa70bc4ef35b51d97a709d0b28e537c", upload-time = "2026-01-14T12:55:06.489Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/e3/33450438ff3a8c581d4ed7f798a70b07c3206d298cf0b87d3806e72e3ed8/librt-0.7.8-cp311-cp311-win_arm64.whl", hash = "sha256:20e3946863d872f7cabf7f77c6c9d370b8b3d74333d3a32471c50d3a86c0a232", upload-time = "2026-01-14T12:55:07.49Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a3/87ea9c1049f2c781177496ebee29430e4631f439b8553a4969c88747d5d8/librt-0.7.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3e9c11aa260c31493d4b3197d1e28dd07768594a4f92bec4506849d736248f", size = 56507 },
+    { url = "https://files.pythonhosted.org/packages/5e/4a/23bcef149f37f771ad30203d561fcfd45b02bc54947b91f7a9ac34815747/librt-0.7.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ddb52499d0b3ed4aa88746aaf6f36a08314677d5c346234c3987ddc506404eac", size = 58455 },
+    { url = "https://files.pythonhosted.org/packages/22/6e/46eb9b85c1b9761e0f42b6e6311e1cc544843ac897457062b9d5d0b21df4/librt-0.7.8-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e9c0afebbe6ce177ae8edba0c7c4d626f2a0fc12c33bb993d163817c41a7a05c", size = 164956 },
+    { url = "https://files.pythonhosted.org/packages/7a/3f/aa7c7f6829fb83989feb7ba9aa11c662b34b4bd4bd5b262f2876ba3db58d/librt-0.7.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:631599598e2c76ded400c0a8722dec09217c89ff64dc54b060f598ed68e7d2a8", size = 174364 },
+    { url = "https://files.pythonhosted.org/packages/3f/2d/d57d154b40b11f2cb851c4df0d4c4456bacd9b1ccc4ecb593ddec56c1a8b/librt-0.7.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c1ba843ae20db09b9d5c80475376168feb2640ce91cd9906414f23cc267a1ff", size = 188034 },
+    { url = "https://files.pythonhosted.org/packages/59/f9/36c4dad00925c16cd69d744b87f7001792691857d3b79187e7a673e812fb/librt-0.7.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b5b007bb22ea4b255d3ee39dfd06d12534de2fcc3438567d9f48cdaf67ae1ae3", size = 186295 },
+    { url = "https://files.pythonhosted.org/packages/23/9b/8a9889d3df5efb67695a67785028ccd58e661c3018237b73ad081691d0cb/librt-0.7.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dbd79caaf77a3f590cbe32dc2447f718772d6eea59656a7dcb9311161b10fa75", size = 181470 },
+    { url = "https://files.pythonhosted.org/packages/43/64/54d6ef11afca01fef8af78c230726a9394759f2addfbf7afc5e3cc032a45/librt-0.7.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:87808a8d1e0bd62a01cafc41f0fd6818b5a5d0ca0d8a55326a81643cdda8f873", size = 201713 },
+    { url = "https://files.pythonhosted.org/packages/2d/29/73e7ed2991330b28919387656f54109139b49e19cd72902f466bd44415fd/librt-0.7.8-cp311-cp311-win32.whl", hash = "sha256:31724b93baa91512bd0a376e7cf0b59d8b631ee17923b1218a65456fa9bda2e7", size = 43803 },
+    { url = "https://files.pythonhosted.org/packages/3f/de/66766ff48ed02b4d78deea30392ae200bcbd99ae61ba2418b49fd50a4831/librt-0.7.8-cp311-cp311-win_amd64.whl", hash = "sha256:978e8b5f13e52cf23a9e80f3286d7546baa70bc4ef35b51d97a709d0b28e537c", size = 50080 },
+    { url = "https://files.pythonhosted.org/packages/6f/e3/33450438ff3a8c581d4ed7f798a70b07c3206d298cf0b87d3806e72e3ed8/librt-0.7.8-cp311-cp311-win_arm64.whl", hash = "sha256:20e3946863d872f7cabf7f77c6c9d370b8b3d74333d3a32471c50d3a86c0a232", size = 43383 },
 ]
 
 [[package]]
@@ -1961,9 +1972,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", upload-time = "2026-02-05T07:17:35.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", upload-time = "2026-02-05T07:17:34.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954 },
 ]
 
 [[package]]
@@ -1973,9 +1984,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uc-micro-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", upload-time = "2026-03-01T07:48:47.683Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", upload-time = "2026-03-01T07:48:46.098Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878 },
 ]
 
 [[package]]
@@ -1995,9 +2006,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/5d/646bebdb4769d77e6a018b9152c9ccf17afe15d0f88974f338d3f2ee7c15/litellm-1.74.9.tar.gz", hash = "sha256:4a32eff70342e1aee4d1cbf2de2a6ed64a7c39d86345c58d4401036af018b7de", upload-time = "2025-07-28T16:42:39.297Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/5d/646bebdb4769d77e6a018b9152c9ccf17afe15d0f88974f338d3f2ee7c15/litellm-1.74.9.tar.gz", hash = "sha256:4a32eff70342e1aee4d1cbf2de2a6ed64a7c39d86345c58d4401036af018b7de", size = 9660510 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/e4/f1546746049c99c6b8b247e2f34485b9eae36faa9322b84e2a17262e6712/litellm-1.74.9-py3-none-any.whl", hash = "sha256:ab8f8a6e4d8689d3c7c4f9c3bbc7e46212cc3ebc74ddd0f3c0c921bb459c9874", upload-time = "2025-07-28T16:42:36.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e4/f1546746049c99c6b8b247e2f34485b9eae36faa9322b84e2a17262e6712/litellm-1.74.9-py3-none-any.whl", hash = "sha256:ab8f8a6e4d8689d3c7c4f9c3bbc7e46212cc3ebc74ddd0f3c0c921bb459c9874", size = 8740449 },
 ]
 
 [package.optional-dependencies]
@@ -2009,30 +2020,30 @@ caching = [
 name = "lxml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", upload-time = "2025-09-22T04:04:59.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d5/becbe1e2569b474a23f0c672ead8a29ac50b2dc1d5b9de184831bda8d14c/lxml-6.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13e35cbc684aadf05d8711a5d1b5857c92e5e580efa9a0d2be197199c8def607", upload-time = "2025-09-22T04:00:45.672Z" },
-    { url = "https://files.pythonhosted.org/packages/28/66/1ced58f12e804644426b85d0bb8a4478ca77bc1761455da310505f1a3526/lxml-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b1675e096e17c6fe9c0e8c81434f5736c0739ff9ac6123c87c2d452f48fc938", upload-time = "2025-09-22T04:00:47.783Z" },
-    { url = "https://files.pythonhosted.org/packages/11/84/549098ffea39dfd167e3f174b4ce983d0eed61f9d8d25b7bf2a57c3247fc/lxml-6.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac6e5811ae2870953390452e3476694196f98d447573234592d30488147404d", upload-time = "2025-09-22T04:00:49.845Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/bd/f207f16abf9749d2037453d56b643a7471d8fde855a231a12d1e095c4f01/lxml-6.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5aa0fc67ae19d7a64c3fe725dc9a1bb11f80e01f78289d05c6f62545affec438", upload-time = "2025-09-22T04:00:51.709Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ae/bd813e87d8941d52ad5b65071b1affb48da01c4ed3c9c99e40abb266fbff/lxml-6.0.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de496365750cc472b4e7902a485d3f152ecf57bd3ba03ddd5578ed8ceb4c5964", upload-time = "2025-09-22T04:00:53.593Z" },
-    { url = "https://files.pythonhosted.org/packages/02/cd/9bfef16bd1d874fbe0cb51afb00329540f30a3283beb9f0780adbb7eec03/lxml-6.0.2-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:200069a593c5e40b8f6fc0d84d86d970ba43138c3e68619ffa234bc9bb806a4d", upload-time = "2025-09-22T04:00:55.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/89/ea8f91594bc5dbb879734d35a6f2b0ad50605d7fb419de2b63d4211765cc/lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d2de809c2ee3b888b59f995625385f74629707c9355e0ff856445cdcae682b7", upload-time = "2025-09-22T04:00:57.269Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/37/9c735274f5dbec726b2db99b98a43950395ba3d4a1043083dba2ad814170/lxml-6.0.2-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:b2c3da8d93cf5db60e8858c17684c47d01fee6405e554fb55018dd85fc23b178", upload-time = "2025-09-22T04:00:59.052Z" },
-    { url = "https://files.pythonhosted.org/packages/20/28/7dfe1ba3475d8bfca3878365075abe002e05d40dfaaeb7ec01b4c587d533/lxml-6.0.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:442de7530296ef5e188373a1ea5789a46ce90c4847e597856570439621d9c553", upload-time = "2025-09-22T04:01:01.335Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/cf/5f14bc0de763498fc29510e3532bf2b4b3a1c1d5d0dff2e900c16ba021ef/lxml-6.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2593c77efde7bfea7f6389f1ab249b15ed4aa5bc5cb5131faa3b843c429fbedb", upload-time = "2025-09-22T04:01:03.13Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/b0/bb8275ab5472f32b28cfbbcc6db7c9d092482d3439ca279d8d6fa02f7025/lxml-6.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3e3cb08855967a20f553ff32d147e14329b3ae70ced6edc2f282b94afbc74b2a", upload-time = "2025-09-22T04:01:05.013Z" },
-    { url = "https://files.pythonhosted.org/packages/25/4c/7c222753bc72edca3b99dbadba1b064209bc8ed4ad448af990e60dcce462/lxml-6.0.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ed6c667fcbb8c19c6791bbf40b7268ef8ddf5a96940ba9404b9f9a304832f6c", upload-time = "2025-09-22T04:01:07.327Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/8c/478a0dc6b6ed661451379447cdbec77c05741a75736d97e5b2b729687828/lxml-6.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8f18914faec94132e5b91e69d76a5c1d7b0c73e2489ea8929c4aaa10b76bbf7", upload-time = "2025-09-22T04:01:09.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d9/5be3a6ab2784cdf9accb0703b65e1b64fcdd9311c9f007630c7db0cfcce1/lxml-6.0.2-cp311-cp311-win32.whl", hash = "sha256:6605c604e6daa9e0d7f0a2137bdc47a2e93b59c60a65466353e37f8272f47c46", upload-time = "2025-09-22T04:01:11.102Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/7d/ca6fb13349b473d5732fb0ee3eec8f6c80fc0688e76b7d79c1008481bf1f/lxml-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5867f2651016a3afd8dd2c8238baa66f1e2802f44bc17e236f547ace6647078", upload-time = "2025-09-22T04:01:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a2/51363b5ecd3eab46563645f3a2c3836a2fc67d01a1b87c5017040f39f567/lxml-6.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:4197fb2534ee05fd3e7afaab5d8bfd6c2e186f65ea7f9cd6a82809c887bd1285", upload-time = "2025-09-22T04:01:14.874Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/11/29d08bc103a62c0eba8016e7ed5aeebbf1e4312e83b0b1648dd203b0e87d/lxml-6.0.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1c06035eafa8404b5cf475bb37a9f6088b0aca288d4ccc9d69389750d5543700", upload-time = "2025-09-22T04:04:45.608Z" },
-    { url = "https://files.pythonhosted.org/packages/12/b3/52ab9a3b31e5ab8238da241baa19eec44d2ab426532441ee607165aebb52/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c7d13103045de1bdd6fe5d61802565f1a3537d70cd3abf596aa0af62761921ee", upload-time = "2025-09-22T04:04:47.754Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/33/1eaf780c1baad88224611df13b1c2a9dfa460b526cacfe769103ff50d845/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a3c150a95fbe5ac91de323aa756219ef9cf7fde5a3f00e2281e30f33fa5fa4f", upload-time = "2025-09-22T04:04:49.907Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/c1/27428a2ff348e994ab4f8777d3a0ad510b6b92d37718e5887d2da99952a2/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9", upload-time = "2025-09-22T04:04:51.801Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d0/3020fa12bcec4ab62f97aab026d57c2f0cfd480a558758d9ca233bb6a79d/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a", upload-time = "2025-09-22T04:04:55.024Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/77/d7f491cbc05303ac6801651aabeb262d43f319288c1ea96c66b1d2692ff3/lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e", upload-time = "2025-09-22T04:04:57.097Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d5/becbe1e2569b474a23f0c672ead8a29ac50b2dc1d5b9de184831bda8d14c/lxml-6.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13e35cbc684aadf05d8711a5d1b5857c92e5e580efa9a0d2be197199c8def607", size = 8634365 },
+    { url = "https://files.pythonhosted.org/packages/28/66/1ced58f12e804644426b85d0bb8a4478ca77bc1761455da310505f1a3526/lxml-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b1675e096e17c6fe9c0e8c81434f5736c0739ff9ac6123c87c2d452f48fc938", size = 4650793 },
+    { url = "https://files.pythonhosted.org/packages/11/84/549098ffea39dfd167e3f174b4ce983d0eed61f9d8d25b7bf2a57c3247fc/lxml-6.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac6e5811ae2870953390452e3476694196f98d447573234592d30488147404d", size = 4944362 },
+    { url = "https://files.pythonhosted.org/packages/ac/bd/f207f16abf9749d2037453d56b643a7471d8fde855a231a12d1e095c4f01/lxml-6.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5aa0fc67ae19d7a64c3fe725dc9a1bb11f80e01f78289d05c6f62545affec438", size = 5083152 },
+    { url = "https://files.pythonhosted.org/packages/15/ae/bd813e87d8941d52ad5b65071b1affb48da01c4ed3c9c99e40abb266fbff/lxml-6.0.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de496365750cc472b4e7902a485d3f152ecf57bd3ba03ddd5578ed8ceb4c5964", size = 5023539 },
+    { url = "https://files.pythonhosted.org/packages/02/cd/9bfef16bd1d874fbe0cb51afb00329540f30a3283beb9f0780adbb7eec03/lxml-6.0.2-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:200069a593c5e40b8f6fc0d84d86d970ba43138c3e68619ffa234bc9bb806a4d", size = 5344853 },
+    { url = "https://files.pythonhosted.org/packages/b8/89/ea8f91594bc5dbb879734d35a6f2b0ad50605d7fb419de2b63d4211765cc/lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d2de809c2ee3b888b59f995625385f74629707c9355e0ff856445cdcae682b7", size = 5225133 },
+    { url = "https://files.pythonhosted.org/packages/b9/37/9c735274f5dbec726b2db99b98a43950395ba3d4a1043083dba2ad814170/lxml-6.0.2-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:b2c3da8d93cf5db60e8858c17684c47d01fee6405e554fb55018dd85fc23b178", size = 4677944 },
+    { url = "https://files.pythonhosted.org/packages/20/28/7dfe1ba3475d8bfca3878365075abe002e05d40dfaaeb7ec01b4c587d533/lxml-6.0.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:442de7530296ef5e188373a1ea5789a46ce90c4847e597856570439621d9c553", size = 5284535 },
+    { url = "https://files.pythonhosted.org/packages/e7/cf/5f14bc0de763498fc29510e3532bf2b4b3a1c1d5d0dff2e900c16ba021ef/lxml-6.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2593c77efde7bfea7f6389f1ab249b15ed4aa5bc5cb5131faa3b843c429fbedb", size = 5067343 },
+    { url = "https://files.pythonhosted.org/packages/1c/b0/bb8275ab5472f32b28cfbbcc6db7c9d092482d3439ca279d8d6fa02f7025/lxml-6.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3e3cb08855967a20f553ff32d147e14329b3ae70ced6edc2f282b94afbc74b2a", size = 4725419 },
+    { url = "https://files.pythonhosted.org/packages/25/4c/7c222753bc72edca3b99dbadba1b064209bc8ed4ad448af990e60dcce462/lxml-6.0.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ed6c667fcbb8c19c6791bbf40b7268ef8ddf5a96940ba9404b9f9a304832f6c", size = 5275008 },
+    { url = "https://files.pythonhosted.org/packages/6c/8c/478a0dc6b6ed661451379447cdbec77c05741a75736d97e5b2b729687828/lxml-6.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8f18914faec94132e5b91e69d76a5c1d7b0c73e2489ea8929c4aaa10b76bbf7", size = 5248906 },
+    { url = "https://files.pythonhosted.org/packages/2d/d9/5be3a6ab2784cdf9accb0703b65e1b64fcdd9311c9f007630c7db0cfcce1/lxml-6.0.2-cp311-cp311-win32.whl", hash = "sha256:6605c604e6daa9e0d7f0a2137bdc47a2e93b59c60a65466353e37f8272f47c46", size = 3610357 },
+    { url = "https://files.pythonhosted.org/packages/e2/7d/ca6fb13349b473d5732fb0ee3eec8f6c80fc0688e76b7d79c1008481bf1f/lxml-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5867f2651016a3afd8dd2c8238baa66f1e2802f44bc17e236f547ace6647078", size = 4036583 },
+    { url = "https://files.pythonhosted.org/packages/ab/a2/51363b5ecd3eab46563645f3a2c3836a2fc67d01a1b87c5017040f39f567/lxml-6.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:4197fb2534ee05fd3e7afaab5d8bfd6c2e186f65ea7f9cd6a82809c887bd1285", size = 3680591 },
+    { url = "https://files.pythonhosted.org/packages/0b/11/29d08bc103a62c0eba8016e7ed5aeebbf1e4312e83b0b1648dd203b0e87d/lxml-6.0.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1c06035eafa8404b5cf475bb37a9f6088b0aca288d4ccc9d69389750d5543700", size = 3949829 },
+    { url = "https://files.pythonhosted.org/packages/12/b3/52ab9a3b31e5ab8238da241baa19eec44d2ab426532441ee607165aebb52/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c7d13103045de1bdd6fe5d61802565f1a3537d70cd3abf596aa0af62761921ee", size = 4226277 },
+    { url = "https://files.pythonhosted.org/packages/a0/33/1eaf780c1baad88224611df13b1c2a9dfa460b526cacfe769103ff50d845/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a3c150a95fbe5ac91de323aa756219ef9cf7fde5a3f00e2281e30f33fa5fa4f", size = 4330433 },
+    { url = "https://files.pythonhosted.org/packages/7a/c1/27428a2ff348e994ab4f8777d3a0ad510b6b92d37718e5887d2da99952a2/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9", size = 4272119 },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/3020fa12bcec4ab62f97aab026d57c2f0cfd480a558758d9ca233bb6a79d/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a", size = 4417314 },
+    { url = "https://files.pythonhosted.org/packages/6c/77/d7f491cbc05303ac6801651aabeb262d43f319288c1ea96c66b1d2692ff3/lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e", size = 3518768 },
 ]
 
 [[package]]
@@ -2042,9 +2053,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509 },
 ]
 
 [[package]]
@@ -2054,9 +2065,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321 },
 ]
 
 [package.optional-dependencies]
@@ -2068,19 +2079,19 @@ linkify = [
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", upload-time = "2025-09-27T18:37:40.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", upload-time = "2025-09-27T18:36:18.185Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", upload-time = "2025-09-27T18:36:19.444Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", upload-time = "2025-09-27T18:36:20.768Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", upload-time = "2025-09-27T18:36:22.249Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", upload-time = "2025-09-27T18:36:23.535Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", upload-time = "2025-09-27T18:36:24.823Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", upload-time = "2025-09-27T18:36:25.95Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", upload-time = "2025-09-27T18:36:27.109Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", upload-time = "2025-09-27T18:36:28.045Z" },
-    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", upload-time = "2025-09-27T18:36:29.025Z" },
-    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631 },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058 },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287 },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940 },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887 },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692 },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471 },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923 },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572 },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077 },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876 },
 ]
 
 [[package]]
@@ -2090,9 +2101,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", upload-time = "2025-12-22T06:53:53.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", upload-time = "2025-12-22T06:53:51.801Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964 },
 ]
 
 [[package]]
@@ -2110,18 +2121,18 @@ dependencies = [
     { name = "pyparsing" },
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/76/d3c6e3a13fe484ebe7718d14e269c9569c4eb0020a968a327acb3b9a8fe6/matplotlib-3.10.8.tar.gz", hash = "sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3", upload-time = "2025-12-10T22:56:51.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/76/d3c6e3a13fe484ebe7718d14e269c9569c4eb0020a968a327acb3b9a8fe6/matplotlib-3.10.8.tar.gz", hash = "sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3", size = 34806269 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/86/de7e3a1cdcfc941483af70609edc06b83e7c8a0e0dc9ac325200a3f4d220/matplotlib-3.10.8-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6be43b667360fef5c754dda5d25a32e6307a03c204f3c0fc5468b78fa87b4160", upload-time = "2025-12-10T22:55:16.175Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/14/baad3222f424b19ce6ad243c71de1ad9ec6b2e4eb1e458a48fdc6d120401/matplotlib-3.10.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a2b336e2d91a3d7006864e0990c83b216fcdca64b5a6484912902cef87313d78", upload-time = "2025-12-10T22:55:17.712Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a0/7024215e95d456de5883e6732e708d8187d9753a21d32f8ddb3befc0c445/matplotlib-3.10.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efb30e3baaea72ce5928e32bab719ab4770099079d66726a62b11b1ef7273be4", upload-time = "2025-12-10T22:55:20.8Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f4/b8347351da9a5b3f41e26cf547252d861f685c6867d179a7c9d60ad50189/matplotlib-3.10.8-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d56a1efd5bfd61486c8bc968fa18734464556f0fb8e51690f4ac25d85cbbbbc2", upload-time = "2025-12-10T22:55:23.258Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/c0/c7b914e297efe0bc36917bf216b2acb91044b91e930e878ae12981e461e5/matplotlib-3.10.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:238b7ce5717600615c895050239ec955d91f321c209dd110db988500558e70d6", upload-time = "2025-12-10T22:55:25.217Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/d3/a4bbc01c237ab710a1f22b4da72f4ff6d77eb4c7735ea9811a94ae239067/matplotlib-3.10.8-cp311-cp311-win_amd64.whl", hash = "sha256:18821ace09c763ec93aef5eeff087ee493a24051936d7b9ebcad9662f66501f9", upload-time = "2025-12-10T22:55:27.162Z" },
-    { url = "https://files.pythonhosted.org/packages/89/dd/a0b6588f102beab33ca6f5218b31725216577b2a24172f327eaf6417d5c9/matplotlib-3.10.8-cp311-cp311-win_arm64.whl", hash = "sha256:bab485bcf8b1c7d2060b4fcb6fc368a9e6f4cd754c9c2fea281f4be21df394a2", upload-time = "2025-12-10T22:55:29.185Z" },
-    { url = "https://files.pythonhosted.org/packages/04/30/3afaa31c757f34b7725ab9d2ba8b48b5e89c2019c003e7d0ead143aabc5a/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6da7c2ce169267d0d066adcf63758f0604aa6c3eebf67458930f9d9b79ad1db1", upload-time = "2025-12-10T22:56:45.584Z" },
-    { url = "https://files.pythonhosted.org/packages/48/2f/6334aec331f57485a642a7c8be03cb286f29111ae71c46c38b363230063c/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9153c3292705be9f9c64498a8872118540c3f4123d1a1c840172edf262c8be4a", upload-time = "2025-12-10T22:56:47.339Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e4/6d6f14b2a759c622f191b2d67e9075a3f56aaccb3be4bb9bb6890030d0a0/matplotlib-3.10.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae029229a57cd1e8fe542485f27e7ca7b23aa9e8944ddb4985d0bc444f1eca2", upload-time = "2025-12-10T22:56:48.954Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/86/de7e3a1cdcfc941483af70609edc06b83e7c8a0e0dc9ac325200a3f4d220/matplotlib-3.10.8-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6be43b667360fef5c754dda5d25a32e6307a03c204f3c0fc5468b78fa87b4160", size = 8251215 },
+    { url = "https://files.pythonhosted.org/packages/fd/14/baad3222f424b19ce6ad243c71de1ad9ec6b2e4eb1e458a48fdc6d120401/matplotlib-3.10.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a2b336e2d91a3d7006864e0990c83b216fcdca64b5a6484912902cef87313d78", size = 8139625 },
+    { url = "https://files.pythonhosted.org/packages/8f/a0/7024215e95d456de5883e6732e708d8187d9753a21d32f8ddb3befc0c445/matplotlib-3.10.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efb30e3baaea72ce5928e32bab719ab4770099079d66726a62b11b1ef7273be4", size = 8712614 },
+    { url = "https://files.pythonhosted.org/packages/5a/f4/b8347351da9a5b3f41e26cf547252d861f685c6867d179a7c9d60ad50189/matplotlib-3.10.8-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d56a1efd5bfd61486c8bc968fa18734464556f0fb8e51690f4ac25d85cbbbbc2", size = 9540997 },
+    { url = "https://files.pythonhosted.org/packages/9e/c0/c7b914e297efe0bc36917bf216b2acb91044b91e930e878ae12981e461e5/matplotlib-3.10.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:238b7ce5717600615c895050239ec955d91f321c209dd110db988500558e70d6", size = 9596825 },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a4bbc01c237ab710a1f22b4da72f4ff6d77eb4c7735ea9811a94ae239067/matplotlib-3.10.8-cp311-cp311-win_amd64.whl", hash = "sha256:18821ace09c763ec93aef5eeff087ee493a24051936d7b9ebcad9662f66501f9", size = 8135090 },
+    { url = "https://files.pythonhosted.org/packages/89/dd/a0b6588f102beab33ca6f5218b31725216577b2a24172f327eaf6417d5c9/matplotlib-3.10.8-cp311-cp311-win_arm64.whl", hash = "sha256:bab485bcf8b1c7d2060b4fcb6fc368a9e6f4cd754c9c2fea281f4be21df394a2", size = 8012377 },
+    { url = "https://files.pythonhosted.org/packages/04/30/3afaa31c757f34b7725ab9d2ba8b48b5e89c2019c003e7d0ead143aabc5a/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6da7c2ce169267d0d066adcf63758f0604aa6c3eebf67458930f9d9b79ad1db1", size = 8249198 },
+    { url = "https://files.pythonhosted.org/packages/48/2f/6334aec331f57485a642a7c8be03cb286f29111ae71c46c38b363230063c/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9153c3292705be9f9c64498a8872118540c3f4123d1a1c840172edf262c8be4a", size = 8136817 },
+    { url = "https://files.pythonhosted.org/packages/73/e4/6d6f14b2a759c622f191b2d67e9075a3f56aaccb3be4bb9bb6890030d0a0/matplotlib-3.10.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae029229a57cd1e8fe542485f27e7ca7b23aa9e8944ddb4985d0bc444f1eca2", size = 8713867 },
 ]
 
 [[package]]
@@ -2144,9 +2155,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615 },
 ]
 
 [package.optional-dependencies]
@@ -2164,9 +2175,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", upload-time = "2025-10-16T07:11:56.736Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/21/703a79103273b5dd268457ffb94dc8b7d6efcc7fe54413e9723cf2caa8c9/mcpadapt-0.1.19-py3-none-any.whl", hash = "sha256:052e91dea8b6f530770d6fd45a1640a8c34816d18d060918dc752c5221083525", upload-time = "2025-10-16T07:11:55.487Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/21/703a79103273b5dd268457ffb94dc8b7d6efcc7fe54413e9723cf2caa8c9/mcpadapt-0.1.19-py3-none-any.whl", hash = "sha256:052e91dea8b6f530770d6fd45a1640a8c34816d18d060918dc752c5221083525", size = 19454 },
 ]
 
 [[package]]
@@ -2176,18 +2187,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", upload-time = "2025-08-11T07:25:49.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", upload-time = "2025-08-11T07:25:47.597Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205 },
 ]
 
 [[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", upload-time = "2022-08-14T12:40:10.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", upload-time = "2022-08-14T12:40:09.779Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
 ]
 
 [[package]]
@@ -2216,9 +2227,9 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "waitress", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/0b/3404a057daceffe9ce18cd08868648a1e9b817270177bdf8a764576b988b/mlflow-3.14.0.tar.gz", hash = "sha256:5a1f818fa003035c724162096ce3ded7bc7bc47a1cae595df6173961983f4718", upload-time = "2026-06-17T07:57:44.712Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/0b/3404a057daceffe9ce18cd08868648a1e9b817270177bdf8a764576b988b/mlflow-3.14.0.tar.gz", hash = "sha256:5a1f818fa003035c724162096ce3ded7bc7bc47a1cae595df6173961983f4718", size = 11792369 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/b9/76dcdef7f7f856b36f18cfcd752c2717d9847812a0aaa36d50a7baed569d/mlflow-3.14.0-py3-none-any.whl", hash = "sha256:dbf77f7cdb5b5c0ec59b4671c61730b1b914b4dff7a2892e267a547cb5454f56", upload-time = "2026-06-17T07:57:42.348Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b9/76dcdef7f7f856b36f18cfcd752c2717d9847812a0aaa36d50a7baed569d/mlflow-3.14.0-py3-none-any.whl", hash = "sha256:dbf77f7cdb5b5c0ec59b4671c61730b1b914b4dff7a2892e267a547cb5454f56", size = 12564161 },
 ]
 
 [[package]]
@@ -2247,9 +2258,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/4f/a054cd8860590e4e942aee1aab3c94307878159f945fa844acc9ea787721/mlflow_skinny-3.14.0.tar.gz", hash = "sha256:e50f4506422c7737157ae6643c165122af7898345f2e828fa93c4f10128653cf", upload-time = "2026-06-17T07:57:44.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/4f/a054cd8860590e4e942aee1aab3c94307878159f945fa844acc9ea787721/mlflow_skinny-3.14.0.tar.gz", hash = "sha256:e50f4506422c7737157ae6643c165122af7898345f2e828fa93c4f10128653cf", size = 2901772 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/e7/b80f76ce689b9d6f21cdb84abb2b02148a1149e63a6428dd2c629cefd061/mlflow_skinny-3.14.0-py3-none-any.whl", hash = "sha256:a4880e086365871ef9d78e727a34ea5fb1ce615689579998d48e8c65ee1665a9", upload-time = "2026-06-17T07:57:42.583Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e7/b80f76ce689b9d6f21cdb84abb2b02148a1149e63a6428dd2c629cefd061/mlflow_skinny-3.14.0-py3-none-any.whl", hash = "sha256:a4880e086365871ef9d78e727a34ea5fb1ce615689579998d48e8c65ee1665a9", size = 3462788 },
 ]
 
 [[package]]
@@ -2266,42 +2277,42 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/34/ff5e72919b4eec8fe65e6fc843978a1a512194e6fafbd1761deca48269ad/mlflow_tracing-3.14.0.tar.gz", hash = "sha256:c2f701e001d35964f23fbbdfdda36c818a76c157b912ae83781199fd714be09a", upload-time = "2026-06-17T07:58:00.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/34/ff5e72919b4eec8fe65e6fc843978a1a512194e6fafbd1761deca48269ad/mlflow_tracing-3.14.0.tar.gz", hash = "sha256:c2f701e001d35964f23fbbdfdda36c818a76c157b912ae83781199fd714be09a", size = 1429017 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/4a/4658a9e514c8f079e40b608661844b9beb21c7530e6ee1e7f830cf81541e/mlflow_tracing-3.14.0-py3-none-any.whl", hash = "sha256:854488dd18068f15e2a56f1cc7b8868c611d09ea39068d0a691a3f07e0048cae", upload-time = "2026-06-17T07:57:58.687Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4a/4658a9e514c8f079e40b608661844b9beb21c7530e6ee1e7f830cf81541e/mlflow_tracing-3.14.0-py3-none-any.whl", hash = "sha256:854488dd18068f15e2a56f1cc7b8868c611d09ea39068d0a691a3f07e0048cae", size = 1703863 },
 ]
 
 [[package]]
 name = "mmh3"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/af/f28c2c2f51f31abb4725f9a64bc7863d5f491f6539bd26aee2a1d21a649e/mmh3-5.2.0.tar.gz", hash = "sha256:1efc8fec8478e9243a78bb993422cf79f8ff85cb4cf6b79647480a31e0d950a8", upload-time = "2025-07-29T07:43:48.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/af/f28c2c2f51f31abb4725f9a64bc7863d5f491f6539bd26aee2a1d21a649e/mmh3-5.2.0.tar.gz", hash = "sha256:1efc8fec8478e9243a78bb993422cf79f8ff85cb4cf6b79647480a31e0d950a8", size = 33582 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/87/399567b3796e134352e11a8b973cd470c06b2ecfad5468fe580833be442b/mmh3-5.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7901c893e704ee3c65f92d39b951f8f34ccf8e8566768c58103fb10e55afb8c1", upload-time = "2025-07-29T07:41:57.07Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/09/830af30adf8678955b247d97d3d9543dd2fd95684f3cd41c0cd9d291da9f/mmh3-5.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4a5f5536b1cbfa72318ab3bfc8a8188b949260baed186b75f0abc75b95d8c051", upload-time = "2025-07-29T07:41:57.903Z" },
-    { url = "https://files.pythonhosted.org/packages/07/14/eaba79eef55b40d653321765ac5e8f6c9ac38780b8a7c2a2f8df8ee0fb72/mmh3-5.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cedac4f4054b8f7859e5aed41aaa31ad03fce6851901a7fdc2af0275ac533c10", upload-time = "2025-07-29T07:41:58.772Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/26/83a0f852e763f81b2265d446b13ed6d49ee49e1fc0c47b9655977e6f3d81/mmh3-5.2.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eb756caf8975882630ce4e9fbbeb9d3401242a72528230422c9ab3a0d278e60c", upload-time = "2025-07-29T07:41:59.678Z" },
-    { url = "https://files.pythonhosted.org/packages/00/7d/b7133b10d12239aeaebf6878d7eaf0bf7d3738c44b4aba3c564588f6d802/mmh3-5.2.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:097e13c8b8a66c5753c6968b7640faefe85d8e38992703c1f666eda6ef4c3762", upload-time = "2025-07-29T07:42:01.197Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/3e/62f0b5dce2e22fd5b7d092aba285abd7959ea2b17148641e029f2eab1ffa/mmh3-5.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7c0c7845566b9686480e6a7e9044db4afb60038d5fabd19227443f0104eeee4", upload-time = "2025-07-29T07:42:02.601Z" },
-    { url = "https://files.pythonhosted.org/packages/66/84/ea88bb816edfe65052c757a1c3408d65c4201ddbd769d4a287b0f1a628b2/mmh3-5.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:61ac226af521a572700f863d6ecddc6ece97220ce7174e311948ff8c8919a363", upload-time = "2025-07-29T07:42:03.632Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/13/c9b1c022807db575fe4db806f442d5b5784547e2e82cff36133e58ea31c7/mmh3-5.2.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:582f9dbeefe15c32a5fa528b79b088b599a1dfe290a4436351c6090f90ddebb8", upload-time = "2025-07-29T07:42:04.991Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/5f/0e2dfe1a38f6a78788b7eb2b23432cee24623aeabbc907fed07fc17d6935/mmh3-5.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2ebfc46b39168ab1cd44670a32ea5489bcbc74a25795c61b6d888c5c2cf654ed", upload-time = "2025-07-29T07:42:05.929Z" },
-    { url = "https://files.pythonhosted.org/packages/77/27/aefb7d663b67e6a0c4d61a513c83e39ba2237e8e4557fa7122a742a23de5/mmh3-5.2.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1556e31e4bd0ac0c17eaf220be17a09c171d7396919c3794274cb3415a9d3646", upload-time = "2025-07-29T07:42:06.87Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/97/a21cc9b1a7c6e92205a1b5fa030cdf62277d177570c06a239eca7bd6dd32/mmh3-5.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:81df0dae22cd0da87f1c978602750f33d17fb3d21fb0f326c89dc89834fea79b", upload-time = "2025-07-29T07:42:07.804Z" },
-    { url = "https://files.pythonhosted.org/packages/43/18/db19ae82ea63c8922a880e1498a75342311f8aa0c581c4dd07711473b5f7/mmh3-5.2.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:eba01ec3bd4a49b9ac5ca2bc6a73ff5f3af53374b8556fcc2966dd2af9eb7779", upload-time = "2025-07-29T07:42:08.735Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f5/41dcf0d1969125fc6f61d8618b107c79130b5af50b18a4651210ea52ab40/mmh3-5.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e9a011469b47b752e7d20de296bb34591cdfcbe76c99c2e863ceaa2aa61113d2", upload-time = "2025-07-29T07:42:09.706Z" },
-    { url = "https://files.pythonhosted.org/packages/32/b3/cce9eaa0efac1f0e735bb178ef9d1d2887b4927fe0ec16609d5acd492dda/mmh3-5.2.0-cp311-cp311-win32.whl", hash = "sha256:bc44fc2b886243d7c0d8daeb37864e16f232e5b56aaec27cc781d848264cfd28", upload-time = "2025-07-29T07:42:10.546Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/e9/3fa0290122e6d5a7041b50ae500b8a9f4932478a51e48f209a3879fe0b9b/mmh3-5.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:8ebf241072cf2777a492d0e09252f8cc2b3edd07dfdb9404b9757bffeb4f2cee", upload-time = "2025-07-29T07:42:11.399Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/54/c277475b4102588e6f06b2e9095ee758dfe31a149312cdbf62d39a9f5c30/mmh3-5.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:b5f317a727bba0e633a12e71228bc6a4acb4f471a98b1c003163b917311ea9a9", upload-time = "2025-07-29T07:42:12.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/399567b3796e134352e11a8b973cd470c06b2ecfad5468fe580833be442b/mmh3-5.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7901c893e704ee3c65f92d39b951f8f34ccf8e8566768c58103fb10e55afb8c1", size = 56107 },
+    { url = "https://files.pythonhosted.org/packages/c3/09/830af30adf8678955b247d97d3d9543dd2fd95684f3cd41c0cd9d291da9f/mmh3-5.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4a5f5536b1cbfa72318ab3bfc8a8188b949260baed186b75f0abc75b95d8c051", size = 40635 },
+    { url = "https://files.pythonhosted.org/packages/07/14/eaba79eef55b40d653321765ac5e8f6c9ac38780b8a7c2a2f8df8ee0fb72/mmh3-5.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cedac4f4054b8f7859e5aed41aaa31ad03fce6851901a7fdc2af0275ac533c10", size = 40078 },
+    { url = "https://files.pythonhosted.org/packages/bb/26/83a0f852e763f81b2265d446b13ed6d49ee49e1fc0c47b9655977e6f3d81/mmh3-5.2.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eb756caf8975882630ce4e9fbbeb9d3401242a72528230422c9ab3a0d278e60c", size = 97262 },
+    { url = "https://files.pythonhosted.org/packages/00/7d/b7133b10d12239aeaebf6878d7eaf0bf7d3738c44b4aba3c564588f6d802/mmh3-5.2.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:097e13c8b8a66c5753c6968b7640faefe85d8e38992703c1f666eda6ef4c3762", size = 103118 },
+    { url = "https://files.pythonhosted.org/packages/7b/3e/62f0b5dce2e22fd5b7d092aba285abd7959ea2b17148641e029f2eab1ffa/mmh3-5.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7c0c7845566b9686480e6a7e9044db4afb60038d5fabd19227443f0104eeee4", size = 106072 },
+    { url = "https://files.pythonhosted.org/packages/66/84/ea88bb816edfe65052c757a1c3408d65c4201ddbd769d4a287b0f1a628b2/mmh3-5.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:61ac226af521a572700f863d6ecddc6ece97220ce7174e311948ff8c8919a363", size = 112925 },
+    { url = "https://files.pythonhosted.org/packages/2e/13/c9b1c022807db575fe4db806f442d5b5784547e2e82cff36133e58ea31c7/mmh3-5.2.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:582f9dbeefe15c32a5fa528b79b088b599a1dfe290a4436351c6090f90ddebb8", size = 120583 },
+    { url = "https://files.pythonhosted.org/packages/8a/5f/0e2dfe1a38f6a78788b7eb2b23432cee24623aeabbc907fed07fc17d6935/mmh3-5.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2ebfc46b39168ab1cd44670a32ea5489bcbc74a25795c61b6d888c5c2cf654ed", size = 99127 },
+    { url = "https://files.pythonhosted.org/packages/77/27/aefb7d663b67e6a0c4d61a513c83e39ba2237e8e4557fa7122a742a23de5/mmh3-5.2.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1556e31e4bd0ac0c17eaf220be17a09c171d7396919c3794274cb3415a9d3646", size = 98544 },
+    { url = "https://files.pythonhosted.org/packages/ab/97/a21cc9b1a7c6e92205a1b5fa030cdf62277d177570c06a239eca7bd6dd32/mmh3-5.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:81df0dae22cd0da87f1c978602750f33d17fb3d21fb0f326c89dc89834fea79b", size = 106262 },
+    { url = "https://files.pythonhosted.org/packages/43/18/db19ae82ea63c8922a880e1498a75342311f8aa0c581c4dd07711473b5f7/mmh3-5.2.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:eba01ec3bd4a49b9ac5ca2bc6a73ff5f3af53374b8556fcc2966dd2af9eb7779", size = 109824 },
+    { url = "https://files.pythonhosted.org/packages/9f/f5/41dcf0d1969125fc6f61d8618b107c79130b5af50b18a4651210ea52ab40/mmh3-5.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e9a011469b47b752e7d20de296bb34591cdfcbe76c99c2e863ceaa2aa61113d2", size = 97255 },
+    { url = "https://files.pythonhosted.org/packages/32/b3/cce9eaa0efac1f0e735bb178ef9d1d2887b4927fe0ec16609d5acd492dda/mmh3-5.2.0-cp311-cp311-win32.whl", hash = "sha256:bc44fc2b886243d7c0d8daeb37864e16f232e5b56aaec27cc781d848264cfd28", size = 40779 },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/3fa0290122e6d5a7041b50ae500b8a9f4932478a51e48f209a3879fe0b9b/mmh3-5.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:8ebf241072cf2777a492d0e09252f8cc2b3edd07dfdb9404b9757bffeb4f2cee", size = 41549 },
+    { url = "https://files.pythonhosted.org/packages/3a/54/c277475b4102588e6f06b2e9095ee758dfe31a149312cdbf62d39a9f5c30/mmh3-5.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:b5f317a727bba0e633a12e71228bc6a4acb4f471a98b1c003163b917311ea9a9", size = 39336 },
 ]
 
 [[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", upload-time = "2023-03-07T16:47:11.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", upload-time = "2023-03-07T16:47:09.197Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
 ]
 
 [[package]]
@@ -2313,9 +2324,9 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/0e/c857c46d653e104019a84f22d4494f2119b4fe9f896c92b4b864b3b045cc/msal-1.34.0.tar.gz", hash = "sha256:76ba83b716ea5a6d75b0279c0ac353a0e05b820ca1f6682c0eb7f45190c43c2f", upload-time = "2025-09-22T23:05:48.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/0e/c857c46d653e104019a84f22d4494f2119b4fe9f896c92b4b864b3b045cc/msal-1.34.0.tar.gz", hash = "sha256:76ba83b716ea5a6d75b0279c0ac353a0e05b820ca1f6682c0eb7f45190c43c2f", size = 153961 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/dc/18d48843499e278538890dc709e9ee3dea8375f8be8e82682851df1b48b5/msal-1.34.0-py3-none-any.whl", hash = "sha256:f669b1644e4950115da7a176441b0e13ec2975c29528d8b9e81316023676d6e1", upload-time = "2025-09-22T23:05:47.294Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/18d48843499e278538890dc709e9ee3dea8375f8be8e82682851df1b48b5/msal-1.34.0-py3-none-any.whl", hash = "sha256:f669b1644e4950115da7a176441b0e13ec2975c29528d8b9e81316023676d6e1", size = 116987 },
 ]
 
 [[package]]
@@ -2325,36 +2336,36 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "msal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", upload-time = "2025-03-14T23:51:03.902Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", upload-time = "2025-03-14T23:51:03.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583 },
 ]
 
 [[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", upload-time = "2026-01-26T02:46:45.979Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", upload-time = "2026-01-26T02:43:26.485Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", upload-time = "2026-01-26T02:43:27.607Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", upload-time = "2026-01-26T02:43:28.661Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", upload-time = "2026-01-26T02:43:31.165Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", upload-time = "2026-01-26T02:43:32.581Z" },
-    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", upload-time = "2026-01-26T02:43:34.417Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", upload-time = "2026-01-26T02:43:35.741Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", upload-time = "2026-01-26T02:43:36.976Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", upload-time = "2026-01-26T02:43:38.258Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", upload-time = "2026-01-26T02:43:40.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", upload-time = "2026-01-26T02:43:41.752Z" },
-    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", upload-time = "2026-01-26T02:43:43.042Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", upload-time = "2026-01-26T02:43:44.371Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", upload-time = "2026-01-26T02:43:45.745Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", upload-time = "2026-01-26T02:43:47.054Z" },
-    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", upload-time = "2026-01-26T02:43:48.753Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", upload-time = "2026-01-26T02:43:49.921Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", upload-time = "2026-01-26T02:43:51.635Z" },
-    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", upload-time = "2026-01-26T02:46:44.004Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626 },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706 },
+    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356 },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", size = 244355 },
+    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", size = 246433 },
+    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", size = 225376 },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", size = 257365 },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", size = 254747 },
+    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", size = 246293 },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", size = 242962 },
+    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", size = 237360 },
+    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", size = 245940 },
+    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", size = 253502 },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", size = 247065 },
+    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", size = 241870 },
+    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", size = 41302 },
+    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981 },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159 },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319 },
 ]
 
 [[package]]
@@ -2367,33 +2378,33 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", upload-time = "2025-12-15T05:03:48.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/47/6b3ebabd5474d9cdc170d1342fbf9dddc1b0ec13ec90bf9004ee6f391c31/mypy-1.19.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d8dfc6ab58ca7dda47d9237349157500468e404b17213d44fc1cb77bce532288", upload-time = "2025-12-15T05:03:44.129Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/a6/ac7c7a88a3c9c54334f53a941b765e6ec6c4ebd65d3fe8cdcfbe0d0fd7db/mypy-1.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3f276d8493c3c97930e354b2595a44a21348b320d859fb4a2b9f66da9ed27ab", upload-time = "2025-12-15T05:03:37.679Z" },
-    { url = "https://files.pythonhosted.org/packages/67/af/3afa9cf880aa4a2c803798ac24f1d11ef72a0c8079689fac5cfd815e2830/mypy-1.19.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2abb24cf3f17864770d18d673c85235ba52456b36a06b6afc1e07c1fdcd3d0e6", upload-time = "2025-12-15T05:02:31.526Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/46/20f8a7114a56484ab268b0ab372461cb3a8f7deed31ea96b83a4e4cfcfca/mypy-1.19.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a009ffa5a621762d0c926a078c2d639104becab69e79538a494bcccb62cc0331", upload-time = "2025-12-15T05:03:15.606Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/f8/33b291ea85050a21f15da910002460f1f445f8007adb29230f0adea279cb/mypy-1.19.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f7cee03c9a2e2ee26ec07479f38ea9c884e301d42c6d43a19d20fb014e3ba925", upload-time = "2025-12-15T05:02:26.731Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/a3/47cbd4e85bec4335a9cd80cf67dbc02be21b5d4c9c23ad6b95d6c5196bac/mypy-1.19.1-cp311-cp311-win_amd64.whl", hash = "sha256:4b84a7a18f41e167f7995200a1d07a4a6810e89d29859df936f1c3923d263042", upload-time = "2025-12-15T05:03:26.179Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", upload-time = "2025-12-15T05:03:07.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/47/6b3ebabd5474d9cdc170d1342fbf9dddc1b0ec13ec90bf9004ee6f391c31/mypy-1.19.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d8dfc6ab58ca7dda47d9237349157500468e404b17213d44fc1cb77bce532288", size = 13028539 },
+    { url = "https://files.pythonhosted.org/packages/5c/a6/ac7c7a88a3c9c54334f53a941b765e6ec6c4ebd65d3fe8cdcfbe0d0fd7db/mypy-1.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3f276d8493c3c97930e354b2595a44a21348b320d859fb4a2b9f66da9ed27ab", size = 12083163 },
+    { url = "https://files.pythonhosted.org/packages/67/af/3afa9cf880aa4a2c803798ac24f1d11ef72a0c8079689fac5cfd815e2830/mypy-1.19.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2abb24cf3f17864770d18d673c85235ba52456b36a06b6afc1e07c1fdcd3d0e6", size = 12687629 },
+    { url = "https://files.pythonhosted.org/packages/2d/46/20f8a7114a56484ab268b0ab372461cb3a8f7deed31ea96b83a4e4cfcfca/mypy-1.19.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a009ffa5a621762d0c926a078c2d639104becab69e79538a494bcccb62cc0331", size = 13436933 },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/33b291ea85050a21f15da910002460f1f445f8007adb29230f0adea279cb/mypy-1.19.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f7cee03c9a2e2ee26ec07479f38ea9c884e301d42c6d43a19d20fb014e3ba925", size = 13661754 },
+    { url = "https://files.pythonhosted.org/packages/fd/a3/47cbd4e85bec4335a9cd80cf67dbc02be21b5d4c9c23ad6b95d6c5196bac/mypy-1.19.1-cp311-cp311-win_amd64.whl", hash = "sha256:4b84a7a18f41e167f7995200a1d07a4a6810e89d29859df936f1c3923d263042", size = 10055772 },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239 },
 ]
 
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", upload-time = "2025-04-22T14:54:24.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", upload-time = "2025-04-22T14:54:22.983Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
 ]
 
 [[package]]
 name = "narwhals"
 version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6f/713be67779028d482c6e0f2dde5bc430021b2578a4808c1c9f6d7ad48257/narwhals-2.16.0.tar.gz", hash = "sha256:155bb45132b370941ba0396d123cf9ed192bf25f39c4cea726f2da422ca4e145", upload-time = "2026-02-02T10:31:00.545Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6f/713be67779028d482c6e0f2dde5bc430021b2578a4808c1c9f6d7ad48257/narwhals-2.16.0.tar.gz", hash = "sha256:155bb45132b370941ba0396d123cf9ed192bf25f39c4cea726f2da422ca4e145", size = 618268 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/cc/7cb74758e6df95e0c4e1253f203b6dd7f348bf2f29cf89e9210a2416d535/narwhals-2.16.0-py3-none-any.whl", hash = "sha256:846f1fd7093ac69d63526e50732033e86c30ea0026a44d9b23991010c7d1485d", upload-time = "2026-02-02T10:30:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/7cb74758e6df95e0c4e1253f203b6dd7f348bf2f29cf89e9210a2416d535/narwhals-2.16.0-py3-none-any.whl", hash = "sha256:846f1fd7093ac69d63526e50732033e86c30ea0026a44d9b23991010c7d1485d", size = 443951 },
 ]
 
 [[package]]
@@ -2410,44 +2421,44 @@ dependencies = [
     { name = "tqdm" },
     { name = "utilsforecast" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/43/f1b50292ffebf88bcf4bd08caf3738f975ad906356ded373394e616911da/nixtla-0.7.2.tar.gz", hash = "sha256:66b218662f0c738130e0a6a5be4edb0b6dc70536c317cdd0287dc01c350c1c2a", upload-time = "2025-12-10T22:37:28.845Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/43/f1b50292ffebf88bcf4bd08caf3738f975ad906356ded373394e616911da/nixtla-0.7.2.tar.gz", hash = "sha256:66b218662f0c738130e0a6a5be4edb0b6dc70536c317cdd0287dc01c350c1c2a", size = 105374 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/5f/cf3f4124344097d5ceb988e052e782e92629c006c289755972297c6e5c50/nixtla-0.7.2-py3-none-any.whl", hash = "sha256:e8be55be3057432b043a04cea314df0caa1a3a6f63fede5bb8063a7609bff74a", upload-time = "2025-12-10T22:37:26.939Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5f/cf3f4124344097d5ceb988e052e782e92629c006c289755972297c6e5c50/nixtla-0.7.2-py3-none-any.whl", hash = "sha256:e8be55be3057432b043a04cea314df0caa1a3a6f63fede5bb8063a7609bff74a", size = 127815 },
 ]
 
 [[package]]
 name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", upload-time = "2026-01-31T23:13:10.135Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/44/71852273146957899753e69986246d6a176061ea183407e95418c2aa4d9a/numpy-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e88598032542bd49af7c4747541422884219056c268823ef6e5e89851c8825", upload-time = "2026-01-31T23:10:25.623Z" },
-    { url = "https://files.pythonhosted.org/packages/74/41/5d17d4058bd0cd96bcbd4d9ff0fb2e21f52702aab9a72e4a594efa18692f/numpy-2.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7edc794af8b36ca37ef5fcb5e0d128c7e0595c7b96a2318d1badb6fcd8ee86b1", upload-time = "2026-01-31T23:10:28.186Z" },
-    { url = "https://files.pythonhosted.org/packages/49/48/fb1ce8136c19452ed15f033f8aee91d5defe515094e330ce368a0647846f/numpy-2.4.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:6e9f61981ace1360e42737e2bae58b27bf28a1b27e781721047d84bd754d32e7", upload-time = "2026-01-31T23:10:30.848Z" },
-    { url = "https://files.pythonhosted.org/packages/40/a9/3feb49f17bbd1300dd2570432961f5c8a4ffeff1db6f02c7273bd020a4c9/numpy-2.4.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:cb7bbb88aa74908950d979eeaa24dbdf1a865e3c7e45ff0121d8f70387b55f73", upload-time = "2026-01-31T23:10:32.352Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/39/fdf35cbd6d6e2fcad42fcf85ac04a85a0d0fbfbf34b30721c98d602fd70a/numpy-2.4.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f069069931240b3fc703f1e23df63443dbd6390614c8c44a87d96cd0ec81eb1", upload-time = "2026-01-31T23:10:34.502Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/46/6fa4ea94f1ddf969b2ee941290cca6f1bfac92b53c76ae5f44afe17ceb69/numpy-2.4.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c02ef4401a506fb60b411467ad501e1429a3487abca4664871d9ae0b46c8ba32", upload-time = "2026-01-31T23:10:37.075Z" },
-    { url = "https://files.pythonhosted.org/packages/09/a1/2a424e162b1a14a5bd860a464ab4e07513916a64ab1683fae262f735ccd2/numpy-2.4.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2653de5c24910e49c2b106499803124dde62a5a1fe0eedeaecf4309a5f639390", upload-time = "2026-01-31T23:10:39.704Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/a2/73014149ff250628df72c58204822ac01d768697913881aacf839ff78680/numpy-2.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1ae241bbfc6ae276f94a170b14785e561cb5e7f626b6688cf076af4110887413", upload-time = "2026-01-31T23:10:41.924Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/0c/73e8be2f1accd56df74abc1c5e18527822067dced5ec0861b5bb882c2ce0/numpy-2.4.2-cp311-cp311-win32.whl", hash = "sha256:df1b10187212b198dd45fa943d8985a3c8cf854aed4923796e0e019e113a1bda", upload-time = "2026-01-31T23:10:45.26Z" },
-    { url = "https://files.pythonhosted.org/packages/76/ae/e0265e0163cf127c24c3969d29f1c4c64551a1e375d95a13d32eab25d364/numpy-2.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:b9c618d56a29c9cb1c4da979e9899be7578d2e0b3c24d52079c166324c9e8695", upload-time = "2026-01-31T23:10:47.021Z" },
-    { url = "https://files.pythonhosted.org/packages/29/a5/c43029af9b8014d6ea157f192652c50042e8911f4300f8f6ed3336bf437f/numpy-2.4.2-cp311-cp311-win_arm64.whl", hash = "sha256:47c5a6ed21d9452b10227e5e8a0e1c22979811cad7dcc19d8e3e2fb8fa03f1a3", upload-time = "2026-01-31T23:10:50.087Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f8/50e14d36d915ef64d8f8bc4a087fc8264d82c785eda6711f80ab7e620335/numpy-2.4.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:89f7268c009bc492f506abd6f5265defa7cb3f7487dc21d357c3d290add45082", upload-time = "2026-01-31T23:12:53.5Z" },
-    { url = "https://files.pythonhosted.org/packages/17/17/809b5cad63812058a8189e91a1e2d55a5a18fd04611dbad244e8aeae465c/numpy-2.4.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6dee3bb76aa4009d5a912180bf5b2de012532998d094acee25d9cb8dee3e44a", upload-time = "2026-01-31T23:12:55.933Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/ea/181b9bcf7627fc8371720316c24db888dcb9829b1c0270abf3d288b2e29b/numpy-2.4.2-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:cd2bd2bbed13e213d6b55dc1d035a4f91748a7d3edc9480c13898b0353708920", upload-time = "2026-01-31T23:12:58.671Z" },
-    { url = "https://files.pythonhosted.org/packages/33/9f/413adf3fc955541ff5536b78fcf0754680b3c6d95103230252a2c9408d23/numpy-2.4.2-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:cf28c0c1d4c4bf00f509fa7eb02c58d7caf221b50b467bcb0d9bbf1584d5c821", upload-time = "2026-01-31T23:13:00.518Z" },
-    { url = "https://files.pythonhosted.org/packages/91/da/643aad274e29ccbdf42ecd94dafe524b81c87bcb56b83872d54827f10543/numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e04ae107ac591763a47398bb45b568fc38f02dbc4aa44c063f67a131f99346cb", upload-time = "2026-01-31T23:13:02.219Z" },
-    { url = "https://files.pythonhosted.org/packages/66/27/965b8525e9cb5dc16481b30a1b3c21e50c7ebf6e9dbd48d0c4d0d5089c7e/numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:602f65afdef699cda27ec0b9224ae5dc43e328f4c24c689deaf77133dbee74d0", upload-time = "2026-01-31T23:13:04.62Z" },
-    { url = "https://files.pythonhosted.org/packages/de/e5/b7d20451657664b07986c2f6e3be564433f5dcaf3482d68eaecd79afaf03/numpy-2.4.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be71bf1edb48ebbbf7f6337b5bfd2f895d1902f6335a5830b20141fc126ffba0", upload-time = "2026-01-31T23:13:07.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/44/71852273146957899753e69986246d6a176061ea183407e95418c2aa4d9a/numpy-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e88598032542bd49af7c4747541422884219056c268823ef6e5e89851c8825", size = 16955478 },
+    { url = "https://files.pythonhosted.org/packages/74/41/5d17d4058bd0cd96bcbd4d9ff0fb2e21f52702aab9a72e4a594efa18692f/numpy-2.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7edc794af8b36ca37ef5fcb5e0d128c7e0595c7b96a2318d1badb6fcd8ee86b1", size = 14965467 },
+    { url = "https://files.pythonhosted.org/packages/49/48/fb1ce8136c19452ed15f033f8aee91d5defe515094e330ce368a0647846f/numpy-2.4.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:6e9f61981ace1360e42737e2bae58b27bf28a1b27e781721047d84bd754d32e7", size = 5475172 },
+    { url = "https://files.pythonhosted.org/packages/40/a9/3feb49f17bbd1300dd2570432961f5c8a4ffeff1db6f02c7273bd020a4c9/numpy-2.4.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:cb7bbb88aa74908950d979eeaa24dbdf1a865e3c7e45ff0121d8f70387b55f73", size = 6805145 },
+    { url = "https://files.pythonhosted.org/packages/3f/39/fdf35cbd6d6e2fcad42fcf85ac04a85a0d0fbfbf34b30721c98d602fd70a/numpy-2.4.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f069069931240b3fc703f1e23df63443dbd6390614c8c44a87d96cd0ec81eb1", size = 15966084 },
+    { url = "https://files.pythonhosted.org/packages/1b/46/6fa4ea94f1ddf969b2ee941290cca6f1bfac92b53c76ae5f44afe17ceb69/numpy-2.4.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c02ef4401a506fb60b411467ad501e1429a3487abca4664871d9ae0b46c8ba32", size = 16899477 },
+    { url = "https://files.pythonhosted.org/packages/09/a1/2a424e162b1a14a5bd860a464ab4e07513916a64ab1683fae262f735ccd2/numpy-2.4.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2653de5c24910e49c2b106499803124dde62a5a1fe0eedeaecf4309a5f639390", size = 17323429 },
+    { url = "https://files.pythonhosted.org/packages/ce/a2/73014149ff250628df72c58204822ac01d768697913881aacf839ff78680/numpy-2.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1ae241bbfc6ae276f94a170b14785e561cb5e7f626b6688cf076af4110887413", size = 18635109 },
+    { url = "https://files.pythonhosted.org/packages/6c/0c/73e8be2f1accd56df74abc1c5e18527822067dced5ec0861b5bb882c2ce0/numpy-2.4.2-cp311-cp311-win32.whl", hash = "sha256:df1b10187212b198dd45fa943d8985a3c8cf854aed4923796e0e019e113a1bda", size = 6237915 },
+    { url = "https://files.pythonhosted.org/packages/76/ae/e0265e0163cf127c24c3969d29f1c4c64551a1e375d95a13d32eab25d364/numpy-2.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:b9c618d56a29c9cb1c4da979e9899be7578d2e0b3c24d52079c166324c9e8695", size = 12607972 },
+    { url = "https://files.pythonhosted.org/packages/29/a5/c43029af9b8014d6ea157f192652c50042e8911f4300f8f6ed3336bf437f/numpy-2.4.2-cp311-cp311-win_arm64.whl", hash = "sha256:47c5a6ed21d9452b10227e5e8a0e1c22979811cad7dcc19d8e3e2fb8fa03f1a3", size = 10485763 },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/50e14d36d915ef64d8f8bc4a087fc8264d82c785eda6711f80ab7e620335/numpy-2.4.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:89f7268c009bc492f506abd6f5265defa7cb3f7487dc21d357c3d290add45082", size = 16833179 },
+    { url = "https://files.pythonhosted.org/packages/17/17/809b5cad63812058a8189e91a1e2d55a5a18fd04611dbad244e8aeae465c/numpy-2.4.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6dee3bb76aa4009d5a912180bf5b2de012532998d094acee25d9cb8dee3e44a", size = 14889755 },
+    { url = "https://files.pythonhosted.org/packages/3e/ea/181b9bcf7627fc8371720316c24db888dcb9829b1c0270abf3d288b2e29b/numpy-2.4.2-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:cd2bd2bbed13e213d6b55dc1d035a4f91748a7d3edc9480c13898b0353708920", size = 5399500 },
+    { url = "https://files.pythonhosted.org/packages/33/9f/413adf3fc955541ff5536b78fcf0754680b3c6d95103230252a2c9408d23/numpy-2.4.2-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:cf28c0c1d4c4bf00f509fa7eb02c58d7caf221b50b467bcb0d9bbf1584d5c821", size = 6714252 },
+    { url = "https://files.pythonhosted.org/packages/91/da/643aad274e29ccbdf42ecd94dafe524b81c87bcb56b83872d54827f10543/numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e04ae107ac591763a47398bb45b568fc38f02dbc4aa44c063f67a131f99346cb", size = 15797142 },
+    { url = "https://files.pythonhosted.org/packages/66/27/965b8525e9cb5dc16481b30a1b3c21e50c7ebf6e9dbd48d0c4d0d5089c7e/numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:602f65afdef699cda27ec0b9224ae5dc43e328f4c24c689deaf77133dbee74d0", size = 16727979 },
+    { url = "https://files.pythonhosted.org/packages/de/e5/b7d20451657664b07986c2f6e3be564433f5dcaf3482d68eaecd79afaf03/numpy-2.4.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be71bf1edb48ebbbf7f6337b5bfd2f895d1902f6335a5830b20141fc126ffba0", size = 12502577 },
 ]
 
 [[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", upload-time = "2025-06-19T22:48:08.269Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", upload-time = "2025-06-19T22:48:06.508Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065 },
 ]
 
 [[package]]
@@ -2458,9 +2469,9 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", upload-time = "2026-04-29T21:21:15.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", upload-time = "2026-04-29T21:21:13.794Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115 },
 ]
 
 [[package]]
@@ -2475,10 +2486,10 @@ dependencies = [
     { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/88/d9757c62a0f96b5193f8d447a141eefd14498c404cc5caf1a6f3233cf102/onnxruntime-1.24.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:79b3119ab9f4f3817062e6dbe7f4a44937de93905e3a31ba34313d18cb49e7be", upload-time = "2026-02-05T17:32:13.986Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/61/b3305c39144e19dbe8791802076b29b4b592b09de03d0e340c1314bfd408/onnxruntime-1.24.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86bc43e922b1f581b3de26a3dc402149c70e5542fceb5bec6b3a85542dbeb164", upload-time = "2026-02-05T17:30:53.846Z" },
-    { url = "https://files.pythonhosted.org/packages/94/d6/d273b75fe7825ea3feed321dd540aef33d8a1380ddd8ac3bb70a8ed000fe/onnxruntime-1.24.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cabe71ca14dcfbf812d312aab0a704507ac909c137ee6e89e4908755d0fc60e", upload-time = "2026-02-05T17:31:29.057Z" },
-    { url = "https://files.pythonhosted.org/packages/21/3f/0616101a3938bfe2918ea60b581a9bbba61ffc255c63388abb0885f7ce18/onnxruntime-1.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:3273c330f5802b64b4103e87b5bbc334c0355fff1b8935d8910b0004ce2f20c8", upload-time = "2026-02-05T17:32:04.451Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/88/d9757c62a0f96b5193f8d447a141eefd14498c404cc5caf1a6f3233cf102/onnxruntime-1.24.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:79b3119ab9f4f3817062e6dbe7f4a44937de93905e3a31ba34313d18cb49e7be", size = 17212018 },
+    { url = "https://files.pythonhosted.org/packages/7b/61/b3305c39144e19dbe8791802076b29b4b592b09de03d0e340c1314bfd408/onnxruntime-1.24.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86bc43e922b1f581b3de26a3dc402149c70e5542fceb5bec6b3a85542dbeb164", size = 15018703 },
+    { url = "https://files.pythonhosted.org/packages/94/d6/d273b75fe7825ea3feed321dd540aef33d8a1380ddd8ac3bb70a8ed000fe/onnxruntime-1.24.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cabe71ca14dcfbf812d312aab0a704507ac909c137ee6e89e4908755d0fc60e", size = 17096352 },
+    { url = "https://files.pythonhosted.org/packages/21/3f/0616101a3938bfe2918ea60b581a9bbba61ffc255c63388abb0885f7ce18/onnxruntime-1.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:3273c330f5802b64b4103e87b5bbc334c0355fff1b8935d8910b0004ce2f20c8", size = 12493235 },
 ]
 
 [[package]]
@@ -2495,9 +2506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", upload-time = "2026-04-15T22:28:19.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", upload-time = "2026-04-15T22:28:17.714Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570 },
 ]
 
 [[package]]
@@ -2510,9 +2521,9 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/b6/c0e7e047ae4962f2755a3bc9141fdd6272c75c74e47dfc6aa71978a9b78f/openinference_instrumentation-0.1.53.tar.gz", hash = "sha256:3c0c145cf6e13cfa630b29d0e3ca806f3821470ffca7922f1590e3970fadd4da", upload-time = "2026-06-02T16:37:21.771Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b6/c0e7e047ae4962f2755a3bc9141fdd6272c75c74e47dfc6aa71978a9b78f/openinference_instrumentation-0.1.53.tar.gz", hash = "sha256:3c0c145cf6e13cfa630b29d0e3ca806f3821470ffca7922f1590e3970fadd4da", size = 33712 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/bb/01262d9945c476e15aa21bb9ca05b18604e525d73d9761cadb677f485198/openinference_instrumentation-0.1.53-py3-none-any.whl", hash = "sha256:f43695080eded47b1e03ff1b19cb5c23ea4409459cfe16c5b5748d5656832eb1", upload-time = "2026-06-02T16:37:20.69Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bb/01262d9945c476e15aa21bb9ca05b18604e525d73d9761cadb677f485198/openinference_instrumentation-0.1.53-py3-none-any.whl", hash = "sha256:f43695080eded47b1e03ff1b19cb5c23ea4409459cfe16c5b5748d5656832eb1", size = 40958 },
 ]
 
 [[package]]
@@ -2528,18 +2539,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/77/44e8bdeb10ce729f5a0de97d7ec443665cac900417e9132029f9db9ea4fa/openinference_instrumentation_crewai-1.1.9.tar.gz", hash = "sha256:8075d6973850f3fb9c1e3a935ad1f01ebb02c54856942055cc322c3a8a58ee78", upload-time = "2026-06-02T16:37:23.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/77/44e8bdeb10ce729f5a0de97d7ec443665cac900417e9132029f9db9ea4fa/openinference_instrumentation_crewai-1.1.9.tar.gz", hash = "sha256:8075d6973850f3fb9c1e3a935ad1f01ebb02c54856942055cc322c3a8a58ee78", size = 26240 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/5b/cb4a0c4eebe1055fe9913b183c1518b982f89ad3ec2e0a183e0e72c370f6/openinference_instrumentation_crewai-1.1.9-py3-none-any.whl", hash = "sha256:ae25c40e3a5007c7d9da453a69e9b4b7b03b3847482e51c9024ff74c0597e392", upload-time = "2026-06-02T16:37:22.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/5b/cb4a0c4eebe1055fe9913b183c1518b982f89ad3ec2e0a183e0e72c370f6/openinference_instrumentation_crewai-1.1.9-py3-none-any.whl", hash = "sha256:ae25c40e3a5007c7d9da453a69e9b4b7b03b3847482e51c9024ff74c0597e392", size = 29101 },
 ]
 
 [[package]]
 name = "openinference-semantic-conventions"
 version = "0.1.30"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/51/8ba1182ee86fc79793d5ff2d11e7fdcda10ded2d01f3e46ca6fcf0568213/openinference_semantic_conventions-0.1.30.tar.gz", hash = "sha256:81fece76e09c83789e35c393b8b30523481eeabf1008745b955631a53e3221d9", upload-time = "2026-05-22T21:10:44.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/51/8ba1182ee86fc79793d5ff2d11e7fdcda10ded2d01f3e46ca6fcf0568213/openinference_semantic_conventions-0.1.30.tar.gz", hash = "sha256:81fece76e09c83789e35c393b8b30523481eeabf1008745b955631a53e3221d9", size = 13391 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/76/5b7e78cf0de38589b821bbe8e9c29c59a6e76edfb980488d0854cbb90f7c/openinference_semantic_conventions-0.1.30-py3-none-any.whl", hash = "sha256:36d946d3f95f699b7c4b12324ae9c1f02d6c7750df11eece56aa159cff430b3d", upload-time = "2026-05-22T21:10:43.04Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/76/5b7e78cf0de38589b821bbe8e9c29c59a6e76edfb980488d0854cbb90f7c/openinference_semantic_conventions-0.1.30-py3-none-any.whl", hash = "sha256:36d946d3f95f699b7c4b12324ae9c1f02d6c7750df11eece56aa159cff430b3d", size = 10911 },
 ]
 
 [[package]]
@@ -2549,9 +2560,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "et-xmlfile" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", upload-time = "2024-06-28T14:03:44.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", upload-time = "2024-06-28T14:03:41.161Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910 },
 ]
 
 [[package]]
@@ -2562,9 +2573,9 @@ dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/5e/94a8cb759e4e409022229418294e098ca7feca00eb3c467bb20cbd329bda/opentelemetry_api-1.34.1.tar.gz", hash = "sha256:64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3", upload-time = "2025-06-10T08:55:19.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/5e/94a8cb759e4e409022229418294e098ca7feca00eb3c467bb20cbd329bda/opentelemetry_api-1.34.1.tar.gz", hash = "sha256:64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3", size = 64987 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/3a/2ba85557e8dc024c0842ad22c570418dc02c36cbd1ab4b832a93edf071b8/opentelemetry_api-1.34.1-py3-none-any.whl", hash = "sha256:b7df4cb0830d5a6c29ad0c0691dbae874d8daefa934b8b1d642de48323d32a8c", upload-time = "2025-06-10T08:54:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3a/2ba85557e8dc024c0842ad22c570418dc02c36cbd1ab4b832a93edf071b8/opentelemetry_api-1.34.1-py3-none-any.whl", hash = "sha256:b7df4cb0830d5a6c29ad0c0691dbae874d8daefa934b8b1d642de48323d32a8c", size = 65767 },
 ]
 
 [[package]]
@@ -2574,9 +2585,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/f0/ff235936ee40db93360233b62da932d4fd9e8d103cd090c6bcb9afaf5f01/opentelemetry_exporter_otlp_proto_common-1.34.1.tar.gz", hash = "sha256:b59a20a927facd5eac06edaf87a07e49f9e4a13db487b7d8a52b37cb87710f8b", upload-time = "2025-06-10T08:55:22.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/f0/ff235936ee40db93360233b62da932d4fd9e8d103cd090c6bcb9afaf5f01/opentelemetry_exporter_otlp_proto_common-1.34.1.tar.gz", hash = "sha256:b59a20a927facd5eac06edaf87a07e49f9e4a13db487b7d8a52b37cb87710f8b", size = 20817 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/e8/8b292a11cc8d8d87ec0c4089ae21b6a58af49ca2e51fa916435bc922fdc7/opentelemetry_exporter_otlp_proto_common-1.34.1-py3-none-any.whl", hash = "sha256:8e2019284bf24d3deebbb6c59c71e6eef3307cd88eff8c633e061abba33f7e87", upload-time = "2025-06-10T08:55:00.806Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e8/8b292a11cc8d8d87ec0c4089ae21b6a58af49ca2e51fa916435bc922fdc7/opentelemetry_exporter_otlp_proto_common-1.34.1-py3-none-any.whl", hash = "sha256:8e2019284bf24d3deebbb6c59c71e6eef3307cd88eff8c633e061abba33f7e87", size = 18834 },
 ]
 
 [[package]]
@@ -2592,9 +2603,9 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/f7/bb63837a3edb9ca857aaf5760796874e7cecddc88a2571b0992865a48fb6/opentelemetry_exporter_otlp_proto_grpc-1.34.1.tar.gz", hash = "sha256:7c841b90caa3aafcfc4fee58487a6c71743c34c6dc1787089d8b0578bbd794dd", upload-time = "2025-06-10T08:55:23.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f7/bb63837a3edb9ca857aaf5760796874e7cecddc88a2571b0992865a48fb6/opentelemetry_exporter_otlp_proto_grpc-1.34.1.tar.gz", hash = "sha256:7c841b90caa3aafcfc4fee58487a6c71743c34c6dc1787089d8b0578bbd794dd", size = 22566 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/42/0a4dd47e7ef54edf670c81fc06a83d68ea42727b82126a1df9dd0477695d/opentelemetry_exporter_otlp_proto_grpc-1.34.1-py3-none-any.whl", hash = "sha256:04bb8b732b02295be79f8a86a4ad28fae3d4ddb07307a98c7aa6f331de18cca6", upload-time = "2025-06-10T08:55:02.214Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/42/0a4dd47e7ef54edf670c81fc06a83d68ea42727b82126a1df9dd0477695d/opentelemetry_exporter_otlp_proto_grpc-1.34.1-py3-none-any.whl", hash = "sha256:04bb8b732b02295be79f8a86a4ad28fae3d4ddb07307a98c7aa6f331de18cca6", size = 18615 },
 ]
 
 [[package]]
@@ -2610,9 +2621,9 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/8f/954bc725961cbe425a749d55c0ba1df46832a5999eae764d1a7349ac1c29/opentelemetry_exporter_otlp_proto_http-1.34.1.tar.gz", hash = "sha256:aaac36fdce46a8191e604dcf632e1f9380c7d5b356b27b3e0edb5610d9be28ad", upload-time = "2025-06-10T08:55:24.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/8f/954bc725961cbe425a749d55c0ba1df46832a5999eae764d1a7349ac1c29/opentelemetry_exporter_otlp_proto_http-1.34.1.tar.gz", hash = "sha256:aaac36fdce46a8191e604dcf632e1f9380c7d5b356b27b3e0edb5610d9be28ad", size = 15351 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/54/b05251c04e30c1ac70cf4a7c5653c085dfcf2c8b98af71661d6a252adc39/opentelemetry_exporter_otlp_proto_http-1.34.1-py3-none-any.whl", hash = "sha256:5251f00ca85872ce50d871f6d3cc89fe203b94c3c14c964bbdc3883366c705d8", upload-time = "2025-06-10T08:55:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/b05251c04e30c1ac70cf4a7c5653c085dfcf2c8b98af71661d6a252adc39/opentelemetry_exporter_otlp_proto_http-1.34.1-py3-none-any.whl", hash = "sha256:5251f00ca85872ce50d871f6d3cc89fe203b94c3c14c964bbdc3883366c705d8", size = 17744 },
 ]
 
 [[package]]
@@ -2625,9 +2636,9 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/69/d8995f229ddf4d98b9c85dd126aeca03dd1742f6dc5d3bc0d2f6dae1535c/opentelemetry_instrumentation-0.55b1.tar.gz", hash = "sha256:2dc50aa207b9bfa16f70a1a0571e011e737a9917408934675b89ef4d5718c87b", upload-time = "2025-06-10T08:58:15.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/69/d8995f229ddf4d98b9c85dd126aeca03dd1742f6dc5d3bc0d2f6dae1535c/opentelemetry_instrumentation-0.55b1.tar.gz", hash = "sha256:2dc50aa207b9bfa16f70a1a0571e011e737a9917408934675b89ef4d5718c87b", size = 28552 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/7d/8ddfda1506c2fcca137924d5688ccabffa1aed9ec0955b7d0772de02cec3/opentelemetry_instrumentation-0.55b1-py3-none-any.whl", hash = "sha256:cbb1496b42bc394e01bc63701b10e69094e8564e281de063e4328d122cc7a97e", upload-time = "2025-06-10T08:57:14.355Z" },
+    { url = "https://files.pythonhosted.org/packages/60/7d/8ddfda1506c2fcca137924d5688ccabffa1aed9ec0955b7d0772de02cec3/opentelemetry_instrumentation-0.55b1-py3-none-any.whl", hash = "sha256:cbb1496b42bc394e01bc63701b10e69094e8564e281de063e4328d122cc7a97e", size = 31108 },
 ]
 
 [[package]]
@@ -2637,9 +2648,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/b3/c3158dd012463bb7c0eb7304a85a6f63baeeb5b4c93a53845cf89f848c7e/opentelemetry_proto-1.34.1.tar.gz", hash = "sha256:16286214e405c211fc774187f3e4bbb1351290b8dfb88e8948af209ce85b719e", upload-time = "2025-06-10T08:55:32.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b3/c3158dd012463bb7c0eb7304a85a6f63baeeb5b4c93a53845cf89f848c7e/opentelemetry_proto-1.34.1.tar.gz", hash = "sha256:16286214e405c211fc774187f3e4bbb1351290b8dfb88e8948af209ce85b719e", size = 34344 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/ab/4591bfa54e946350ce8b3f28e5c658fe9785e7cd11e9c11b1671a867822b/opentelemetry_proto-1.34.1-py3-none-any.whl", hash = "sha256:eb4bb5ac27f2562df2d6857fc557b3a481b5e298bc04f94cc68041f00cebcbd2", upload-time = "2025-06-10T08:55:14.904Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ab/4591bfa54e946350ce8b3f28e5c658fe9785e7cd11e9c11b1671a867822b/opentelemetry_proto-1.34.1-py3-none-any.whl", hash = "sha256:eb4bb5ac27f2562df2d6857fc557b3a481b5e298bc04f94cc68041f00cebcbd2", size = 55692 },
 ]
 
 [[package]]
@@ -2651,9 +2662,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/41/fe20f9036433da8e0fcef568984da4c1d1c771fa072ecd1a4d98779dccdd/opentelemetry_sdk-1.34.1.tar.gz", hash = "sha256:8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d", upload-time = "2025-06-10T08:55:33.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/41/fe20f9036433da8e0fcef568984da4c1d1c771fa072ecd1a4d98779dccdd/opentelemetry_sdk-1.34.1.tar.gz", hash = "sha256:8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d", size = 159441 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/1b/def4fe6aa73f483cabf4c748f4c25070d5f7604dcc8b52e962983491b29e/opentelemetry_sdk-1.34.1-py3-none-any.whl", hash = "sha256:308effad4059562f1d92163c61c8141df649da24ce361827812c40abb2a1e96e", upload-time = "2025-06-10T08:55:16.02Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1b/def4fe6aa73f483cabf4c748f4c25070d5f7604dcc8b52e962983491b29e/opentelemetry_sdk-1.34.1-py3-none-any.whl", hash = "sha256:308effad4059562f1d92163c61c8141df649da24ce361827812c40abb2a1e96e", size = 118477 },
 ]
 
 [[package]]
@@ -2664,49 +2675,49 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/f0/f33458486da911f47c4aa6db9bda308bb80f3236c111bf848bd870c16b16/opentelemetry_semantic_conventions-0.55b1.tar.gz", hash = "sha256:ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3", upload-time = "2025-06-10T08:55:33.881Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/f0/f33458486da911f47c4aa6db9bda308bb80f3236c111bf848bd870c16b16/opentelemetry_semantic_conventions-0.55b1.tar.gz", hash = "sha256:ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3", size = 119829 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/89/267b0af1b1d0ba828f0e60642b6a5116ac1fd917cde7fc02821627029bd1/opentelemetry_semantic_conventions-0.55b1-py3-none-any.whl", hash = "sha256:5da81dfdf7d52e3d37f8fe88d5e771e191de924cfff5f550ab0b8f7b2409baed", upload-time = "2025-06-10T08:55:17.638Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/267b0af1b1d0ba828f0e60642b6a5116ac1fd917cde7fc02821627029bd1/opentelemetry_semantic_conventions-0.55b1-py3-none-any.whl", hash = "sha256:5da81dfdf7d52e3d37f8fe88d5e771e191de924cfff5f550ab0b8f7b2409baed", size = 196223 },
 ]
 
 [[package]]
 name = "orjson"
 version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/45/b268004f745ede84e5798b48ee12b05129d19235d0e15267aa57dcdb400b/orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49", upload-time = "2026-02-02T15:38:49.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/45/b268004f745ede84e5798b48ee12b05129d19235d0e15267aa57dcdb400b/orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49", size = 6144992 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/02/da6cb01fc6087048d7f61522c327edf4250f1683a58a839fdcc435746dd5/orjson-3.11.7-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9487abc2c2086e7c8eb9a211d2ce8855bae0e92586279d0d27b341d5ad76c85c", upload-time = "2026-02-02T15:37:25.542Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/c2/5885e7a5881dba9a9af51bc564e8967225a642b3e03d089289a35054e749/orjson-3.11.7-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:79cacb0b52f6004caf92405a7e1f11e6e2de8bdf9019e4f76b44ba045125cd6b", upload-time = "2026-02-02T15:37:26.92Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/1d/4e7688de0a92d1caf600dfd5fb70b4c5bfff51dfa61ac555072ef2d0d32a/orjson-3.11.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2e85fe4698b6a56d5e2ebf7ae87544d668eb6bde1ad1226c13f44663f20ec9e", upload-time = "2026-02-02T15:37:28.108Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/b2/ec04b74ae03a125db7bd69cffd014b227b7f341e3261bf75b5eb88a1aa92/orjson-3.11.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b8d14b71c0b12963fe8a62aac87119f1afdf4cb88a400f61ca5ae581449efcb5", upload-time = "2026-02-02T15:37:30.287Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/69/f95bdf960605f08f827f6e3291fe243d8aa9c5c9ff017a8d7232209184c3/orjson-3.11.7-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91c81ef070c8f3220054115e1ef468b1c9ce8497b4e526cb9f68ab4dc0a7ac62", upload-time = "2026-02-02T15:37:31.595Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/1b/de59c57bae1d148ef298852abd31909ac3089cff370dfd4cd84cc99cbc42/orjson-3.11.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:411ebaf34d735e25e358a6d9e7978954a9c9d58cfb47bc6683cdc3964cd2f910", upload-time = "2026-02-02T15:37:32.985Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/9e/9decc59f4499f695f65c650f6cfa6cd4c37a3fbe8fa235a0a3614cb54386/orjson-3.11.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a16bcd08ab0bcdfc7e8801d9c4a9cc17e58418e4d48ddc6ded4e9e4b1a94062b", upload-time = "2026-02-02T15:37:34.204Z" },
-    { url = "https://files.pythonhosted.org/packages/28/e6/59f932bcabd1eac44e334fe8e3281a92eacfcb450586e1f4bde0423728d8/orjson-3.11.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c0b51672e466fd7e56230ffbae7f1639e18d0ce023351fb75da21b71bc2c960", upload-time = "2026-02-02T15:37:35.446Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/36/b0f05c0eaa7ca30bc965e37e6a2956b0d67adb87a9872942d3568da846ae/orjson-3.11.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:136dcd6a2e796dfd9ffca9fc027d778567b0b7c9968d092842d3c323cef88aa8", upload-time = "2026-02-02T15:37:36.657Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/03/58ec7d302b8d86944c60c7b4b82975d5161fcce4c9bc8c6cb1d6741b6115/orjson-3.11.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:7ba61079379b0ae29e117db13bda5f28d939766e410d321ec1624afc6a0b0504", upload-time = "2026-02-02T15:37:38.076Z" },
-    { url = "https://files.pythonhosted.org/packages/06/3a/868d65ef9a8b99be723bd510de491349618abd9f62c826cf206d962db295/orjson-3.11.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0527a4510c300e3b406591b0ba69b5dc50031895b0a93743526a3fc45f59d26e", upload-time = "2026-02-02T15:37:39.706Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/c7/1e18e1c83afe3349f4f6dc9e14910f0ae5f82eac756d1412ea4018938535/orjson-3.11.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a709e881723c9b18acddcfb8ba357322491ad553e277cf467e1e7e20e2d90561", upload-time = "2026-02-02T15:37:41.002Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/0b/ccb7ee1a65b37e8eeb8b267dc953561d72370e85185e459616d4345bab34/orjson-3.11.7-cp311-cp311-win32.whl", hash = "sha256:c43b8b5bab288b6b90dac410cca7e986a4fa747a2e8f94615aea407da706980d", upload-time = "2026-02-02T15:37:42.241Z" },
-    { url = "https://files.pythonhosted.org/packages/af/9e/55c776dffda3f381e0f07d010a4f5f3902bf48eaba1bb7684d301acd4924/orjson-3.11.7-cp311-cp311-win_amd64.whl", hash = "sha256:6543001328aa857187f905308a028935864aefe9968af3848401b6fe80dbb471", upload-time = "2026-02-02T15:37:43.444Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/8e/424a620fa7d263b880162505fb107ef5e0afaa765b5b06a88312ac291560/orjson-3.11.7-cp311-cp311-win_arm64.whl", hash = "sha256:1ee5cc7160a821dfe14f130bc8e63e7611051f964b463d9e2a3a573204446a4d", upload-time = "2026-02-02T15:37:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/37/02/da6cb01fc6087048d7f61522c327edf4250f1683a58a839fdcc435746dd5/orjson-3.11.7-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9487abc2c2086e7c8eb9a211d2ce8855bae0e92586279d0d27b341d5ad76c85c", size = 228664 },
+    { url = "https://files.pythonhosted.org/packages/c1/c2/5885e7a5881dba9a9af51bc564e8967225a642b3e03d089289a35054e749/orjson-3.11.7-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:79cacb0b52f6004caf92405a7e1f11e6e2de8bdf9019e4f76b44ba045125cd6b", size = 125344 },
+    { url = "https://files.pythonhosted.org/packages/a4/1d/4e7688de0a92d1caf600dfd5fb70b4c5bfff51dfa61ac555072ef2d0d32a/orjson-3.11.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2e85fe4698b6a56d5e2ebf7ae87544d668eb6bde1ad1226c13f44663f20ec9e", size = 128404 },
+    { url = "https://files.pythonhosted.org/packages/2f/b2/ec04b74ae03a125db7bd69cffd014b227b7f341e3261bf75b5eb88a1aa92/orjson-3.11.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b8d14b71c0b12963fe8a62aac87119f1afdf4cb88a400f61ca5ae581449efcb5", size = 123677 },
+    { url = "https://files.pythonhosted.org/packages/4c/69/f95bdf960605f08f827f6e3291fe243d8aa9c5c9ff017a8d7232209184c3/orjson-3.11.7-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91c81ef070c8f3220054115e1ef468b1c9ce8497b4e526cb9f68ab4dc0a7ac62", size = 128950 },
+    { url = "https://files.pythonhosted.org/packages/a4/1b/de59c57bae1d148ef298852abd31909ac3089cff370dfd4cd84cc99cbc42/orjson-3.11.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:411ebaf34d735e25e358a6d9e7978954a9c9d58cfb47bc6683cdc3964cd2f910", size = 141756 },
+    { url = "https://files.pythonhosted.org/packages/ee/9e/9decc59f4499f695f65c650f6cfa6cd4c37a3fbe8fa235a0a3614cb54386/orjson-3.11.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a16bcd08ab0bcdfc7e8801d9c4a9cc17e58418e4d48ddc6ded4e9e4b1a94062b", size = 130812 },
+    { url = "https://files.pythonhosted.org/packages/28/e6/59f932bcabd1eac44e334fe8e3281a92eacfcb450586e1f4bde0423728d8/orjson-3.11.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c0b51672e466fd7e56230ffbae7f1639e18d0ce023351fb75da21b71bc2c960", size = 133444 },
+    { url = "https://files.pythonhosted.org/packages/f1/36/b0f05c0eaa7ca30bc965e37e6a2956b0d67adb87a9872942d3568da846ae/orjson-3.11.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:136dcd6a2e796dfd9ffca9fc027d778567b0b7c9968d092842d3c323cef88aa8", size = 138609 },
+    { url = "https://files.pythonhosted.org/packages/b8/03/58ec7d302b8d86944c60c7b4b82975d5161fcce4c9bc8c6cb1d6741b6115/orjson-3.11.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:7ba61079379b0ae29e117db13bda5f28d939766e410d321ec1624afc6a0b0504", size = 408918 },
+    { url = "https://files.pythonhosted.org/packages/06/3a/868d65ef9a8b99be723bd510de491349618abd9f62c826cf206d962db295/orjson-3.11.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0527a4510c300e3b406591b0ba69b5dc50031895b0a93743526a3fc45f59d26e", size = 143998 },
+    { url = "https://files.pythonhosted.org/packages/5b/c7/1e18e1c83afe3349f4f6dc9e14910f0ae5f82eac756d1412ea4018938535/orjson-3.11.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a709e881723c9b18acddcfb8ba357322491ad553e277cf467e1e7e20e2d90561", size = 134802 },
+    { url = "https://files.pythonhosted.org/packages/d4/0b/ccb7ee1a65b37e8eeb8b267dc953561d72370e85185e459616d4345bab34/orjson-3.11.7-cp311-cp311-win32.whl", hash = "sha256:c43b8b5bab288b6b90dac410cca7e986a4fa747a2e8f94615aea407da706980d", size = 127828 },
+    { url = "https://files.pythonhosted.org/packages/af/9e/55c776dffda3f381e0f07d010a4f5f3902bf48eaba1bb7684d301acd4924/orjson-3.11.7-cp311-cp311-win_amd64.whl", hash = "sha256:6543001328aa857187f905308a028935864aefe9968af3848401b6fe80dbb471", size = 124941 },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/424a620fa7d263b880162505fb107ef5e0afaa765b5b06a88312ac291560/orjson-3.11.7-cp311-cp311-win_arm64.whl", hash = "sha256:1ee5cc7160a821dfe14f130bc8e63e7611051f964b463d9e2a3a573204446a4d", size = 126245 },
 ]
 
 [[package]]
 name = "ormsgpack"
 version = "1.12.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", upload-time = "2026-01-18T20:55:28.023Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", upload-time = "2026-01-18T20:55:59.876Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", upload-time = "2026-01-18T20:55:30.59Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", upload-time = "2026-01-18T20:55:48.569Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", upload-time = "2026-01-18T20:56:10.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", upload-time = "2026-01-18T20:56:12.047Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", upload-time = "2026-01-18T20:56:05.152Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", upload-time = "2026-01-18T20:55:37.83Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", upload-time = "2026-01-18T20:55:31.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", upload-time = "2026-01-18T20:55:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266 },
+    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035 },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539 },
+    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401 },
+    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082 },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346 },
+    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181 },
+    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182 },
+    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464 },
 ]
 
 [[package]]
@@ -2716,27 +2727,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", upload-time = "2023-10-26T04:26:04.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", upload-time = "2023-10-26T04:26:02.532Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692 },
 ]
 
 [[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", upload-time = "2024-01-27T21:01:33.423Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", upload-time = "2024-01-27T21:01:31.393Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832 },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
 ]
 
 [[package]]
@@ -2749,24 +2760,24 @@ dependencies = [
     { name = "pytz" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", upload-time = "2025-09-29T23:34:51.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", upload-time = "2025-09-29T23:18:30.065Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", upload-time = "2025-09-29T23:38:56.071Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", upload-time = "2025-09-29T23:18:41.627Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", upload-time = "2025-09-29T23:18:56.834Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", upload-time = "2025-09-29T23:19:09.247Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", upload-time = "2025-09-29T23:19:25.342Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790 },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831 },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267 },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281 },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453 },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361 },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702 },
 ]
 
 [[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206 },
 ]
 
 [[package]]
@@ -2777,9 +2788,9 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/9a/d79d8fa6d47a0338846bb558b39b9963b8eb2dfedec61867c138c1b17eeb/pdfminer_six-20251230.tar.gz", hash = "sha256:e8f68a14c57e00c2d7276d26519ea64be1b48f91db1cdc776faa80528ca06c1e", upload-time = "2025-12-30T15:49:13.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/9a/d79d8fa6d47a0338846bb558b39b9963b8eb2dfedec61867c138c1b17eeb/pdfminer_six-20251230.tar.gz", hash = "sha256:e8f68a14c57e00c2d7276d26519ea64be1b48f91db1cdc776faa80528ca06c1e", size = 8511285 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/d7/b288ea32deb752a09aab73c75e1e7572ab2a2b56c3124a5d1eb24c62ceb3/pdfminer_six-20251230-py3-none-any.whl", hash = "sha256:9ff2e3466a7dfc6de6fd779478850b6b7c2d9e9405aa2a5869376a822771f485", upload-time = "2025-12-30T15:49:10.76Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d7/b288ea32deb752a09aab73c75e1e7572ab2a2b56c3124a5d1eb24c62ceb3/pdfminer_six-20251230-py3-none-any.whl", hash = "sha256:9ff2e3466a7dfc6de6fd779478850b6b7c2d9e9405aa2a5869376a822771f485", size = 6591909 },
 ]
 
 [[package]]
@@ -2791,9 +2802,9 @@ dependencies = [
     { name = "pillow" },
     { name = "pypdfium2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", upload-time = "2026-01-05T08:10:29.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", upload-time = "2026-01-05T08:10:27.512Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045 },
 ]
 
 [[package]]
@@ -2804,53 +2815,53 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "scramp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/9a/077ab21e700051e03d8c5232b6bcb9a1a4d4b6242c9a0226df2cfa306414/pg8000-1.31.5.tar.gz", hash = "sha256:46ebb03be52b7a77c03c725c79da2ca281d6e8f59577ca66b17c9009618cae78", upload-time = "2025-09-14T09:16:49.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/9a/077ab21e700051e03d8c5232b6bcb9a1a4d4b6242c9a0226df2cfa306414/pg8000-1.31.5.tar.gz", hash = "sha256:46ebb03be52b7a77c03c725c79da2ca281d6e8f59577ca66b17c9009618cae78", size = 118933 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/07/5fd183858dff4d24840f07fc845f213cd371a19958558607ba22035dadd7/pg8000-1.31.5-py3-none-any.whl", hash = "sha256:0af2c1926b153307639868d2ee5cef6cd3a7d07448e12736989b10e1d491e201", upload-time = "2025-09-14T09:16:47.798Z" },
+    { url = "https://files.pythonhosted.org/packages/45/07/5fd183858dff4d24840f07fc845f213cd371a19958558607ba22035dadd7/pg8000-1.31.5-py3-none-any.whl", hash = "sha256:0af2c1926b153307639868d2ee5cef6cd3a7d07448e12736989b10e1d491e201", size = 57816 },
 ]
 
 [[package]]
 name = "pillow"
 version = "12.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/02/d52c733a2452ef1ffcc123b68e6606d07276b0e358db70eabad7e40042b7/pillow-12.1.0.tar.gz", hash = "sha256:5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9", upload-time = "2026-01-02T09:13:29.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/02/d52c733a2452ef1ffcc123b68e6606d07276b0e358db70eabad7e40042b7/pillow-12.1.0.tar.gz", hash = "sha256:5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9", size = 46977283 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/c4/bf8328039de6cc22182c3ef007a2abfbbdab153661c0a9aa78af8d706391/pillow-12.1.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:a83e0850cb8f5ac975291ebfc4170ba481f41a28065277f7f735c202cd8e0af3", upload-time = "2026-01-02T09:10:46.627Z" },
-    { url = "https://files.pythonhosted.org/packages/43/06/7264c0597e676104cc22ca73ee48f752767cd4b1fe084662620b17e10120/pillow-12.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b6e53e82ec2db0717eabb276aa56cf4e500c9a7cec2c2e189b55c24f65a3e8c0", upload-time = "2026-01-02T09:10:49.548Z" },
-    { url = "https://files.pythonhosted.org/packages/72/64/f9189e44474610daf83da31145fa56710b627b5c4c0b9c235e34058f6b31/pillow-12.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:40a8e3b9e8773876d6e30daed22f016509e3987bab61b3b7fe309d7019a87451", upload-time = "2026-01-02T09:10:51.62Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/30/0df458009be6a4caca4ca2c52975e6275c387d4e5c95544e34138b41dc86/pillow-12.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:800429ac32c9b72909c671aaf17ecd13110f823ddb7db4dfef412a5587c2c24e", upload-time = "2026-01-02T09:10:53.446Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/86/95845d4eda4f4f9557e25381d70876aa213560243ac1a6d619c46caaedd9/pillow-12.1.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b022eaaf709541b391ee069f0022ee5b36c709df71986e3f7be312e46f42c84", upload-time = "2026-01-02T09:10:55.426Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/1f/8e66ab9be3aaf1435bc03edd1ebdf58ffcd17f7349c1d970cafe87af27d9/pillow-12.1.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f345e7bc9d7f368887c712aa5054558bad44d2a301ddf9248599f4161abc7c0", upload-time = "2026-01-02T09:10:57.11Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f6/683b83cb9b1db1fb52b87951b1c0b99bdcfceaa75febf11406c19f82cb5e/pillow-12.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d70347c8a5b7ccd803ec0c85c8709f036e6348f1e6a5bf048ecd9c64d3550b8b", upload-time = "2026-01-02T09:10:59.331Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/7d/de833d63622538c1d58ce5395e7c6cb7e7dce80decdd8bde4a484e095d9f/pillow-12.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1fcc52d86ce7a34fd17cb04e87cfdb164648a3662a6f20565910a99653d66c18", upload-time = "2026-01-02T09:11:01.82Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/40/50d86571c9e5868c42b81fe7da0c76ca26373f3b95a8dd675425f4a92ec1/pillow-12.1.0-cp311-cp311-win32.whl", hash = "sha256:3ffaa2f0659e2f740473bcf03c702c39a8d4b2b7ffc629052028764324842c64", upload-time = "2026-01-02T09:11:04.556Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/af/b1d7e301c4cd26cd45d4af884d9ee9b6fab893b0ad2450d4746d74a6968c/pillow-12.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:806f3987ffe10e867bab0ddad45df1148a2b98221798457fa097ad85d6e8bc75", upload-time = "2026-01-02T09:11:06.538Z" },
-    { url = "https://files.pythonhosted.org/packages/48/36/d5716586d887fb2a810a4a61518a327a1e21c8b7134c89283af272efe84b/pillow-12.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:9f5fefaca968e700ad1a4a9de98bf0869a94e397fe3524c4c9450c1445252304", upload-time = "2026-01-02T09:11:08.226Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/bc/224b1d98cffd7164b14707c91aac83c07b047fbd8f58eba4066a3e53746a/pillow-12.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ca94b6aac0d7af2a10ba08c0f888b3d5114439b6b3ef39968378723622fed377", upload-time = "2026-01-02T09:13:14.084Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ca/49ca7769c4550107de049ed85208240ba0f330b3f2e316f24534795702ce/pillow-12.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:351889afef0f485b84078ea40fe33727a0492b9af3904661b0abbafee0355b72", upload-time = "2026-01-02T09:13:15.964Z" },
-    { url = "https://files.pythonhosted.org/packages/73/48/fac807ce82e5955bcc2718642b94b1bd22a82a6d452aea31cbb678cddf12/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb0984b30e973f7e2884362b7d23d0a348c7143ee559f38ef3eaab640144204c", upload-time = "2026-01-02T09:13:17.913Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/95/3e0742fe358c4664aed4fd05d5f5373dcdad0b27af52aa0972568541e3f4/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:84cabc7095dd535ca934d57e9ce2a72ffd216e435a84acb06b2277b1de2689bd", upload-time = "2026-01-02T09:13:20.083Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/74/fe2ac378e4e202e56d50540d92e1ef4ff34ed687f3c60f6a121bcf99437e/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53d8b764726d3af1a138dd353116f774e3862ec7e3794e0c8781e30db0f35dfc", upload-time = "2026-01-02T09:13:22.405Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/77/2a60dee1adee4e2655ac328dd05c02a955c1cd683b9f1b82ec3feb44727c/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5da841d81b1a05ef940a8567da92decaa15bc4d7dedb540a8c219ad83d91808a", upload-time = "2026-01-02T09:13:24.706Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/71/64e9b1c7f04ae0027f788a248e6297d7fcc29571371fe7d45495a78172c0/pillow-12.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:75af0b4c229ac519b155028fa1be632d812a519abba9b46b20e50c6caa184f19", upload-time = "2026-01-02T09:13:26.541Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c4/bf8328039de6cc22182c3ef007a2abfbbdab153661c0a9aa78af8d706391/pillow-12.1.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:a83e0850cb8f5ac975291ebfc4170ba481f41a28065277f7f735c202cd8e0af3", size = 5304057 },
+    { url = "https://files.pythonhosted.org/packages/43/06/7264c0597e676104cc22ca73ee48f752767cd4b1fe084662620b17e10120/pillow-12.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b6e53e82ec2db0717eabb276aa56cf4e500c9a7cec2c2e189b55c24f65a3e8c0", size = 4657811 },
+    { url = "https://files.pythonhosted.org/packages/72/64/f9189e44474610daf83da31145fa56710b627b5c4c0b9c235e34058f6b31/pillow-12.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:40a8e3b9e8773876d6e30daed22f016509e3987bab61b3b7fe309d7019a87451", size = 6232243 },
+    { url = "https://files.pythonhosted.org/packages/ef/30/0df458009be6a4caca4ca2c52975e6275c387d4e5c95544e34138b41dc86/pillow-12.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:800429ac32c9b72909c671aaf17ecd13110f823ddb7db4dfef412a5587c2c24e", size = 8037872 },
+    { url = "https://files.pythonhosted.org/packages/e4/86/95845d4eda4f4f9557e25381d70876aa213560243ac1a6d619c46caaedd9/pillow-12.1.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b022eaaf709541b391ee069f0022ee5b36c709df71986e3f7be312e46f42c84", size = 6345398 },
+    { url = "https://files.pythonhosted.org/packages/5c/1f/8e66ab9be3aaf1435bc03edd1ebdf58ffcd17f7349c1d970cafe87af27d9/pillow-12.1.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f345e7bc9d7f368887c712aa5054558bad44d2a301ddf9248599f4161abc7c0", size = 7034667 },
+    { url = "https://files.pythonhosted.org/packages/f9/f6/683b83cb9b1db1fb52b87951b1c0b99bdcfceaa75febf11406c19f82cb5e/pillow-12.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d70347c8a5b7ccd803ec0c85c8709f036e6348f1e6a5bf048ecd9c64d3550b8b", size = 6458743 },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/de833d63622538c1d58ce5395e7c6cb7e7dce80decdd8bde4a484e095d9f/pillow-12.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1fcc52d86ce7a34fd17cb04e87cfdb164648a3662a6f20565910a99653d66c18", size = 7159342 },
+    { url = "https://files.pythonhosted.org/packages/8c/40/50d86571c9e5868c42b81fe7da0c76ca26373f3b95a8dd675425f4a92ec1/pillow-12.1.0-cp311-cp311-win32.whl", hash = "sha256:3ffaa2f0659e2f740473bcf03c702c39a8d4b2b7ffc629052028764324842c64", size = 6328655 },
+    { url = "https://files.pythonhosted.org/packages/6c/af/b1d7e301c4cd26cd45d4af884d9ee9b6fab893b0ad2450d4746d74a6968c/pillow-12.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:806f3987ffe10e867bab0ddad45df1148a2b98221798457fa097ad85d6e8bc75", size = 7031469 },
+    { url = "https://files.pythonhosted.org/packages/48/36/d5716586d887fb2a810a4a61518a327a1e21c8b7134c89283af272efe84b/pillow-12.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:9f5fefaca968e700ad1a4a9de98bf0869a94e397fe3524c4c9450c1445252304", size = 2452515 },
+    { url = "https://files.pythonhosted.org/packages/8b/bc/224b1d98cffd7164b14707c91aac83c07b047fbd8f58eba4066a3e53746a/pillow-12.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ca94b6aac0d7af2a10ba08c0f888b3d5114439b6b3ef39968378723622fed377", size = 5228605 },
+    { url = "https://files.pythonhosted.org/packages/0c/ca/49ca7769c4550107de049ed85208240ba0f330b3f2e316f24534795702ce/pillow-12.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:351889afef0f485b84078ea40fe33727a0492b9af3904661b0abbafee0355b72", size = 4622245 },
+    { url = "https://files.pythonhosted.org/packages/73/48/fac807ce82e5955bcc2718642b94b1bd22a82a6d452aea31cbb678cddf12/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb0984b30e973f7e2884362b7d23d0a348c7143ee559f38ef3eaab640144204c", size = 5247593 },
+    { url = "https://files.pythonhosted.org/packages/d2/95/3e0742fe358c4664aed4fd05d5f5373dcdad0b27af52aa0972568541e3f4/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:84cabc7095dd535ca934d57e9ce2a72ffd216e435a84acb06b2277b1de2689bd", size = 6989008 },
+    { url = "https://files.pythonhosted.org/packages/5a/74/fe2ac378e4e202e56d50540d92e1ef4ff34ed687f3c60f6a121bcf99437e/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53d8b764726d3af1a138dd353116f774e3862ec7e3794e0c8781e30db0f35dfc", size = 5313824 },
+    { url = "https://files.pythonhosted.org/packages/f3/77/2a60dee1adee4e2655ac328dd05c02a955c1cd683b9f1b82ec3feb44727c/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5da841d81b1a05ef940a8567da92decaa15bc4d7dedb540a8c219ad83d91808a", size = 5963278 },
+    { url = "https://files.pythonhosted.org/packages/2d/71/64e9b1c7f04ae0027f788a248e6297d7fcc29571371fe7d45495a78172c0/pillow-12.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:75af0b4c229ac519b155028fa1be632d812a519abba9b46b20e50c6caa184f19", size = 7029809 },
 ]
 
 [[package]]
 name = "platformdirs"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", upload-time = "2025-12-05T13:52:58.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", upload-time = "2025-12-05T13:52:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731 },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", upload-time = "2025-05-15T12:30:07.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", upload-time = "2025-05-15T12:30:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
 ]
 
 [[package]]
@@ -2860,9 +2871,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/f8/969e6f280201b40b31bcb62843c619f343dcc351dff83a5891530c9dd60e/portalocker-2.7.0.tar.gz", hash = "sha256:032e81d534a88ec1736d03f780ba073f047a06c478b06e2937486f334e955c51", upload-time = "2023-01-18T23:36:14.436Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/f8/969e6f280201b40b31bcb62843c619f343dcc351dff83a5891530c9dd60e/portalocker-2.7.0.tar.gz", hash = "sha256:032e81d534a88ec1736d03f780ba073f047a06c478b06e2937486f334e955c51", size = 20183 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/df/d4f711d168524f5aebd7fb30969eaa31e3048cf8979688cde3b08f6e5eb8/portalocker-2.7.0-py2.py3-none-any.whl", hash = "sha256:a07c5b4f3985c3cf4798369631fb7011adb498e2a46d8440efc75a8f29a0f983", upload-time = "2023-01-18T23:36:12.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/df/d4f711d168524f5aebd7fb30969eaa31e3048cf8979688cde3b08f6e5eb8/portalocker-2.7.0-py2.py3-none-any.whl", hash = "sha256:a07c5b4f3985c3cf4798369631fb7011adb498e2a46d8440efc75a8f29a0f983", size = 15502 },
 ]
 
 [[package]]
@@ -2876,9 +2887,9 @@ dependencies = [
     { name = "requests" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/20/60ae67bb9d82f00427946218d49e2e7e80fb41c15dc5019482289ec9ce8d/posthog-5.4.0.tar.gz", hash = "sha256:701669261b8d07cdde0276e5bc096b87f9e200e3b9589c5ebff14df658c5893c", upload-time = "2025-06-20T23:19:23.485Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/20/60ae67bb9d82f00427946218d49e2e7e80fb41c15dc5019482289ec9ce8d/posthog-5.4.0.tar.gz", hash = "sha256:701669261b8d07cdde0276e5bc096b87f9e200e3b9589c5ebff14df658c5893c", size = 88076 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/98/e480cab9a08d1c09b1c59a93dade92c1bb7544826684ff2acbfd10fcfbd4/posthog-5.4.0-py3-none-any.whl", hash = "sha256:284dfa302f64353484420b52d4ad81ff5c2c2d1d607c4e2db602ac72761831bd", upload-time = "2025-06-20T23:19:22.001Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/e480cab9a08d1c09b1c59a93dade92c1bb7544826684ff2acbfd10fcfbd4/posthog-5.4.0-py3-none-any.whl", hash = "sha256:284dfa302f64353484420b52d4ad81ff5c2c2d1d607c4e2db602ac72761831bd", size = 105364 },
 ]
 
 [[package]]
@@ -2888,33 +2899,33 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", upload-time = "2025-11-14T17:33:20.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", upload-time = "2025-11-14T17:33:19.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433 },
 ]
 
 [[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", upload-time = "2025-10-08T19:49:02.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/d4/4e2c9aaf7ac2242b9358f98dccd8f90f2605402f5afeff6c578682c2c491/propcache-0.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60a8fda9644b7dfd5dece8c61d8a85e271cb958075bfc4e01083c148b61a7caf", upload-time = "2025-10-08T19:46:24.597Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/21/d7b68e911f9c8e18e4ae43bdbc1e1e9bbd971f8866eb81608947b6f585ff/propcache-0.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c30b53e7e6bda1d547cabb47c825f3843a0a1a42b0496087bb58d8fedf9f41b5", upload-time = "2025-10-08T19:46:25.733Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/1d/11605e99ac8ea9435651ee71ab4cb4bf03f0949586246476a25aadfec54a/propcache-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6918ecbd897443087a3b7cd978d56546a812517dcaaca51b49526720571fa93e", upload-time = "2025-10-08T19:46:27.304Z" },
-    { url = "https://files.pythonhosted.org/packages/58/1a/3c62c127a8466c9c843bccb503d40a273e5cc69838805f322e2826509e0d/propcache-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d902a36df4e5989763425a8ab9e98cd8ad5c52c823b34ee7ef307fd50582566", upload-time = "2025-10-08T19:46:28.62Z" },
-    { url = "https://files.pythonhosted.org/packages/56/b9/8fa98f850960b367c4b8fe0592e7fc341daa7a9462e925228f10a60cf74f/propcache-0.4.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a9695397f85973bb40427dedddf70d8dc4a44b22f1650dd4af9eedf443d45165", upload-time = "2025-10-08T19:46:30.358Z" },
-    { url = "https://files.pythonhosted.org/packages/46/a6/0ab4f660eb59649d14b3d3d65c439421cf2f87fe5dd68591cbe3c1e78a89/propcache-0.4.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2bb07ffd7eaad486576430c89f9b215f9e4be68c4866a96e97db9e97fead85dc", upload-time = "2025-10-08T19:46:32.607Z" },
-    { url = "https://files.pythonhosted.org/packages/52/6a/57f43e054fb3d3a56ac9fc532bc684fc6169a26c75c353e65425b3e56eef/propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd6f30fdcf9ae2a70abd34da54f18da086160e4d7d9251f81f3da0ff84fc5a48", upload-time = "2025-10-08T19:46:33.969Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e2/27e6feebb5f6b8408fa29f5efbb765cd54c153ac77314d27e457a3e993b7/propcache-0.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fc38cba02d1acba4e2869eef1a57a43dfbd3d49a59bf90dda7444ec2be6a5570", upload-time = "2025-10-08T19:46:35.309Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f8/91c27b22ccda1dbc7967f921c42825564fa5336a01ecd72eb78a9f4f53c2/propcache-0.4.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:67fad6162281e80e882fb3ec355398cf72864a54069d060321f6cd0ade95fe85", upload-time = "2025-10-08T19:46:36.993Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/26/7f00bd6bd1adba5aafe5f4a66390f243acab58eab24ff1a08bebb2ef9d40/propcache-0.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f10207adf04d08bec185bae14d9606a1444715bc99180f9331c9c02093e1959e", upload-time = "2025-10-08T19:46:38.398Z" },
-    { url = "https://files.pythonhosted.org/packages/84/89/fd108ba7815c1117ddca79c228f3f8a15fc82a73bca8b142eb5de13b2785/propcache-0.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e9b0d8d0845bbc4cfcdcbcdbf5086886bc8157aa963c31c777ceff7846c77757", upload-time = "2025-10-08T19:46:39.732Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/3ec3f7e3173e73f1d600495d8b545b53802cbf35506e5732dd8578db3724/propcache-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:981333cb2f4c1896a12f4ab92a9cc8f09ea664e9b7dbdc4eff74627af3a11c0f", upload-time = "2025-10-08T19:46:41.025Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b0/b2631c19793f869d35f47d5a3a56fb19e9160d3c119f15ac7344fc3ccae7/propcache-0.4.1-cp311-cp311-win32.whl", hash = "sha256:f1d2f90aeec838a52f1c1a32fe9a619fefd5e411721a9117fbf82aea638fe8a1", upload-time = "2025-10-08T19:46:42.693Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/78/6cce448e2098e9f3bfc91bb877f06aa24b6ccace872e39c53b2f707c4648/propcache-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:364426a62660f3f699949ac8c621aad6977be7126c5807ce48c0aeb8e7333ea6", upload-time = "2025-10-08T19:46:43.778Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/e9/754f180cccd7f51a39913782c74717c581b9cc8177ad0e949f4d51812383/propcache-0.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:e53f3a38d3510c11953f3e6a33f205c6d1b001129f972805ca9b42fc308bc239", upload-time = "2025-10-08T19:46:44.872Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", upload-time = "2025-10-08T19:49:00.792Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d4/4e2c9aaf7ac2242b9358f98dccd8f90f2605402f5afeff6c578682c2c491/propcache-0.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60a8fda9644b7dfd5dece8c61d8a85e271cb958075bfc4e01083c148b61a7caf", size = 80208 },
+    { url = "https://files.pythonhosted.org/packages/c2/21/d7b68e911f9c8e18e4ae43bdbc1e1e9bbd971f8866eb81608947b6f585ff/propcache-0.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c30b53e7e6bda1d547cabb47c825f3843a0a1a42b0496087bb58d8fedf9f41b5", size = 45777 },
+    { url = "https://files.pythonhosted.org/packages/d3/1d/11605e99ac8ea9435651ee71ab4cb4bf03f0949586246476a25aadfec54a/propcache-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6918ecbd897443087a3b7cd978d56546a812517dcaaca51b49526720571fa93e", size = 47647 },
+    { url = "https://files.pythonhosted.org/packages/58/1a/3c62c127a8466c9c843bccb503d40a273e5cc69838805f322e2826509e0d/propcache-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d902a36df4e5989763425a8ab9e98cd8ad5c52c823b34ee7ef307fd50582566", size = 214929 },
+    { url = "https://files.pythonhosted.org/packages/56/b9/8fa98f850960b367c4b8fe0592e7fc341daa7a9462e925228f10a60cf74f/propcache-0.4.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a9695397f85973bb40427dedddf70d8dc4a44b22f1650dd4af9eedf443d45165", size = 221778 },
+    { url = "https://files.pythonhosted.org/packages/46/a6/0ab4f660eb59649d14b3d3d65c439421cf2f87fe5dd68591cbe3c1e78a89/propcache-0.4.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2bb07ffd7eaad486576430c89f9b215f9e4be68c4866a96e97db9e97fead85dc", size = 228144 },
+    { url = "https://files.pythonhosted.org/packages/52/6a/57f43e054fb3d3a56ac9fc532bc684fc6169a26c75c353e65425b3e56eef/propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd6f30fdcf9ae2a70abd34da54f18da086160e4d7d9251f81f3da0ff84fc5a48", size = 210030 },
+    { url = "https://files.pythonhosted.org/packages/40/e2/27e6feebb5f6b8408fa29f5efbb765cd54c153ac77314d27e457a3e993b7/propcache-0.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fc38cba02d1acba4e2869eef1a57a43dfbd3d49a59bf90dda7444ec2be6a5570", size = 208252 },
+    { url = "https://files.pythonhosted.org/packages/9e/f8/91c27b22ccda1dbc7967f921c42825564fa5336a01ecd72eb78a9f4f53c2/propcache-0.4.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:67fad6162281e80e882fb3ec355398cf72864a54069d060321f6cd0ade95fe85", size = 202064 },
+    { url = "https://files.pythonhosted.org/packages/f2/26/7f00bd6bd1adba5aafe5f4a66390f243acab58eab24ff1a08bebb2ef9d40/propcache-0.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f10207adf04d08bec185bae14d9606a1444715bc99180f9331c9c02093e1959e", size = 212429 },
+    { url = "https://files.pythonhosted.org/packages/84/89/fd108ba7815c1117ddca79c228f3f8a15fc82a73bca8b142eb5de13b2785/propcache-0.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e9b0d8d0845bbc4cfcdcbcdbf5086886bc8157aa963c31c777ceff7846c77757", size = 216727 },
+    { url = "https://files.pythonhosted.org/packages/79/37/3ec3f7e3173e73f1d600495d8b545b53802cbf35506e5732dd8578db3724/propcache-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:981333cb2f4c1896a12f4ab92a9cc8f09ea664e9b7dbdc4eff74627af3a11c0f", size = 205097 },
+    { url = "https://files.pythonhosted.org/packages/61/b0/b2631c19793f869d35f47d5a3a56fb19e9160d3c119f15ac7344fc3ccae7/propcache-0.4.1-cp311-cp311-win32.whl", hash = "sha256:f1d2f90aeec838a52f1c1a32fe9a619fefd5e411721a9117fbf82aea638fe8a1", size = 38084 },
+    { url = "https://files.pythonhosted.org/packages/f4/78/6cce448e2098e9f3bfc91bb877f06aa24b6ccace872e39c53b2f707c4648/propcache-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:364426a62660f3f699949ac8c621aad6977be7126c5807ce48c0aeb8e7333ea6", size = 41637 },
+    { url = "https://files.pythonhosted.org/packages/9c/e9/754f180cccd7f51a39913782c74717c581b9cc8177ad0e949f4d51812383/propcache-0.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:e53f3a38d3510c11953f3e6a33f205c6d1b001129f972805ca9b42fc308bc239", size = 38064 },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305 },
 ]
 
 [[package]]
@@ -2924,72 +2935,72 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/02/8832cde80e7380c600fbf55090b6ab7b62bd6825dbedde6d6657c15a1f8e/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147", upload-time = "2026-02-02T17:34:49.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/02/8832cde80e7380c600fbf55090b6ab7b62bd6825dbedde6d6657c15a1f8e/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147", size = 56929 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/79/ac273cbbf744691821a9cca88957257f41afe271637794975ca090b9588b/proto_plus-1.27.1-py3-none-any.whl", hash = "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc", upload-time = "2026-02-02T17:34:47.339Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/79/ac273cbbf744691821a9cca88957257f41afe271637794975ca090b9588b/proto_plus-1.27.1-py3-none-any.whl", hash = "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc", size = 50480 },
 ]
 
 [[package]]
 name = "protobuf"
 version = "5.29.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/57/394a763c103e0edf87f0938dafcd918d53b4c011dfc5c8ae80f3b0452dbb/protobuf-5.29.6.tar.gz", hash = "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723", upload-time = "2026-02-04T22:54:40.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/57/394a763c103e0edf87f0938dafcd918d53b4c011dfc5c8ae80f3b0452dbb/protobuf-5.29.6.tar.gz", hash = "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723", size = 425623 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/88/9ee58ff7863c479d6f8346686d4636dd4c415b0cbeed7a6a7d0617639c2a/protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1", upload-time = "2026-02-04T22:54:25.805Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/66/2dc736a4d576847134fb6d80bd995c569b13cdc7b815d669050bf0ce2d2c/protobuf-5.29.6-cp310-abi3-win_amd64.whl", hash = "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda", upload-time = "2026-02-04T22:54:28.592Z" },
-    { url = "https://files.pythonhosted.org/packages/06/db/49b05966fd208ae3f44dcd33837b6243b4915c57561d730a43f881f24dea/protobuf-5.29.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:b5a169e664b4057183a34bdc424540e86eea47560f3c123a0d64de4e137f9269", upload-time = "2026-02-04T22:54:30.266Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/d7/48cbf6b0c3c39761e47a99cb483405f0fde2be22cf00d71ef316ce52b458/protobuf-5.29.6-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6", upload-time = "2026-02-04T22:54:31.782Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dd/cadd6ec43069247d91f6345fa7a0d2858bef6af366dbd7ba8f05d2c77d3b/protobuf-5.29.6-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9", upload-time = "2026-02-04T22:54:32.909Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cb/e3065b447186cb70aa65acc70c86baf482d82bf75625bf5a2c4f6919c6a3/protobuf-5.29.6-py3-none-any.whl", hash = "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86", upload-time = "2026-02-04T22:54:39.462Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/88/9ee58ff7863c479d6f8346686d4636dd4c415b0cbeed7a6a7d0617639c2a/protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1", size = 423357 },
+    { url = "https://files.pythonhosted.org/packages/1c/66/2dc736a4d576847134fb6d80bd995c569b13cdc7b815d669050bf0ce2d2c/protobuf-5.29.6-cp310-abi3-win_amd64.whl", hash = "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda", size = 435175 },
+    { url = "https://files.pythonhosted.org/packages/06/db/49b05966fd208ae3f44dcd33837b6243b4915c57561d730a43f881f24dea/protobuf-5.29.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:b5a169e664b4057183a34bdc424540e86eea47560f3c123a0d64de4e137f9269", size = 418619 },
+    { url = "https://files.pythonhosted.org/packages/b7/d7/48cbf6b0c3c39761e47a99cb483405f0fde2be22cf00d71ef316ce52b458/protobuf-5.29.6-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6", size = 320284 },
+    { url = "https://files.pythonhosted.org/packages/e3/dd/cadd6ec43069247d91f6345fa7a0d2858bef6af366dbd7ba8f05d2c77d3b/protobuf-5.29.6-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9", size = 320478 },
+    { url = "https://files.pythonhosted.org/packages/5a/cb/e3065b447186cb70aa65acc70c86baf482d82bf75625bf5a2c4f6919c6a3/protobuf-5.29.6-py3-none-any.whl", hash = "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86", size = 173126 },
 ]
 
 [[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", upload-time = "2026-01-28T18:14:54.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", upload-time = "2026-01-28T18:15:22.168Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", upload-time = "2026-01-28T18:15:23.795Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", upload-time = "2026-01-28T18:15:25.976Z" },
-    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", upload-time = "2026-01-28T18:15:27.794Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", upload-time = "2026-01-28T18:15:29.342Z" },
-    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", upload-time = "2026-01-28T18:15:31.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", upload-time = "2026-01-28T18:15:33.849Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", upload-time = "2026-01-28T18:15:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090 },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859 },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560 },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997 },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972 },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266 },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737 },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617 },
 ]
 
 [[package]]
 name = "py4j"
 version = "0.10.9.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/f2/b34255180c72c36ff7097f7c2cdca02abcbd89f5eebf7c7c41262a9a0637/py4j-0.10.9.7.tar.gz", hash = "sha256:0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb", upload-time = "2022-08-12T22:49:09.792Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/f2/b34255180c72c36ff7097f7c2cdca02abcbd89f5eebf7c7c41262a9a0637/py4j-0.10.9.7.tar.gz", hash = "sha256:0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb", size = 1508234 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/30/a58b32568f1623aaad7db22aa9eafc4c6c194b429ff35bdc55ca2726da47/py4j-0.10.9.7-py2.py3-none-any.whl", hash = "sha256:85defdfd2b2376eb3abf5ca6474b51ab7e0de341c75a02f46dc9b5976f5a5c1b", upload-time = "2022-08-12T22:49:07.05Z" },
+    { url = "https://files.pythonhosted.org/packages/10/30/a58b32568f1623aaad7db22aa9eafc4c6c194b429ff35bdc55ca2726da47/py4j-0.10.9.7-py2.py3-none-any.whl", hash = "sha256:85defdfd2b2376eb3abf5ca6474b51ab7e0de341c75a02f46dc9b5976f5a5c1b", size = 200481 },
 ]
 
 [[package]]
 name = "pyarrow"
 version = "21.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/c2/ea068b8f00905c06329a3dfcd40d0fcc2b7d0f2e355bdb25b65e0a0e4cd4/pyarrow-21.0.0.tar.gz", hash = "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc", upload-time = "2025-07-18T00:57:31.761Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/c2/ea068b8f00905c06329a3dfcd40d0fcc2b7d0f2e355bdb25b65e0a0e4cd4/pyarrow-21.0.0.tar.gz", hash = "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc", size = 1133487 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/dc/80564a3071a57c20b7c32575e4a0120e8a330ef487c319b122942d665960/pyarrow-21.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c077f48aab61738c237802836fc3844f85409a46015635198761b0d6a688f87b", upload-time = "2025-07-18T00:55:03.812Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/cc/3b51cb2db26fe535d14f74cab4c79b191ed9a8cd4cbba45e2379b5ca2746/pyarrow-21.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:689f448066781856237eca8d1975b98cace19b8dd2ab6145bf49475478bcaa10", upload-time = "2025-07-18T00:55:07.495Z" },
-    { url = "https://files.pythonhosted.org/packages/24/11/a4431f36d5ad7d83b87146f515c063e4d07ef0b7240876ddb885e6b44f2e/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:479ee41399fcddc46159a551705b89c05f11e8b8cb8e968f7fec64f62d91985e", upload-time = "2025-07-18T00:55:11.461Z" },
-    { url = "https://files.pythonhosted.org/packages/74/dc/035d54638fc5d2971cbf1e987ccd45f1091c83bcf747281cf6cc25e72c88/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:40ebfcb54a4f11bcde86bc586cbd0272bac0d516cfa539c799c2453768477569", upload-time = "2025-07-18T00:55:16.301Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/3b/89fced102448a9e3e0d4dded1f37fa3ce4700f02cdb8665457fcc8015f5b/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8d58d8497814274d3d20214fbb24abcad2f7e351474357d552a8d53bce70c70e", upload-time = "2025-07-18T00:55:23.82Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/bb/ea7f1bd08978d39debd3b23611c293f64a642557e8141c80635d501e6d53/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:585e7224f21124dd57836b1530ac8f2df2afc43c861d7bf3d58a4870c42ae36c", upload-time = "2025-07-18T00:55:28.231Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0b/77ea0600009842b30ceebc3337639a7380cd946061b620ac1a2f3cb541e2/pyarrow-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:555ca6935b2cbca2c0e932bedd853e9bc523098c39636de9ad4693b5b1df86d6", upload-time = "2025-07-18T00:55:32.122Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/80564a3071a57c20b7c32575e4a0120e8a330ef487c319b122942d665960/pyarrow-21.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c077f48aab61738c237802836fc3844f85409a46015635198761b0d6a688f87b", size = 31243234 },
+    { url = "https://files.pythonhosted.org/packages/ea/cc/3b51cb2db26fe535d14f74cab4c79b191ed9a8cd4cbba45e2379b5ca2746/pyarrow-21.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:689f448066781856237eca8d1975b98cace19b8dd2ab6145bf49475478bcaa10", size = 32714370 },
+    { url = "https://files.pythonhosted.org/packages/24/11/a4431f36d5ad7d83b87146f515c063e4d07ef0b7240876ddb885e6b44f2e/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:479ee41399fcddc46159a551705b89c05f11e8b8cb8e968f7fec64f62d91985e", size = 41135424 },
+    { url = "https://files.pythonhosted.org/packages/74/dc/035d54638fc5d2971cbf1e987ccd45f1091c83bcf747281cf6cc25e72c88/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:40ebfcb54a4f11bcde86bc586cbd0272bac0d516cfa539c799c2453768477569", size = 42823810 },
+    { url = "https://files.pythonhosted.org/packages/2e/3b/89fced102448a9e3e0d4dded1f37fa3ce4700f02cdb8665457fcc8015f5b/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8d58d8497814274d3d20214fbb24abcad2f7e351474357d552a8d53bce70c70e", size = 43391538 },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/ea7f1bd08978d39debd3b23611c293f64a642557e8141c80635d501e6d53/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:585e7224f21124dd57836b1530ac8f2df2afc43c861d7bf3d58a4870c42ae36c", size = 45120056 },
+    { url = "https://files.pythonhosted.org/packages/6e/0b/77ea0600009842b30ceebc3337639a7380cd946061b620ac1a2f3cb541e2/pyarrow-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:555ca6935b2cbca2c0e932bedd853e9bc523098c39636de9ad4693b5b1df86d6", size = 26220568 },
 ]
 
 [[package]]
 name = "pyasn1"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", upload-time = "2026-01-16T18:04:17.174Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371 },
 ]
 
 [[package]]
@@ -2999,56 +3010,51 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", upload-time = "2025-03-28T02:41:22.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", upload-time = "2025-03-28T02:41:19.028Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259 },
 ]
 
 [[package]]
 name = "pybase64"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/b8/4ed5c7ad5ec15b08d35cc79ace6145d5c1ae426e46435f4987379439dfea/pybase64-1.4.3.tar.gz", hash = "sha256:c2ed274c9e0ba9c8f9c4083cfe265e66dd679126cd9c2027965d807352f3f053", upload-time = "2025-12-06T13:27:04.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/b8/4ed5c7ad5ec15b08d35cc79ace6145d5c1ae426e46435f4987379439dfea/pybase64-1.4.3.tar.gz", hash = "sha256:c2ed274c9e0ba9c8f9c4083cfe265e66dd679126cd9c2027965d807352f3f053", size = 137272 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/63/21e981e9d3f1f123e0b0ee2130112b1956cad9752309f574862c7ae77c08/pybase64-1.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:70b0d4a4d54e216ce42c2655315378b8903933ecfa32fced453989a92b4317b2", upload-time = "2025-12-06T13:22:52.159Z" },
-    { url = "https://files.pythonhosted.org/packages/92/fb/3f448e139516404d2a3963915cc10dc9dde7d3a67de4edba2f827adfef17/pybase64-1.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8127f110cdee7a70e576c5c9c1d4e17e92e76c191869085efbc50419f4ae3c72", upload-time = "2025-12-06T13:22:53.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fb/bb06a5b9885e7d853ac1e801c4d8abfdb4c8506deee33e53d55aa6690e67/pybase64-1.4.3-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:f9ef0388878bc15a084bd9bf73ec1b2b4ee513d11009b1506375e10a7aae5032", upload-time = "2025-12-06T13:22:54.197Z" },
-    { url = "https://files.pythonhosted.org/packages/64/15/8d60b9ec5e658185fc2ee3333e01a6e30d717cf677b24f47cbb3a859d13c/pybase64-1.4.3-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95a57cccf106352a72ed8bc8198f6820b16cc7d55aa3867a16dea7011ae7c218", upload-time = "2025-12-06T13:22:55.517Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/29/a3e5c1667cc8c38d025a4636855de0fc117fc62e2afeb033a3c6f12c6a22/pybase64-1.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cd1c47dfceb9c7bd3de210fb4e65904053ed2d7c9dce6d107f041ff6fbd7e21", upload-time = "2025-12-06T13:22:56.682Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/00/8ffcf9810bd23f3984698be161cf7edba656fd639b818039a7be1d6405d4/pybase64-1.4.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:9fe9922698f3e2f72874b26890d53a051c431d942701bb3a37aae94da0b12107", upload-time = "2025-12-06T13:22:57.724Z" },
-    { url = "https://files.pythonhosted.org/packages/81/62/379e347797cdea4ab686375945bc77ad8d039c688c0d4d0cfb09d247beb9/pybase64-1.4.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:af5f4bd29c86b59bb4375e0491d16ec8a67548fa99c54763aaedaf0b4b5a6632", upload-time = "2025-12-06T13:22:58.758Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/f2/9338ffe2f487086f26a2c8ca175acb3baa86fce0a756ff5670a0822bb877/pybase64-1.4.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c302f6ca7465262908131411226e02100f488f531bb5e64cb901aa3f439bccd9", upload-time = "2025-12-06T13:23:01.007Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/a4/85a6142b65b4df8625b337727aa81dc199642de3d09677804141df6ee312/pybase64-1.4.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2f3f439fa4d7fde164ebbbb41968db7d66b064450ab6017c6c95cef0afa2b349", upload-time = "2025-12-06T13:23:02.369Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/00/e40215d25624012bf5b7416ca37f168cb75f6dd15acdb91ea1f2ea4dc4e7/pybase64-1.4.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7a23c6866551043f8b681a5e1e0d59469148b2920a3b4fc42b1275f25ea4217a", upload-time = "2025-12-06T13:23:03.378Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/73/d7e19a63e795c13837f2356268d95dc79d1180e756f57ced742a1e52fdeb/pybase64-1.4.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:56e6526f8565642abc5f84338cc131ce298a8ccab696b19bdf76fa6d7dc592ef", upload-time = "2025-12-06T13:23:04.458Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/32/3c746d7a310b69bdd9df77ffc85c41b80bce00a774717596f869b0d4a20e/pybase64-1.4.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6a792a8b9d866ffa413c9687d9b611553203753987a3a582d68cbc51cf23da45", upload-time = "2025-12-06T13:23:05.526Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/b3/63cec68f9d6f6e4c0b438d14e5f1ef536a5fe63ce14b70733ac5e31d7ab8/pybase64-1.4.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:62ad29a5026bb22cfcd1ca484ec34b0a5ced56ddba38ceecd9359b2818c9c4f9", upload-time = "2025-12-06T13:23:06.931Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/cb/7acf7c3c06f9692093c07f109668725dc37fb9a3df0fa912b50add645195/pybase64-1.4.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11b9d1d2d32ec358c02214363b8fc3651f6be7dd84d880ecd597a6206a80e121", upload-time = "2025-12-06T13:23:07.936Z" },
-    { url = "https://files.pythonhosted.org/packages/33/39/4eb33ff35d173bfff4002e184ce8907f5d0a42d958d61cd9058ef3570179/pybase64-1.4.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0aebaa7f238caa0a0d373616016e2040c6c879ebce3ba7ab3c59029920f13640", upload-time = "2025-12-06T13:23:09.253Z" },
-    { url = "https://files.pythonhosted.org/packages/19/97/a76d65c375a254e65b730c6f56bf528feca91305da32eceab8bcc08591e6/pybase64-1.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e504682b20c63c2b0c000e5f98a80ea867f8d97642e042a5a39818e44ba4d599", upload-time = "2025-12-06T13:23:10.336Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/2c/8338b6d3da3c265002839e92af0a80d6db88385c313c73f103dfb800c857/pybase64-1.4.3-cp311-cp311-win32.whl", hash = "sha256:e9a8b81984e3c6fb1db9e1614341b0a2d98c0033d693d90c726677db1ffa3a4c", upload-time = "2025-12-06T13:23:11.9Z" },
-    { url = "https://files.pythonhosted.org/packages/39/dc/32efdf2f5927e5449cc341c266a1bbc5fecd5319a8807d9c5405f76e6d02/pybase64-1.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:a90a8fa16a901fabf20de824d7acce07586e6127dc2333f1de05f73b1f848319", upload-time = "2025-12-06T13:23:13.174Z" },
-    { url = "https://files.pythonhosted.org/packages/da/59/eda4f9cb0cbce5a45f0cd06131e710674f8123a4d570772c5b9694f88559/pybase64-1.4.3-cp311-cp311-win_arm64.whl", hash = "sha256:61d87de5bc94d143622e94390ec3e11b9c1d4644fe9be3a81068ab0f91056f59", upload-time = "2025-12-06T13:23:15.696Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/7c/545fd4935a0e1ddd7147f557bf8157c73eecec9cffd523382fa7af2557de/pybase64-1.4.3-graalpy311-graalpy242_311_native-macosx_10_9_x86_64.whl", hash = "sha256:d27c1dfdb0c59a5e758e7a98bd78eaca5983c22f4a811a36f4f980d245df4611", upload-time = "2025-12-06T13:26:19.535Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/ca/ae7a96be9ddc96030d4e9dffc43635d4e136b12058b387fd47eb8301b60f/pybase64-1.4.3-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0f1a0c51d6f159511e3431b73c25db31095ee36c394e26a4349e067c62f434e5", upload-time = "2025-12-06T13:26:20.72Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/44/d4b7adc7bf4fd5b52d8d099121760c450a52c390223806b873f0b6a2d551/pybase64-1.4.3-graalpy311-graalpy242_311_native-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a492518f3078a4e3faaef310697d21df9c6bc71908cebc8c2f6fbfa16d7d6b1f", upload-time = "2025-12-06T13:26:21.845Z" },
-    { url = "https://files.pythonhosted.org/packages/08/86/2ba2d8734ef7939debeb52cf9952e457ba7aa226cae5c0e6dd631f9b851f/pybase64-1.4.3-graalpy311-graalpy242_311_native-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cae1a0f47784fd16df90d8acc32011c8d5fcdd9ab392c9ec49543e5f6a9c43a4", upload-time = "2025-12-06T13:26:23.149Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/5b/19c725dc3aaa6281f2ce3ea4c1628d154a40dd99657d1381995f8096768b/pybase64-1.4.3-graalpy311-graalpy242_311_native-win_amd64.whl", hash = "sha256:03cea70676ffbd39a1ab7930a2d24c625b416cacc9d401599b1d29415a43ab6a", upload-time = "2025-12-06T13:26:24.663Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/76/160dded493c00d3376d4ad0f38a2119c5345de4a6693419ad39c3565959b/pybase64-1.4.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:277de6e03cc9090fb359365c686a2a3036d23aee6cd20d45d22b8c89d1247f17", upload-time = "2025-12-06T13:26:41.014Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/b8/a0f10be8d648d6f8f26e560d6e6955efa7df0ff1e009155717454d76f601/pybase64-1.4.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ab1dd8b1ed2d1d750260ed58ab40defaa5ba83f76a30e18b9ebd5646f6247ae5", upload-time = "2025-12-06T13:26:42.539Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/22/832a2f9e76cdf39b52e01e40d8feeb6a04cf105494f2c3e3126d0149717f/pybase64-1.4.3-pp311-pypy311_pp73-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:bd4d2293de9fd212e294c136cec85892460b17d24e8c18a6ba18750928037750", upload-time = "2025-12-06T13:26:43.782Z" },
-    { url = "https://files.pythonhosted.org/packages/12/d7/6610f34a8972415fab3bb4704c174a1cc477bffbc3c36e526428d0f3957d/pybase64-1.4.3-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af6d0d3a691911cc4c9a625f3ddcd3af720738c21be3d5c72de05629139d393", upload-time = "2025-12-06T13:26:44.936Z" },
-    { url = "https://files.pythonhosted.org/packages/64/25/ed24400948a6c974ab1374a233cb7e8af0a5373cea0dd8a944627d17c34a/pybase64-1.4.3-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfc8c49a28322d82242088378f8542ce97459866ba73150b062a7073e82629d", upload-time = "2025-12-06T13:26:46.098Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/2b/e18ee7c5ee508a82897f021c1981533eca2940b5f072fc6ed0906c03a7a7/pybase64-1.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:debf737e09b8bf832ba86f5ecc3d3dbd0e3021d6cd86ba4abe962d6a5a77adb3", upload-time = "2025-12-06T13:26:47.35Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/63/21e981e9d3f1f123e0b0ee2130112b1956cad9752309f574862c7ae77c08/pybase64-1.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:70b0d4a4d54e216ce42c2655315378b8903933ecfa32fced453989a92b4317b2", size = 38237 },
+    { url = "https://files.pythonhosted.org/packages/92/fb/3f448e139516404d2a3963915cc10dc9dde7d3a67de4edba2f827adfef17/pybase64-1.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8127f110cdee7a70e576c5c9c1d4e17e92e76c191869085efbc50419f4ae3c72", size = 31673 },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/bb06a5b9885e7d853ac1e801c4d8abfdb4c8506deee33e53d55aa6690e67/pybase64-1.4.3-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:f9ef0388878bc15a084bd9bf73ec1b2b4ee513d11009b1506375e10a7aae5032", size = 68331 },
+    { url = "https://files.pythonhosted.org/packages/64/15/8d60b9ec5e658185fc2ee3333e01a6e30d717cf677b24f47cbb3a859d13c/pybase64-1.4.3-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95a57cccf106352a72ed8bc8198f6820b16cc7d55aa3867a16dea7011ae7c218", size = 71370 },
+    { url = "https://files.pythonhosted.org/packages/ac/29/a3e5c1667cc8c38d025a4636855de0fc117fc62e2afeb033a3c6f12c6a22/pybase64-1.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cd1c47dfceb9c7bd3de210fb4e65904053ed2d7c9dce6d107f041ff6fbd7e21", size = 59834 },
+    { url = "https://files.pythonhosted.org/packages/a9/00/8ffcf9810bd23f3984698be161cf7edba656fd639b818039a7be1d6405d4/pybase64-1.4.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:9fe9922698f3e2f72874b26890d53a051c431d942701bb3a37aae94da0b12107", size = 56652 },
+    { url = "https://files.pythonhosted.org/packages/81/62/379e347797cdea4ab686375945bc77ad8d039c688c0d4d0cfb09d247beb9/pybase64-1.4.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:af5f4bd29c86b59bb4375e0491d16ec8a67548fa99c54763aaedaf0b4b5a6632", size = 59382 },
+    { url = "https://files.pythonhosted.org/packages/c6/f2/9338ffe2f487086f26a2c8ca175acb3baa86fce0a756ff5670a0822bb877/pybase64-1.4.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c302f6ca7465262908131411226e02100f488f531bb5e64cb901aa3f439bccd9", size = 59990 },
+    { url = "https://files.pythonhosted.org/packages/f9/a4/85a6142b65b4df8625b337727aa81dc199642de3d09677804141df6ee312/pybase64-1.4.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2f3f439fa4d7fde164ebbbb41968db7d66b064450ab6017c6c95cef0afa2b349", size = 54923 },
+    { url = "https://files.pythonhosted.org/packages/ac/00/e40215d25624012bf5b7416ca37f168cb75f6dd15acdb91ea1f2ea4dc4e7/pybase64-1.4.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7a23c6866551043f8b681a5e1e0d59469148b2920a3b4fc42b1275f25ea4217a", size = 58664 },
+    { url = "https://files.pythonhosted.org/packages/b0/73/d7e19a63e795c13837f2356268d95dc79d1180e756f57ced742a1e52fdeb/pybase64-1.4.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:56e6526f8565642abc5f84338cc131ce298a8ccab696b19bdf76fa6d7dc592ef", size = 52338 },
+    { url = "https://files.pythonhosted.org/packages/f2/32/3c746d7a310b69bdd9df77ffc85c41b80bce00a774717596f869b0d4a20e/pybase64-1.4.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6a792a8b9d866ffa413c9687d9b611553203753987a3a582d68cbc51cf23da45", size = 68993 },
+    { url = "https://files.pythonhosted.org/packages/5d/b3/63cec68f9d6f6e4c0b438d14e5f1ef536a5fe63ce14b70733ac5e31d7ab8/pybase64-1.4.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:62ad29a5026bb22cfcd1ca484ec34b0a5ced56ddba38ceecd9359b2818c9c4f9", size = 58055 },
+    { url = "https://files.pythonhosted.org/packages/d5/cb/7acf7c3c06f9692093c07f109668725dc37fb9a3df0fa912b50add645195/pybase64-1.4.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11b9d1d2d32ec358c02214363b8fc3651f6be7dd84d880ecd597a6206a80e121", size = 54430 },
+    { url = "https://files.pythonhosted.org/packages/33/39/4eb33ff35d173bfff4002e184ce8907f5d0a42d958d61cd9058ef3570179/pybase64-1.4.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0aebaa7f238caa0a0d373616016e2040c6c879ebce3ba7ab3c59029920f13640", size = 56272 },
+    { url = "https://files.pythonhosted.org/packages/19/97/a76d65c375a254e65b730c6f56bf528feca91305da32eceab8bcc08591e6/pybase64-1.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e504682b20c63c2b0c000e5f98a80ea867f8d97642e042a5a39818e44ba4d599", size = 70904 },
+    { url = "https://files.pythonhosted.org/packages/5e/2c/8338b6d3da3c265002839e92af0a80d6db88385c313c73f103dfb800c857/pybase64-1.4.3-cp311-cp311-win32.whl", hash = "sha256:e9a8b81984e3c6fb1db9e1614341b0a2d98c0033d693d90c726677db1ffa3a4c", size = 33639 },
+    { url = "https://files.pythonhosted.org/packages/39/dc/32efdf2f5927e5449cc341c266a1bbc5fecd5319a8807d9c5405f76e6d02/pybase64-1.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:a90a8fa16a901fabf20de824d7acce07586e6127dc2333f1de05f73b1f848319", size = 35797 },
+    { url = "https://files.pythonhosted.org/packages/da/59/eda4f9cb0cbce5a45f0cd06131e710674f8123a4d570772c5b9694f88559/pybase64-1.4.3-cp311-cp311-win_arm64.whl", hash = "sha256:61d87de5bc94d143622e94390ec3e11b9c1d4644fe9be3a81068ab0f91056f59", size = 31160 },
+    { url = "https://files.pythonhosted.org/packages/b2/76/160dded493c00d3376d4ad0f38a2119c5345de4a6693419ad39c3565959b/pybase64-1.4.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:277de6e03cc9090fb359365c686a2a3036d23aee6cd20d45d22b8c89d1247f17", size = 37939 },
+    { url = "https://files.pythonhosted.org/packages/b7/b8/a0f10be8d648d6f8f26e560d6e6955efa7df0ff1e009155717454d76f601/pybase64-1.4.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ab1dd8b1ed2d1d750260ed58ab40defaa5ba83f76a30e18b9ebd5646f6247ae5", size = 31466 },
+    { url = "https://files.pythonhosted.org/packages/d3/22/832a2f9e76cdf39b52e01e40d8feeb6a04cf105494f2c3e3126d0149717f/pybase64-1.4.3-pp311-pypy311_pp73-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:bd4d2293de9fd212e294c136cec85892460b17d24e8c18a6ba18750928037750", size = 40681 },
+    { url = "https://files.pythonhosted.org/packages/12/d7/6610f34a8972415fab3bb4704c174a1cc477bffbc3c36e526428d0f3957d/pybase64-1.4.3-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af6d0d3a691911cc4c9a625f3ddcd3af720738c21be3d5c72de05629139d393", size = 41294 },
+    { url = "https://files.pythonhosted.org/packages/64/25/ed24400948a6c974ab1374a233cb7e8af0a5373cea0dd8a944627d17c34a/pybase64-1.4.3-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfc8c49a28322d82242088378f8542ce97459866ba73150b062a7073e82629d", size = 35447 },
+    { url = "https://files.pythonhosted.org/packages/ee/2b/e18ee7c5ee508a82897f021c1981533eca2940b5f072fc6ed0906c03a7a7/pybase64-1.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:debf737e09b8bf832ba86f5ecc3d3dbd0e3021d6cd86ba4abe962d6a5a77adb3", size = 36134 },
 ]
 
 [[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", upload-time = "2026-01-21T14:26:51.89Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", upload-time = "2026-01-21T14:26:50.693Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172 },
 ]
 
 [[package]]
@@ -3061,9 +3067,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", upload-time = "2025-10-04T10:40:41.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", size = 788494 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a", upload-time = "2025-10-04T10:40:39.055Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a", size = 444823 },
 ]
 
 [package.optional-dependencies]
@@ -3078,31 +3084,31 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", upload-time = "2025-04-23T18:33:52.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", upload-time = "2025-04-23T18:31:03.106Z" },
-    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", upload-time = "2025-04-23T18:31:04.621Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", upload-time = "2025-04-23T18:31:06.377Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", upload-time = "2025-04-23T18:31:07.93Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", upload-time = "2025-04-23T18:31:09.283Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", upload-time = "2025-04-23T18:31:11.7Z" },
-    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", upload-time = "2025-04-23T18:31:13.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", upload-time = "2025-04-23T18:31:15.011Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", upload-time = "2025-04-23T18:31:16.393Z" },
-    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", upload-time = "2025-04-23T18:31:17.892Z" },
-    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", upload-time = "2025-04-23T18:31:19.205Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", upload-time = "2025-04-23T18:31:20.541Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", upload-time = "2025-04-23T18:31:22.371Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", upload-time = "2025-04-23T18:31:24.161Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", upload-time = "2025-04-23T18:33:14.199Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", upload-time = "2025-04-23T18:33:16.555Z" },
-    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", upload-time = "2025-04-23T18:33:18.513Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", upload-time = "2025-04-23T18:33:20.475Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", upload-time = "2025-04-23T18:33:22.501Z" },
-    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", upload-time = "2025-04-23T18:33:24.528Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", upload-time = "2025-04-23T18:33:26.621Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", upload-time = "2025-04-23T18:33:28.656Z" },
-    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", upload-time = "2025-04-23T18:33:30.645Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", size = 2028584 },
+    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", size = 1855071 },
+    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", size = 1897823 },
+    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", size = 1983792 },
+    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", size = 2136338 },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", size = 2730998 },
+    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", size = 2003200 },
+    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", size = 2113890 },
+    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", size = 2073359 },
+    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", size = 2245883 },
+    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", size = 2241074 },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", size = 1910538 },
+    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", size = 1952909 },
+    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", size = 1897786 },
+    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", size = 2025200 },
+    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", size = 1859123 },
+    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", size = 1892852 },
+    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", size = 2067484 },
+    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", size = 2108896 },
+    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", size = 2069475 },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013 },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715 },
+    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757 },
 ]
 
 [[package]]
@@ -3114,27 +3120,27 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", upload-time = "2025-06-24T13:26:46.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", upload-time = "2025-06-24T13:26:45.485Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235 },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
 ]
 
 [[package]]
 name = "pyjwt"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224 },
 ]
 
 [package.optional-dependencies]
@@ -3146,71 +3152,71 @@ crypto = [
 name = "pymupdf"
 version = "1.26.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/d6/09b28f027b510838559f7748807192149c419b30cb90e6d5f0cf916dc9dc/pymupdf-1.26.7.tar.gz", hash = "sha256:71add8bdc8eb1aaa207c69a13400693f06ad9b927bea976f5d5ab9df0bb489c3", upload-time = "2025-12-11T21:48:50.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/d6/09b28f027b510838559f7748807192149c419b30cb90e6d5f0cf916dc9dc/pymupdf-1.26.7.tar.gz", hash = "sha256:71add8bdc8eb1aaa207c69a13400693f06ad9b927bea976f5d5ab9df0bb489c3", size = 84327033 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/35/cd74cea1787b2247702ef8522186bdef32e9cb30a099e6bb864627ef6045/pymupdf-1.26.7-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:07085718dfdae5ab83b05eb5eb397f863bcc538fe05135318a01ea353e7a1353", upload-time = "2025-12-11T21:47:21.587Z" },
-    { url = "https://files.pythonhosted.org/packages/72/74/448b6172927c829c6a3fba80078d7b0a016ebbe2c9ee528821f5ea21677a/pymupdf-1.26.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:31aa9c8377ea1eea02934b92f4dcf79fb2abba0bf41f8a46d64c3e31546a3c02", upload-time = "2025-12-11T21:47:37.105Z" },
-    { url = "https://files.pythonhosted.org/packages/65/e7/47af26f3ac76be7ac3dd4d6cc7ee105948a8355d774e5ca39857bf91c11c/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e419b609996434a14a80fa060adec72c434a1cca6a511ec54db9841bc5d51b3c", upload-time = "2025-12-12T09:51:25.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/6b/3de1714d734ff949be1e90a22375d0598d3540b22ae73eb85c2d7d1f36a9/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:69dfc78f206a96e5b3ac22741263ebab945fdf51f0dbe7c5757c3511b23d9d72", upload-time = "2025-12-11T21:47:51.274Z" },
-    { url = "https://files.pythonhosted.org/packages/62/9b/f86224847949577a523be2207315ae0fd3155b5d909cd66c274d095349a3/pymupdf-1.26.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1d5106f46e1ca0d64d46bd51892372a4f82076bdc14a9678d33d630702abca36", upload-time = "2025-12-12T14:58:45.483Z" },
-    { url = "https://files.pythonhosted.org/packages/85/8e/a117d39092ca645fde8b903f4a941d9aa75b370a67b4f1f435f56393dc5a/pymupdf-1.26.7-cp310-abi3-win32.whl", hash = "sha256:7c9645b6f5452629c747690190350213d3e5bbdb6b2eca227d82702b327f6eee", upload-time = "2025-12-12T13:59:57.613Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/c3/d0047678146c294469c33bae167c8ace337deafb736b0bf97b9bc481aa65/pymupdf-1.26.7-cp310-abi3-win_amd64.whl", hash = "sha256:425b1befe40d41b72eb0fe211711c7ae334db5eb60307e9dd09066ed060cceba", upload-time = "2025-12-11T21:48:02.947Z" },
+    { url = "https://files.pythonhosted.org/packages/94/35/cd74cea1787b2247702ef8522186bdef32e9cb30a099e6bb864627ef6045/pymupdf-1.26.7-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:07085718dfdae5ab83b05eb5eb397f863bcc538fe05135318a01ea353e7a1353", size = 23179369 },
+    { url = "https://files.pythonhosted.org/packages/72/74/448b6172927c829c6a3fba80078d7b0a016ebbe2c9ee528821f5ea21677a/pymupdf-1.26.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:31aa9c8377ea1eea02934b92f4dcf79fb2abba0bf41f8a46d64c3e31546a3c02", size = 22470101 },
+    { url = "https://files.pythonhosted.org/packages/65/e7/47af26f3ac76be7ac3dd4d6cc7ee105948a8355d774e5ca39857bf91c11c/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e419b609996434a14a80fa060adec72c434a1cca6a511ec54db9841bc5d51b3c", size = 23502486 },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/3de1714d734ff949be1e90a22375d0598d3540b22ae73eb85c2d7d1f36a9/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:69dfc78f206a96e5b3ac22741263ebab945fdf51f0dbe7c5757c3511b23d9d72", size = 24115727 },
+    { url = "https://files.pythonhosted.org/packages/62/9b/f86224847949577a523be2207315ae0fd3155b5d909cd66c274d095349a3/pymupdf-1.26.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1d5106f46e1ca0d64d46bd51892372a4f82076bdc14a9678d33d630702abca36", size = 24324386 },
+    { url = "https://files.pythonhosted.org/packages/85/8e/a117d39092ca645fde8b903f4a941d9aa75b370a67b4f1f435f56393dc5a/pymupdf-1.26.7-cp310-abi3-win32.whl", hash = "sha256:7c9645b6f5452629c747690190350213d3e5bbdb6b2eca227d82702b327f6eee", size = 17203888 },
+    { url = "https://files.pythonhosted.org/packages/dd/c3/d0047678146c294469c33bae167c8ace337deafb736b0bf97b9bc481aa65/pymupdf-1.26.7-cp310-abi3-win_amd64.whl", hash = "sha256:425b1befe40d41b72eb0fe211711c7ae334db5eb60307e9dd09066ed060cceba", size = 18405952 },
 ]
 
 [[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", upload-time = "2026-01-21T03:57:59.36Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", upload-time = "2026-01-21T03:57:55.912Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781 },
 ]
 
 [[package]]
 name = "pypdfium2"
 version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/23/b3979a1d4f536fabce02e3d9f332e8aeeed064d9df9391f2a77160f4ab36/pypdfium2-5.4.0.tar.gz", hash = "sha256:7219e55048fb3999fc8adcaea467088507207df4676ff9e521a3ae15a67d99c4", upload-time = "2026-02-08T16:54:08.383Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/23/b3979a1d4f536fabce02e3d9f332e8aeeed064d9df9391f2a77160f4ab36/pypdfium2-5.4.0.tar.gz", hash = "sha256:7219e55048fb3999fc8adcaea467088507207df4676ff9e521a3ae15a67d99c4", size = 269136 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/c0/3d707bff5e973272b5412556d19e8c6889ce859a235465f0049cc8d35bc3/pypdfium2-5.4.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:8bc51a12a8c8eabbdbd7499d3e5ec47bcf56ba18e07b52bdd07d321cc1252c90", upload-time = "2026-02-08T16:53:32.985Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/6b/306cafcb0b18d5fab41687d9ed76eabea86a9ff78bc568bee1bfa34e526d/pypdfium2-5.4.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:a414ef5b685824cc6c7acbe19b7dbc735de2023cf473321a8ebfe8d7f5d8a41f", upload-time = "2026-02-08T16:53:35.026Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/37/3d737c7eb84fb22939ab0a643aa0183dbc0745c309e962b4d61eeff8211b/pypdfium2-5.4.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0e83657db8da5971434ff5683bf3faa007ee1f3a56b61f245b8aa5b60442c23a", upload-time = "2026-02-08T16:53:36.481Z" },
-    { url = "https://files.pythonhosted.org/packages/96/d7/0895737ec3d95ad607ade42e98fa8868b91e35b1170ec39b8c1b5fdb124c/pypdfium2-5.4.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e42b1d14db642e96bb3a57167f620b4247e9c843d22b9fb569b16a7c35a18f47", upload-time = "2026-02-08T16:53:37.992Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/53/f8ab449997d3efa52737b8e6c494f1c3f09dc0642161fadc934f16a57cf0/pypdfium2-5.4.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0698c9a002f839127e74ec0185147e08b64e47a1e6caeaee95df434c05b26e8c", upload-time = "2026-02-08T16:53:39.923Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/28/b8a4d4c1557019101bb722c88ba532ec9c14640117ab1c272c80774d83d7/pypdfium2-5.4.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:22e9d4c73fc48b18b022977ea6fe78df43adf95440e1135020ed35fea9595017", upload-time = "2026-02-08T16:53:41.958Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/4a/6c765f6e0b69d792e2d4c7ef2359301896c82df265d60f9a56e87618ec50/pypdfium2-5.4.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f0619f8a8ae3eb71b2cdc1fbd2a8f5d43f0fc6bee66d1b3aac2c9c23e44a3bf", upload-time = "2026-02-08T16:53:43.974Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/17/4464e4ab6dd98ac3783c10eb799d8da49cb551a769c987eb9c6ba72a5ccf/pypdfium2-5.4.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50124415d815c41de8ce7e21cee5450f74f6f1240a140573bb71ccac804d5e5f", upload-time = "2026-02-08T16:53:46.041Z" },
-    { url = "https://files.pythonhosted.org/packages/92/08/fa315a2ab353b41501b7088be72dc6cf8ad2bd4f1ebdfdb90c41b7f29155/pypdfium2-5.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce482d76e5447e745d761307401eaa366616ca44032b86cf7fbe6be918ade64e", upload-time = "2026-02-08T16:53:47.705Z" },
-    { url = "https://files.pythonhosted.org/packages/02/7a/a171d313d54a028d9437dea2c5d07fc9e1592f4daf5c39cbf514fca75242/pypdfium2-5.4.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16b9c6b07f3dbe7eda209bf7aaf131ca9614e1dae527e9764180dd58bcbaf411", upload-time = "2026-02-08T16:53:49.139Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/c0/60416f011f7e5a4ca29f40ae94907f34975239f3c6dd7fcb51f99e110f3b/pypdfium2-5.4.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3b08d48b7cca3b51aefaad7855bc0e9e251432a6eef1356d532ff438be84855e", upload-time = "2026-02-08T16:53:50.553Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e2/8e36144b5e933c707b6aeab7dc6638eee8208697925b48b5b78ef68fb52a/pypdfium2-5.4.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0a1526e2a2bde7f2f13bec0f471d9fd475f7bbac2c0c860d48c35af8394d5931", upload-time = "2026-02-08T16:53:52.71Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/64/8cda96259a8fdecd457f5d14a9d650315d7bdf496f96055d1d55900b3881/pypdfium2-5.4.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:40cea0bceb1e60a71b3855e2b04d175d2199b7da06212bb80f0c78067d065810", upload-time = "2026-02-08T16:53:54.219Z" },
-    { url = "https://files.pythonhosted.org/packages/33/6b/7764491269f188a922bd6b254359d718899fc3092c90f0f68c2f6e451921/pypdfium2-5.4.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7a116f8fbeae7aa3a18ff2d1fa331ac647831cc16b589d4fbbbb66d64ecc8793", upload-time = "2026-02-08T16:53:56.18Z" },
-    { url = "https://files.pythonhosted.org/packages/87/b0/2484bd3c20ead51ecea2082deaf94a3e91bad709fa14f049ca7fb598dc9a/pypdfium2-5.4.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:55c7fc894718db5fa2981d46dee45fe3a4fcd60d26f5095ad8f7779600fa8b6f", upload-time = "2026-02-08T16:53:57.804Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ac/5f0536be885c3cadc09422de0324a193a21c165488a574029d9d2db92ecb/pypdfium2-5.4.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:dfc1c0c7e6e7ba258ebb338aaf664eb933bff1854cda76e4ee530886ea39b31a", upload-time = "2026-02-08T16:53:59.265Z" },
-    { url = "https://files.pythonhosted.org/packages/13/b9/693b665df0939555491bece0777cafda1270e208734e925006de313abb5b/pypdfium2-5.4.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:4c0a48ede7180f804c029c509c2b6ea0c66813a3fde9eb9afc390183f947164d", upload-time = "2026-02-08T16:54:00.809Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/ea/ba585acdfbefe309ee2fe5ebfeb097e36abe1d33c2a5108828c493c070bb/pypdfium2-5.4.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dea22d15c44a275702fd95ad664ba6eaa3c493d53d58b4d69272a04bdfb0df70", upload-time = "2026-02-08T16:54:02.264Z" },
-    { url = "https://files.pythonhosted.org/packages/97/47/238383e89081a0ed1ca2bf4ef44f7e512fa0c72ffc51adc7df83bfcfd9b9/pypdfium2-5.4.0-py3-none-win32.whl", hash = "sha256:35c643827ed0f4dae9cedf3caf836f94cba5b31bd2c115b80a7c85f004636de9", upload-time = "2026-02-08T16:54:03.692Z" },
-    { url = "https://files.pythonhosted.org/packages/08/37/f1338a0600c6c6e31759f8f80d7ab20aa0bc43b11594da67091300e051d4/pypdfium2-5.4.0-py3-none-win_amd64.whl", hash = "sha256:f9d9ce3c6901294d6984004d4a797dea110f8248b1bde33a823d25b45d3c2685", upload-time = "2026-02-08T16:54:05.304Z" },
-    { url = "https://files.pythonhosted.org/packages/65/17/18ad82f070da18ab970928f730fbd44d9b05aafcb52a2ebb6470eaae53f9/pypdfium2-5.4.0-py3-none-win_arm64.whl", hash = "sha256:2b78ea216fb92e7709b61c46241ebf2cc0c60cf18ad2fb4633af665d7b4e21e6", upload-time = "2026-02-08T16:54:06.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c0/3d707bff5e973272b5412556d19e8c6889ce859a235465f0049cc8d35bc3/pypdfium2-5.4.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:8bc51a12a8c8eabbdbd7499d3e5ec47bcf56ba18e07b52bdd07d321cc1252c90", size = 2759769 },
+    { url = "https://files.pythonhosted.org/packages/1b/6b/306cafcb0b18d5fab41687d9ed76eabea86a9ff78bc568bee1bfa34e526d/pypdfium2-5.4.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:a414ef5b685824cc6c7acbe19b7dbc735de2023cf473321a8ebfe8d7f5d8a41f", size = 2301913 },
+    { url = "https://files.pythonhosted.org/packages/7a/37/3d737c7eb84fb22939ab0a643aa0183dbc0745c309e962b4d61eeff8211b/pypdfium2-5.4.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0e83657db8da5971434ff5683bf3faa007ee1f3a56b61f245b8aa5b60442c23a", size = 2814181 },
+    { url = "https://files.pythonhosted.org/packages/96/d7/0895737ec3d95ad607ade42e98fa8868b91e35b1170ec39b8c1b5fdb124c/pypdfium2-5.4.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e42b1d14db642e96bb3a57167f620b4247e9c843d22b9fb569b16a7c35a18f47", size = 2943476 },
+    { url = "https://files.pythonhosted.org/packages/9a/53/f8ab449997d3efa52737b8e6c494f1c3f09dc0642161fadc934f16a57cf0/pypdfium2-5.4.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0698c9a002f839127e74ec0185147e08b64e47a1e6caeaee95df434c05b26e8c", size = 2976675 },
+    { url = "https://files.pythonhosted.org/packages/c6/28/b8a4d4c1557019101bb722c88ba532ec9c14640117ab1c272c80774d83d7/pypdfium2-5.4.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:22e9d4c73fc48b18b022977ea6fe78df43adf95440e1135020ed35fea9595017", size = 2762396 },
+    { url = "https://files.pythonhosted.org/packages/0b/4a/6c765f6e0b69d792e2d4c7ef2359301896c82df265d60f9a56e87618ec50/pypdfium2-5.4.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f0619f8a8ae3eb71b2cdc1fbd2a8f5d43f0fc6bee66d1b3aac2c9c23e44a3bf", size = 3068559 },
+    { url = "https://files.pythonhosted.org/packages/1c/17/4464e4ab6dd98ac3783c10eb799d8da49cb551a769c987eb9c6ba72a5ccf/pypdfium2-5.4.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50124415d815c41de8ce7e21cee5450f74f6f1240a140573bb71ccac804d5e5f", size = 3419384 },
+    { url = "https://files.pythonhosted.org/packages/92/08/fa315a2ab353b41501b7088be72dc6cf8ad2bd4f1ebdfdb90c41b7f29155/pypdfium2-5.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce482d76e5447e745d761307401eaa366616ca44032b86cf7fbe6be918ade64e", size = 2998123 },
+    { url = "https://files.pythonhosted.org/packages/02/7a/a171d313d54a028d9437dea2c5d07fc9e1592f4daf5c39cbf514fca75242/pypdfium2-5.4.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16b9c6b07f3dbe7eda209bf7aaf131ca9614e1dae527e9764180dd58bcbaf411", size = 3673594 },
+    { url = "https://files.pythonhosted.org/packages/0b/c0/60416f011f7e5a4ca29f40ae94907f34975239f3c6dd7fcb51f99e110f3b/pypdfium2-5.4.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3b08d48b7cca3b51aefaad7855bc0e9e251432a6eef1356d532ff438be84855e", size = 2965025 },
+    { url = "https://files.pythonhosted.org/packages/75/e2/8e36144b5e933c707b6aeab7dc6638eee8208697925b48b5b78ef68fb52a/pypdfium2-5.4.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0a1526e2a2bde7f2f13bec0f471d9fd475f7bbac2c0c860d48c35af8394d5931", size = 4130551 },
+    { url = "https://files.pythonhosted.org/packages/a0/64/8cda96259a8fdecd457f5d14a9d650315d7bdf496f96055d1d55900b3881/pypdfium2-5.4.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:40cea0bceb1e60a71b3855e2b04d175d2199b7da06212bb80f0c78067d065810", size = 3746587 },
+    { url = "https://files.pythonhosted.org/packages/33/6b/7764491269f188a922bd6b254359d718899fc3092c90f0f68c2f6e451921/pypdfium2-5.4.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7a116f8fbeae7aa3a18ff2d1fa331ac647831cc16b589d4fbbbb66d64ecc8793", size = 4336703 },
+    { url = "https://files.pythonhosted.org/packages/87/b0/2484bd3c20ead51ecea2082deaf94a3e91bad709fa14f049ca7fb598dc9a/pypdfium2-5.4.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:55c7fc894718db5fa2981d46dee45fe3a4fcd60d26f5095ad8f7779600fa8b6f", size = 4375051 },
+    { url = "https://files.pythonhosted.org/packages/c0/ac/5f0536be885c3cadc09422de0324a193a21c165488a574029d9d2db92ecb/pypdfium2-5.4.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:dfc1c0c7e6e7ba258ebb338aaf664eb933bff1854cda76e4ee530886ea39b31a", size = 3928935 },
+    { url = "https://files.pythonhosted.org/packages/13/b9/693b665df0939555491bece0777cafda1270e208734e925006de313abb5b/pypdfium2-5.4.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:4c0a48ede7180f804c029c509c2b6ea0c66813a3fde9eb9afc390183f947164d", size = 4997642 },
+    { url = "https://files.pythonhosted.org/packages/fb/ea/ba585acdfbefe309ee2fe5ebfeb097e36abe1d33c2a5108828c493c070bb/pypdfium2-5.4.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dea22d15c44a275702fd95ad664ba6eaa3c493d53d58b4d69272a04bdfb0df70", size = 4179914 },
+    { url = "https://files.pythonhosted.org/packages/97/47/238383e89081a0ed1ca2bf4ef44f7e512fa0c72ffc51adc7df83bfcfd9b9/pypdfium2-5.4.0-py3-none-win32.whl", hash = "sha256:35c643827ed0f4dae9cedf3caf836f94cba5b31bd2c115b80a7c85f004636de9", size = 2995844 },
+    { url = "https://files.pythonhosted.org/packages/08/37/f1338a0600c6c6e31759f8f80d7ab20aa0bc43b11594da67091300e051d4/pypdfium2-5.4.0-py3-none-win_amd64.whl", hash = "sha256:f9d9ce3c6901294d6984004d4a797dea110f8248b1bde33a823d25b45d3c2685", size = 3104198 },
+    { url = "https://files.pythonhosted.org/packages/65/17/18ad82f070da18ab970928f730fbd44d9b05aafcb52a2ebb6470eaae53f9/pypdfium2-5.4.0-py3-none-win_arm64.whl", hash = "sha256:2b78ea216fb92e7709b61c46241ebf2cc0c60cf18ad2fb4633af665d7b4e21e6", size = 2938727 },
 ]
 
 [[package]]
 name = "pypika"
 version = "0.51.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/78/cbaebba88e05e2dcda13ca203131b38d3640219f20ebb49676d26714861b/pypika-0.51.1.tar.gz", hash = "sha256:c30c7c1048fbf056fd3920c5a2b88b0c29dd190a9b2bee971fd17e4abe4d0ebe", upload-time = "2026-02-04T11:27:48.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/78/cbaebba88e05e2dcda13ca203131b38d3640219f20ebb49676d26714861b/pypika-0.51.1.tar.gz", hash = "sha256:c30c7c1048fbf056fd3920c5a2b88b0c29dd190a9b2bee971fd17e4abe4d0ebe", size = 80919 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl", hash = "sha256:77985b4d7ce71b9905255bf12468cf598349e98837c037541cfc240e528aec46", upload-time = "2026-02-04T11:27:46.251Z" },
+    { url = "https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl", hash = "sha256:77985b4d7ce71b9905255bf12468cf598349e98837c037541cfc240e528aec46", size = 60585 },
 ]
 
 [[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", upload-time = "2024-09-29T09:24:13.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", upload-time = "2024-09-29T09:24:11.978Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
 ]
 
 [[package]]
@@ -3222,18 +3228,18 @@ dependencies = [
     { name = "python3-memcached" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/f0/1af4316218dfff434b11b41374fec25f60db60ab6c7b8ab7695436708d73/pysendpulse-0.1.8.tar.gz", hash = "sha256:91779aa6b86a456e22c97328bd8f6df90dc1df249fc0b10714a64246138dcc78", upload-time = "2025-02-11T09:37:14.195Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f0/1af4316218dfff434b11b41374fec25f60db60ab6c7b8ab7695436708d73/pysendpulse-0.1.8.tar.gz", hash = "sha256:91779aa6b86a456e22c97328bd8f6df90dc1df249fc0b10714a64246138dcc78", size = 13445 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/35/dd4e0a8ad990da03824678830caf72e90071fd227a954a41a370b8f68442/pysendpulse-0.1.8-py3-none-any.whl", hash = "sha256:bb33414c4cfe047179351c32810c373efc1a86c3df6a8e227228871d188ab352", upload-time = "2025-02-11T09:37:12.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/35/dd4e0a8ad990da03824678830caf72e90071fd227a954a41a370b8f68442/pysendpulse-0.1.8-py3-none-any.whl", hash = "sha256:bb33414c4cfe047179351c32810c373efc1a86c3df6a8e227228871d188ab352", size = 13422 },
 ]
 
 [[package]]
 name = "pysocks"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", upload-time = "2019-09-20T02:07:35.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", upload-time = "2019-09-20T02:06:22.938Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725 },
 ]
 
 [[package]]
@@ -3247,9 +3253,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
 ]
 
 [[package]]
@@ -3260,9 +3266,9 @@ dependencies = [
     { name = "pytest" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075 },
 ]
 
 [[package]]
@@ -3274,9 +3280,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424 },
 ]
 
 [[package]]
@@ -3286,9 +3292,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", upload-time = "2025-09-16T16:37:27.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", upload-time = "2025-09-16T16:37:25.734Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095 },
 ]
 
 [[package]]
@@ -3299,9 +3305,9 @@ dependencies = [
     { name = "execnet" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", upload-time = "2025-07-01T13:30:59.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", upload-time = "2025-07-01T13:30:56.632Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396 },
 ]
 
 [[package]]
@@ -3311,9 +3317,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", upload-time = "2024-03-01T18:36:20.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", upload-time = "2024-03-01T18:36:18.57Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
 ]
 
 [[package]]
@@ -3324,27 +3330,27 @@ dependencies = [
     { name = "lxml" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", upload-time = "2025-06-16T20:46:27.921Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", upload-time = "2025-06-16T20:46:22.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987 },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", upload-time = "2026-03-01T16:00:26.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", upload-time = "2026-03-01T16:00:25.09Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101 },
 ]
 
 [[package]]
 name = "python-multipart"
 version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579 },
 ]
 
 [[package]]
@@ -3357,47 +3363,47 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "xlsxwriter" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", upload-time = "2024-08-07T17:33:37.772Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", upload-time = "2024-08-07T17:33:28.192Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788 },
 ]
 
 [[package]]
 name = "python3-memcached"
 version = "1.51"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/fa/cd0d93c30722db0cfa777ec9cd0203fa7da2771a5c70c9908f471944b6e2/python3-memcached-1.51.tar.gz", hash = "sha256:7cbe5951d68eef69d948b7a7ed7decfbd101e15e7f5be007dcd1219ccc584859", upload-time = "2013-05-11T21:35:30.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/fa/cd0d93c30722db0cfa777ec9cd0203fa7da2771a5c70c9908f471944b6e2/python3-memcached-1.51.tar.gz", hash = "sha256:7cbe5951d68eef69d948b7a7ed7decfbd101e15e7f5be007dcd1219ccc584859", size = 14082 }
 
 [[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", upload-time = "2026-01-30T01:03:45.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", upload-time = "2026-01-30T01:02:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", upload-time = "2026-01-30T01:02:59.912Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", upload-time = "2026-01-30T01:03:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", upload-time = "2026-01-30T01:03:04.143Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", upload-time = "2026-01-30T01:03:05.412Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", upload-time = "2026-01-30T01:03:45.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864 },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565 },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824 },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075 },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323 },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729 },
 ]
 
 [[package]]
 name = "pytube"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/e7/16fec46c8d255c4bbc4b185d89c91dc92cdb802836570d8004d0db169c91/pytube-15.0.0.tar.gz", hash = "sha256:076052efe76f390dfa24b1194ff821d4e86c17d41cb5562f3a276a8bcbfc9d1d", upload-time = "2023-05-07T19:39:01.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e7/16fec46c8d255c4bbc4b185d89c91dc92cdb802836570d8004d0db169c91/pytube-15.0.0.tar.gz", hash = "sha256:076052efe76f390dfa24b1194ff821d4e86c17d41cb5562f3a276a8bcbfc9d1d", size = 67229 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/64/bcf8632ed2b7a36bbf84a0544885ffa1d0b4bcf25cc0903dba66ec5fdad9/pytube-15.0.0-py3-none-any.whl", hash = "sha256:07b9904749e213485780d7eb606e5e5b8e4341aa4dccf699160876da00e12d78", upload-time = "2023-05-07T19:38:59.191Z" },
+    { url = "https://files.pythonhosted.org/packages/51/64/bcf8632ed2b7a36bbf84a0544885ffa1d0b4bcf25cc0903dba66ec5fdad9/pytube-15.0.0-py3-none-any.whl", hash = "sha256:07b9904749e213485780d7eb606e5e5b8e4341aa4dccf699160876da00e12d78", size = 57594 },
 ]
 
 [[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", upload-time = "2025-03-25T02:25:00.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", upload-time = "2025-03-25T02:24:58.468Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225 },
 ]
 
 [[package]]
@@ -3405,50 +3411,50 @@ name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031 },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308 },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930 },
 ]
 
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", upload-time = "2025-09-25T21:33:16.546Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826 },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577 },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556 },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114 },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638 },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463 },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986 },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543 },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763 },
 ]
 
 [[package]]
 name = "rapidfuzz"
 version = "3.14.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", upload-time = "2026-04-07T11:16:31.931Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/f9/3c41a7be8855803f4f6c713b472226a98d31d41869d98f64f4ca790510d6/rapidfuzz-3.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e251126d48615e1f02b4a178f2cd0cd4f0332b8a019c01a2e10480f7552554b4", upload-time = "2026-04-07T11:13:58.32Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/89/c2557e37531d03465193bff0ab9de70b468420a807d71a26a65100635459/rapidfuzz-3.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab449c9abd0d4e1f8145dce0798a4c822a1a1933d613c764a641bea88b8bdab", upload-time = "2026-04-07T11:14:00.127Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/b2/ffeeb7eca1a897d51b998f4c0ef0281696c3b06abcca4f88f9def708ffe1/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb2829fedd672dd7107267189dabe2bbe07972801d636014417c6861eb89e358", upload-time = "2026-04-07T11:14:01.696Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d0/4539e42a2d596e068f7738f279638a4a74edd1fbb6f8594e2458058979c6/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d50e5861872935fece391351cbb5ba21d1bced277cf5e1143d207a0a35f1925", upload-time = "2026-04-07T11:14:03.29Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/1c/3ec897eb9d8b05308aa8ef6ae4ed64b088ad521a3f9d8ff469e7e97bc2b0/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:7092a216728f80c960bd6b3807275d1ee318b168986bd5dc523349581d4890b8", upload-time = "2026-04-07T11:14:04.94Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/ba/970c03a12ce20a5399e22afe9f8932fd4cd1265b8a8461d0e63b00eb4eae/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9669753caef7fdc6529f6adcc5883ed98d65976445d9322e7dbdb6b697feee13", upload-time = "2026-04-07T11:14:07.228Z" },
-    { url = "https://files.pythonhosted.org/packages/81/93/61d351cae60c1d0e21ba5ff1a1015ad045539ed215da9d6e302204ed887a/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:823b1b9d9230809d8edcc18872770764bfe8ef4357995e16744047c8ccf0e489", upload-time = "2026-04-07T11:14:09.234Z" },
-    { url = "https://files.pythonhosted.org/packages/87/52/374d2d4f60fd98155142a869323aa221e30868cfa1f15171a0f64070c247/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f0b2af76b7e7060c09e1a0dfa9410eb19369cbe6164509bff2ef94094b54d2b6", upload-time = "2026-04-07T11:14:11.332Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/04/82e7989bc9ec20a15b720a335c5cb6b0724bf6582013898f90a3280cfccd/rapidfuzz-3.14.5-cp311-cp311-win32.whl", hash = "sha256:c5801a89604c65ab4cc9e91b23bc4076d0ca80efd8c976fb63843d7879a85d7f", upload-time = "2026-04-07T11:14:13.217Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/b5/eca8ac5609bc9bcb02bb6ff87fa5983cc92b8772d66a431556ab8a8c178f/rapidfuzz-3.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:d7ca16637c0ede8243f84074044bd0b2335a0341421f8227c85756de2d18c819", upload-time = "2026-04-07T11:14:14.766Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/e1/dbf318de28f65fa2cdd0a9dfbdee380f8199eb83b19259bc4f8592551b4e/rapidfuzz-3.14.5-cp311-cp311-win_arm64.whl", hash = "sha256:8c90cdf8516d9057e502aa6003cea71cf5ec27cc44699ca52412b502a04761bb", upload-time = "2026-04-07T11:14:16.788Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/ee/e71853bf82846c5c2174b924b71d8e8099fb05ff87c958a720380b434ba3/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:578e6051f6d5e6200c259b47a103cf06bb875ab5814d17333fc0b5c290b22f4c", upload-time = "2026-04-07T11:16:18.223Z" },
-    { url = "https://files.pythonhosted.org/packages/36/82/40f67b730f32be2ebad9f62add1571c754f52249254b2e88af094b907eee/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbf1b8bb2695415b347f3727da1addca2acb82c9b97ac86bebf8b1bead1eb12d", upload-time = "2026-04-07T11:16:20.682Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/9f/a3635cc4ec8fc6e14b46e7db1f7f8763d8c4bef33dcc124eea2e6cb2c8f3/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53", upload-time = "2026-04-07T11:16:23.451Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/1b/2b229520f0b48464cfcd7aa758f74551d12c9bc4ab544022a60210aab064/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5", upload-time = "2026-04-07T11:16:25.858Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b5/363906b1064fc6fe611783a61764927bbd91919aaaabe8cba82151ca93ef/rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf", upload-time = "2026-04-07T11:16:28.487Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f9/3c41a7be8855803f4f6c713b472226a98d31d41869d98f64f4ca790510d6/rapidfuzz-3.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e251126d48615e1f02b4a178f2cd0cd4f0332b8a019c01a2e10480f7552554b4", size = 1952372 },
+    { url = "https://files.pythonhosted.org/packages/9e/89/c2557e37531d03465193bff0ab9de70b468420a807d71a26a65100635459/rapidfuzz-3.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab449c9abd0d4e1f8145dce0798a4c822a1a1933d613c764a641bea88b8bdab", size = 1159782 },
+    { url = "https://files.pythonhosted.org/packages/1a/b2/ffeeb7eca1a897d51b998f4c0ef0281696c3b06abcca4f88f9def708ffe1/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb2829fedd672dd7107267189dabe2bbe07972801d636014417c6861eb89e358", size = 1383677 },
+    { url = "https://files.pythonhosted.org/packages/6b/d0/4539e42a2d596e068f7738f279638a4a74edd1fbb6f8594e2458058979c6/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d50e5861872935fece391351cbb5ba21d1bced277cf5e1143d207a0a35f1925", size = 3168906 },
+    { url = "https://files.pythonhosted.org/packages/5e/1c/3ec897eb9d8b05308aa8ef6ae4ed64b088ad521a3f9d8ff469e7e97bc2b0/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:7092a216728f80c960bd6b3807275d1ee318b168986bd5dc523349581d4890b8", size = 1478176 },
+    { url = "https://files.pythonhosted.org/packages/ab/ba/970c03a12ce20a5399e22afe9f8932fd4cd1265b8a8461d0e63b00eb4eae/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9669753caef7fdc6529f6adcc5883ed98d65976445d9322e7dbdb6b697feee13", size = 2402441 },
+    { url = "https://files.pythonhosted.org/packages/81/93/61d351cae60c1d0e21ba5ff1a1015ad045539ed215da9d6e302204ed887a/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:823b1b9d9230809d8edcc18872770764bfe8ef4357995e16744047c8ccf0e489", size = 2511628 },
+    { url = "https://files.pythonhosted.org/packages/87/52/374d2d4f60fd98155142a869323aa221e30868cfa1f15171a0f64070c247/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f0b2af76b7e7060c09e1a0dfa9410eb19369cbe6164509bff2ef94094b54d2b6", size = 4275480 },
+    { url = "https://files.pythonhosted.org/packages/d8/04/82e7989bc9ec20a15b720a335c5cb6b0724bf6582013898f90a3280cfccd/rapidfuzz-3.14.5-cp311-cp311-win32.whl", hash = "sha256:c5801a89604c65ab4cc9e91b23bc4076d0ca80efd8c976fb63843d7879a85d7f", size = 1725627 },
+    { url = "https://files.pythonhosted.org/packages/b9/b5/eca8ac5609bc9bcb02bb6ff87fa5983cc92b8772d66a431556ab8a8c178f/rapidfuzz-3.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:d7ca16637c0ede8243f84074044bd0b2335a0341421f8227c85756de2d18c819", size = 1545977 },
+    { url = "https://files.pythonhosted.org/packages/ca/e1/dbf318de28f65fa2cdd0a9dfbdee380f8199eb83b19259bc4f8592551b4e/rapidfuzz-3.14.5-cp311-cp311-win_arm64.whl", hash = "sha256:8c90cdf8516d9057e502aa6003cea71cf5ec27cc44699ca52412b502a04761bb", size = 816827 },
+    { url = "https://files.pythonhosted.org/packages/d9/ee/e71853bf82846c5c2174b924b71d8e8099fb05ff87c958a720380b434ba3/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:578e6051f6d5e6200c259b47a103cf06bb875ab5814d17333fc0b5c290b22f4c", size = 1888603 },
+    { url = "https://files.pythonhosted.org/packages/36/82/40f67b730f32be2ebad9f62add1571c754f52249254b2e88af094b907eee/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbf1b8bb2695415b347f3727da1addca2acb82c9b97ac86bebf8b1bead1eb12d", size = 1120599 },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/a3635cc4ec8fc6e14b46e7db1f7f8763d8c4bef33dcc124eea2e6cb2c8f3/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53", size = 1348524 },
+    { url = "https://files.pythonhosted.org/packages/cc/1b/2b229520f0b48464cfcd7aa758f74551d12c9bc4ab544022a60210aab064/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5", size = 3099302 },
+    { url = "https://files.pythonhosted.org/packages/aa/b5/363906b1064fc6fe611783a61764927bbd91919aaaabe8cba82151ca93ef/rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf", size = 1509889 },
 ]
 
 [[package]]
@@ -3458,9 +3464,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/c8/983d5c6579a411d8a99bc5823cc5712768859b5ce2c8afe1a65b37832c81/redis-7.1.0.tar.gz", hash = "sha256:b1cc3cfa5a2cb9c2ab3ba700864fb0ad75617b41f01352ce5779dabf6d5f9c3c", upload-time = "2025-11-19T15:54:39.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/c8/983d5c6579a411d8a99bc5823cc5712768859b5ce2c8afe1a65b37832c81/redis-7.1.0.tar.gz", hash = "sha256:b1cc3cfa5a2cb9c2ab3ba700864fb0ad75617b41f01352ce5779dabf6d5f9c3c", size = 4796669 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/f0/8956f8a86b20d7bb9d6ac0187cf4cd54d8065bc9a1a09eb8011d4d326596/redis-7.1.0-py3-none-any.whl", hash = "sha256:23c52b208f92b56103e17c5d06bdc1a6c2c0b3106583985a76a18f83b265de2b", upload-time = "2025-11-19T15:54:38.064Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f0/8956f8a86b20d7bb9d6ac0187cf4cd54d8065bc9a1a09eb8011d4d326596/redis-7.1.0-py3-none-any.whl", hash = "sha256:23c52b208f92b56103e17c5d06bdc1a6c2c0b3106583985a76a18f83b265de2b", size = 354159 },
 ]
 
 [[package]]
@@ -3472,33 +3478,33 @@ dependencies = [
     { name = "rpds-py" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", upload-time = "2025-01-25T08:48:16.138Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", upload-time = "2025-01-25T08:48:14.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775 },
 ]
 
 [[package]]
 name = "regex"
 version = "2026.1.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/86/07d5056945f9ec4590b518171c4254a5925832eb727b56d3c38a7476f316/regex-2026.1.15.tar.gz", hash = "sha256:164759aa25575cbc0651bef59a0b18353e54300d79ace8084c818ad8ac72b7d5", upload-time = "2026-01-14T23:18:02.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/86/07d5056945f9ec4590b518171c4254a5925832eb727b56d3c38a7476f316/regex-2026.1.15.tar.gz", hash = "sha256:164759aa25575cbc0651bef59a0b18353e54300d79ace8084c818ad8ac72b7d5", size = 414811 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/c9/0c80c96eab96948363d270143138d671d5731c3a692b417629bf3492a9d6/regex-2026.1.15-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1ae6020fb311f68d753b7efa9d4b9a5d47a5d6466ea0d5e3b5a471a960ea6e4a", upload-time = "2026-01-14T23:14:16.129Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f0/271c92f5389a552494c429e5cc38d76d1322eb142fb5db3c8ccc47751468/regex-2026.1.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eddf73f41225942c1f994914742afa53dc0d01a6e20fe14b878a1b1edc74151f", upload-time = "2026-01-14T23:14:17.715Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f9/5f1fd077d106ca5655a0f9ff8f25a1ab55b92128b5713a91ed7134ff688e/regex-2026.1.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e8cd52557603f5c66a548f69421310886b28b7066853089e1a71ee710e1cdc1", upload-time = "2026-01-14T23:14:19.326Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e1/8f43b03a4968c748858ec77f746c286d81f896c2e437ccf050ebc5d3128c/regex-2026.1.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5170907244b14303edc5978f522f16c974f32d3aa92109fabc2af52411c9433b", upload-time = "2026-01-14T23:14:20.922Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/4e/a39a5e8edc5377a46a7c875c2f9a626ed3338cb3bb06931be461c3e1a34a/regex-2026.1.15-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2748c1ec0663580b4510bd89941a31560b4b439a0b428b49472a3d9944d11cd8", upload-time = "2026-01-14T23:14:22.405Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/1c/9dce667a32a9477f7a2869c1c767dc00727284a9fa3ff5c09a5c6c03575e/regex-2026.1.15-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2f2775843ca49360508d080eaa87f94fa248e2c946bbcd963bb3aae14f333413", upload-time = "2026-01-14T23:14:23.897Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/3c/87ca0a02736d16b6262921425e84b48984e77d8e4e572c9072ce96e66c30/regex-2026.1.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9ea2604370efc9a174c1b5dcc81784fb040044232150f7f33756049edfc9026", upload-time = "2026-01-14T23:14:26.039Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/ff/647d5715aeea7c87bdcbd2f578f47b415f55c24e361e639fe8c0cc88878f/regex-2026.1.15-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0dcd31594264029b57bf16f37fd7248a70b3b764ed9e0839a8f271b2d22c0785", upload-time = "2026-01-14T23:14:28.109Z" },
-    { url = "https://files.pythonhosted.org/packages/af/89/bf22cac25cb4ba0fe6bff52ebedbb65b77a179052a9d6037136ae93f42f4/regex-2026.1.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c08c1f3e34338256732bd6938747daa3c0d5b251e04b6e43b5813e94d503076e", upload-time = "2026-01-14T23:14:29.929Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f4/6ed03e71dca6348a5188363a34f5e26ffd5db1404780288ff0d79513bce4/regex-2026.1.15-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e43a55f378df1e7a4fa3547c88d9a5a9b7113f653a66821bcea4718fe6c58763", upload-time = "2026-01-14T23:14:31.366Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/9a/8e8560bd78caded8eb137e3e47612430a05b9a772caf60876435192d670a/regex-2026.1.15-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f82110ab962a541737bd0ce87978d4c658f06e7591ba899192e2712a517badbb", upload-time = "2026-01-14T23:14:32.802Z" },
-    { url = "https://files.pythonhosted.org/packages/38/6b/61fc710f9aa8dfcd764fe27d37edfaa023b1a23305a0d84fccd5adb346ea/regex-2026.1.15-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:27618391db7bdaf87ac6c92b31e8f0dfb83a9de0075855152b720140bda177a2", upload-time = "2026-01-14T23:14:34.898Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/2e/fbee4cb93f9d686901a7ca8d94285b80405e8c34fe4107f63ffcbfb56379/regex-2026.1.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bfb0d6be01fbae8d6655c8ca21b3b72458606c4aec9bbc932db758d47aba6db1", upload-time = "2026-01-14T23:14:37.116Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/14/3076348f3f586de64b1ab75a3fbabdaab7684af7f308ad43be7ef1849e55/regex-2026.1.15-cp311-cp311-win32.whl", hash = "sha256:b10e42a6de0e32559a92f2f8dc908478cc0fa02838d7dbe764c44dca3fa13569", upload-time = "2026-01-14T23:14:38.426Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/19/772cf8b5fc803f5c89ba85d8b1870a1ca580dc482aa030383a9289c82e44/regex-2026.1.15-cp311-cp311-win_amd64.whl", hash = "sha256:e9bf3f0bbdb56633c07d7116ae60a576f846efdd86a8848f8d62b749e1209ca7", upload-time = "2026-01-14T23:14:39.785Z" },
-    { url = "https://files.pythonhosted.org/packages/78/84/d05f61142709474da3c0853222d91086d3e1372bcdab516c6fd8d80f3297/regex-2026.1.15-cp311-cp311-win_arm64.whl", hash = "sha256:41aef6f953283291c4e4e6850607bd71502be67779586a61472beacb315c97ec", upload-time = "2026-01-14T23:14:41.592Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c9/0c80c96eab96948363d270143138d671d5731c3a692b417629bf3492a9d6/regex-2026.1.15-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1ae6020fb311f68d753b7efa9d4b9a5d47a5d6466ea0d5e3b5a471a960ea6e4a", size = 488168 },
+    { url = "https://files.pythonhosted.org/packages/17/f0/271c92f5389a552494c429e5cc38d76d1322eb142fb5db3c8ccc47751468/regex-2026.1.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eddf73f41225942c1f994914742afa53dc0d01a6e20fe14b878a1b1edc74151f", size = 290636 },
+    { url = "https://files.pythonhosted.org/packages/a0/f9/5f1fd077d106ca5655a0f9ff8f25a1ab55b92128b5713a91ed7134ff688e/regex-2026.1.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e8cd52557603f5c66a548f69421310886b28b7066853089e1a71ee710e1cdc1", size = 288496 },
+    { url = "https://files.pythonhosted.org/packages/b5/e1/8f43b03a4968c748858ec77f746c286d81f896c2e437ccf050ebc5d3128c/regex-2026.1.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5170907244b14303edc5978f522f16c974f32d3aa92109fabc2af52411c9433b", size = 793503 },
+    { url = "https://files.pythonhosted.org/packages/8d/4e/a39a5e8edc5377a46a7c875c2f9a626ed3338cb3bb06931be461c3e1a34a/regex-2026.1.15-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2748c1ec0663580b4510bd89941a31560b4b439a0b428b49472a3d9944d11cd8", size = 860535 },
+    { url = "https://files.pythonhosted.org/packages/dc/1c/9dce667a32a9477f7a2869c1c767dc00727284a9fa3ff5c09a5c6c03575e/regex-2026.1.15-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2f2775843ca49360508d080eaa87f94fa248e2c946bbcd963bb3aae14f333413", size = 907225 },
+    { url = "https://files.pythonhosted.org/packages/a4/3c/87ca0a02736d16b6262921425e84b48984e77d8e4e572c9072ce96e66c30/regex-2026.1.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9ea2604370efc9a174c1b5dcc81784fb040044232150f7f33756049edfc9026", size = 800526 },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/647d5715aeea7c87bdcbd2f578f47b415f55c24e361e639fe8c0cc88878f/regex-2026.1.15-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0dcd31594264029b57bf16f37fd7248a70b3b764ed9e0839a8f271b2d22c0785", size = 773446 },
+    { url = "https://files.pythonhosted.org/packages/af/89/bf22cac25cb4ba0fe6bff52ebedbb65b77a179052a9d6037136ae93f42f4/regex-2026.1.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c08c1f3e34338256732bd6938747daa3c0d5b251e04b6e43b5813e94d503076e", size = 783051 },
+    { url = "https://files.pythonhosted.org/packages/1e/f4/6ed03e71dca6348a5188363a34f5e26ffd5db1404780288ff0d79513bce4/regex-2026.1.15-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e43a55f378df1e7a4fa3547c88d9a5a9b7113f653a66821bcea4718fe6c58763", size = 854485 },
+    { url = "https://files.pythonhosted.org/packages/d9/9a/8e8560bd78caded8eb137e3e47612430a05b9a772caf60876435192d670a/regex-2026.1.15-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f82110ab962a541737bd0ce87978d4c658f06e7591ba899192e2712a517badbb", size = 762195 },
+    { url = "https://files.pythonhosted.org/packages/38/6b/61fc710f9aa8dfcd764fe27d37edfaa023b1a23305a0d84fccd5adb346ea/regex-2026.1.15-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:27618391db7bdaf87ac6c92b31e8f0dfb83a9de0075855152b720140bda177a2", size = 845986 },
+    { url = "https://files.pythonhosted.org/packages/fd/2e/fbee4cb93f9d686901a7ca8d94285b80405e8c34fe4107f63ffcbfb56379/regex-2026.1.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bfb0d6be01fbae8d6655c8ca21b3b72458606c4aec9bbc932db758d47aba6db1", size = 788992 },
+    { url = "https://files.pythonhosted.org/packages/ed/14/3076348f3f586de64b1ab75a3fbabdaab7684af7f308ad43be7ef1849e55/regex-2026.1.15-cp311-cp311-win32.whl", hash = "sha256:b10e42a6de0e32559a92f2f8dc908478cc0fa02838d7dbe764c44dca3fa13569", size = 265893 },
+    { url = "https://files.pythonhosted.org/packages/0f/19/772cf8b5fc803f5c89ba85d8b1870a1ca580dc482aa030383a9289c82e44/regex-2026.1.15-cp311-cp311-win_amd64.whl", hash = "sha256:e9bf3f0bbdb56633c07d7116ae60a576f846efdd86a8848f8d62b749e1209ca7", size = 277840 },
+    { url = "https://files.pythonhosted.org/packages/78/84/d05f61142709474da3c0853222d91086d3e1372bcdab516c6fd8d80f3297/regex-2026.1.15-cp311-cp311-win_arm64.whl", hash = "sha256:41aef6f953283291c4e4e6850607bd71502be67779586a61472beacb315c97ec", size = 270374 },
 ]
 
 [[package]]
@@ -3511,9 +3517,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947 },
 ]
 
 [[package]]
@@ -3524,9 +3530,9 @@ dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", upload-time = "2024-03-22T20:32:29.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", upload-time = "2024-03-22T20:32:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179 },
 ]
 
 [[package]]
@@ -3536,9 +3542,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", upload-time = "2023-05-01T04:11:33.229Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", upload-time = "2023-05-01T04:11:28.427Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481 },
 ]
 
 [[package]]
@@ -3549,44 +3555,44 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", upload-time = "2026-04-11T02:57:45.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", upload-time = "2026-04-11T02:57:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480 },
 ]
 
 [[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", upload-time = "2025-11-30T20:24:38.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", upload-time = "2025-11-30T20:21:53.789Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", upload-time = "2025-11-30T20:21:55.475Z" },
-    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", upload-time = "2025-11-30T20:21:57.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", upload-time = "2025-11-30T20:21:58.47Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", upload-time = "2025-11-30T20:21:59.699Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", upload-time = "2025-11-30T20:22:00.991Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", upload-time = "2025-11-30T20:22:02.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", upload-time = "2025-11-30T20:22:04.367Z" },
-    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", upload-time = "2025-11-30T20:22:05.814Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", upload-time = "2025-11-30T20:22:07.713Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", upload-time = "2025-11-30T20:22:09.312Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", upload-time = "2025-11-30T20:22:11.309Z" },
-    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", upload-time = "2025-11-30T20:22:13.101Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", upload-time = "2025-11-30T20:22:14.853Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", upload-time = "2025-11-30T20:22:16.577Z" },
-    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", upload-time = "2025-11-30T20:24:16.537Z" },
-    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", upload-time = "2025-11-30T20:24:18.086Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", upload-time = "2025-11-30T20:24:20.092Z" },
-    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", upload-time = "2025-11-30T20:24:22.231Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", upload-time = "2025-11-30T20:24:24.302Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", upload-time = "2025-11-30T20:24:25.916Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", upload-time = "2025-11-30T20:24:27.834Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", upload-time = "2025-11-30T20:24:29.457Z" },
-    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", upload-time = "2025-11-30T20:24:31.22Z" },
-    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", upload-time = "2025-11-30T20:24:32.934Z" },
-    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", upload-time = "2025-11-30T20:24:35.169Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", upload-time = "2025-11-30T20:24:36.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157 },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676 },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938 },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932 },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830 },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033 },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828 },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683 },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583 },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496 },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669 },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011 },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406 },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024 },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069 },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292 },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128 },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542 },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004 },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063 },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099 },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177 },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015 },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736 },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981 },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782 },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191 },
 ]
 
 [[package]]
@@ -3596,34 +3602,34 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", upload-time = "2025-04-16T09:51:18.218Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", upload-time = "2025-04-16T09:51:17.142Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
 ]
 
 [[package]]
 name = "ruff"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", upload-time = "2026-02-03T17:53:35.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", upload-time = "2026-02-03T17:52:54.892Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", upload-time = "2026-02-03T17:53:19.778Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", upload-time = "2026-02-03T17:53:29.241Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", upload-time = "2026-02-03T17:52:43.332Z" },
-    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", upload-time = "2026-02-03T17:53:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", upload-time = "2026-02-03T17:53:15.705Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", upload-time = "2026-02-03T17:53:23.031Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", upload-time = "2026-02-03T17:52:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", upload-time = "2026-02-03T17:52:49.274Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", upload-time = "2026-02-03T17:53:33.105Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", upload-time = "2026-02-03T17:53:06.278Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", upload-time = "2026-02-03T17:53:26.084Z" },
-    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", upload-time = "2026-02-03T17:53:09.363Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", upload-time = "2026-02-03T17:52:57.281Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", upload-time = "2026-02-03T17:53:12.591Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", upload-time = "2026-02-03T17:52:51.893Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", upload-time = "2026-02-03T17:53:03.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332 },
+    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189 },
+    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384 },
+    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363 },
+    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736 },
+    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415 },
+    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643 },
+    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787 },
+    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797 },
+    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133 },
+    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646 },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750 },
+    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120 },
+    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636 },
+    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945 },
+    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657 },
+    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753 },
 ]
 
 [[package]]
@@ -3633,9 +3639,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830 },
 ]
 
 [[package]]
@@ -3648,14 +3654,14 @@ dependencies = [
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", upload-time = "2025-12-10T07:08:53.618Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", upload-time = "2025-12-10T07:07:39.385Z" },
-    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", upload-time = "2025-12-10T07:07:41.93Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", upload-time = "2025-12-10T07:07:43.899Z" },
-    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", upload-time = "2025-12-10T07:07:45.982Z" },
-    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", upload-time = "2025-12-10T07:07:48.111Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", upload-time = "2025-12-10T07:07:49.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835 },
+    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381 },
+    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632 },
+    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788 },
+    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706 },
+    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451 },
 ]
 
 [[package]]
@@ -3665,18 +3671,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", upload-time = "2026-01-10T21:34:23.009Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/4b/c89c131aa87cad2b77a54eb0fb94d633a842420fa7e919dc2f922037c3d8/scipy-1.17.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:2abd71643797bd8a106dff97894ff7869eeeb0af0f7a5ce02e4227c6a2e9d6fd", upload-time = "2026-01-10T21:24:33.42Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/5f/a6b38f79a07d74989224d5f11b55267714707582908a5f1ae854cf9a9b84/scipy-1.17.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:ef28d815f4d2686503e5f4f00edc387ae58dfd7a2f42e348bb53359538f01558", upload-time = "2026-01-10T21:24:38.911Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/20/095ad24e031ee8ed3c5975954d816b8e7e2abd731e04f8be573de8740885/scipy-1.17.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:272a9f16d6bb4667e8b50d25d71eddcc2158a214df1b566319298de0939d2ab7", upload-time = "2026-01-10T21:24:43.249Z" },
-    { url = "https://files.pythonhosted.org/packages/89/11/4aad2b3858d0337756f3323f8960755704e530b27eb2a94386c970c32cbe/scipy-1.17.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:7204fddcbec2fe6598f1c5fdf027e9f259106d05202a959a9f1aecf036adc9f6", upload-time = "2026-01-10T21:24:47.266Z" },
-    { url = "https://files.pythonhosted.org/packages/85/bd/f5af70c28c6da2227e510875cadf64879855193a687fb19951f0f44cfd6b/scipy-1.17.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc02c37a5639ee67d8fb646ffded6d793c06c5622d36b35cfa8fe5ececb8f042", upload-time = "2026-01-10T21:24:52.566Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/df/df1457c4df3826e908879fe3d76bc5b6e60aae45f4ee42539512438cfd5d/scipy-1.17.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dac97a27520d66c12a34fd90a4fe65f43766c18c0d6e1c0a80f114d2260080e4", upload-time = "2026-01-10T21:24:58.433Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/bb/88e2c16bd1dd4de19d80d7c5e238387182993c2fb13b4b8111e3927ad422/scipy-1.17.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ebb7446a39b3ae0fe8f416a9a3fdc6fba3f11c634f680f16a239c5187bc487c0", upload-time = "2026-01-10T21:25:04.287Z" },
-    { url = "https://files.pythonhosted.org/packages/02/ba/5120242cc735f71fc002cff0303d536af4405eb265f7c60742851e7ccfe9/scipy-1.17.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:474da16199f6af66601a01546144922ce402cb17362e07d82f5a6cf8f963e449", upload-time = "2026-01-10T21:25:09.851Z" },
-    { url = "https://files.pythonhosted.org/packages/52/c8/08629657ac6c0da198487ce8cd3de78e02cfde42b7f34117d56a3fe249dc/scipy-1.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:255c0da161bd7b32a6c898e7891509e8a9289f0b1c6c7d96142ee0d2b114c2ea", upload-time = "2026-01-10T21:25:15.632Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/4a/465f96d42c6f33ad324a40049dfd63269891db9324aa66c4a1c108c6f994/scipy-1.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:85b0ac3ad17fa3be50abd7e69d583d98792d7edc08367e01445a1e2076005379", upload-time = "2026-01-10T21:25:20.514Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/4b/c89c131aa87cad2b77a54eb0fb94d633a842420fa7e919dc2f922037c3d8/scipy-1.17.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:2abd71643797bd8a106dff97894ff7869eeeb0af0f7a5ce02e4227c6a2e9d6fd", size = 31381316 },
+    { url = "https://files.pythonhosted.org/packages/5e/5f/a6b38f79a07d74989224d5f11b55267714707582908a5f1ae854cf9a9b84/scipy-1.17.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:ef28d815f4d2686503e5f4f00edc387ae58dfd7a2f42e348bb53359538f01558", size = 27966760 },
+    { url = "https://files.pythonhosted.org/packages/c1/20/095ad24e031ee8ed3c5975954d816b8e7e2abd731e04f8be573de8740885/scipy-1.17.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:272a9f16d6bb4667e8b50d25d71eddcc2158a214df1b566319298de0939d2ab7", size = 20138701 },
+    { url = "https://files.pythonhosted.org/packages/89/11/4aad2b3858d0337756f3323f8960755704e530b27eb2a94386c970c32cbe/scipy-1.17.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:7204fddcbec2fe6598f1c5fdf027e9f259106d05202a959a9f1aecf036adc9f6", size = 22480574 },
+    { url = "https://files.pythonhosted.org/packages/85/bd/f5af70c28c6da2227e510875cadf64879855193a687fb19951f0f44cfd6b/scipy-1.17.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc02c37a5639ee67d8fb646ffded6d793c06c5622d36b35cfa8fe5ececb8f042", size = 32862414 },
+    { url = "https://files.pythonhosted.org/packages/ef/df/df1457c4df3826e908879fe3d76bc5b6e60aae45f4ee42539512438cfd5d/scipy-1.17.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dac97a27520d66c12a34fd90a4fe65f43766c18c0d6e1c0a80f114d2260080e4", size = 35112380 },
+    { url = "https://files.pythonhosted.org/packages/5f/bb/88e2c16bd1dd4de19d80d7c5e238387182993c2fb13b4b8111e3927ad422/scipy-1.17.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ebb7446a39b3ae0fe8f416a9a3fdc6fba3f11c634f680f16a239c5187bc487c0", size = 34922676 },
+    { url = "https://files.pythonhosted.org/packages/02/ba/5120242cc735f71fc002cff0303d536af4405eb265f7c60742851e7ccfe9/scipy-1.17.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:474da16199f6af66601a01546144922ce402cb17362e07d82f5a6cf8f963e449", size = 37507599 },
+    { url = "https://files.pythonhosted.org/packages/52/c8/08629657ac6c0da198487ce8cd3de78e02cfde42b7f34117d56a3fe249dc/scipy-1.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:255c0da161bd7b32a6c898e7891509e8a9289f0b1c6c7d96142ee0d2b114c2ea", size = 36380284 },
+    { url = "https://files.pythonhosted.org/packages/6c/4a/465f96d42c6f33ad324a40049dfd63269891db9324aa66c4a1c108c6f994/scipy-1.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:85b0ac3ad17fa3be50abd7e69d583d98792d7edc08367e01445a1e2076005379", size = 24370427 },
 ]
 
 [[package]]
@@ -3686,9 +3692,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asn1crypto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/52/a866f1ac9ae9025ec7f9bea803bba9d54796f8a84236165a700831f61b27/scramp-1.4.8.tar.gz", hash = "sha256:bd018fabfe46343cceeb9f1c3e8d23f55770271e777e3accbfaee3ff0a316e71", upload-time = "2026-01-06T21:01:01.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/52/a866f1ac9ae9025ec7f9bea803bba9d54796f8a84236165a700831f61b27/scramp-1.4.8.tar.gz", hash = "sha256:bd018fabfe46343cceeb9f1c3e8d23f55770271e777e3accbfaee3ff0a316e71", size = 16630 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/07/a962d2477331abfdb2c6a8251b65c673dbb07ad707d1882d61562b8b9147/scramp-1.4.8-py3-none-any.whl", hash = "sha256:87c2f15976845a2872fe5490a06097f0d01813cceb53774ea168c911f2ad025c", upload-time = "2026-01-06T21:00:59.474Z" },
+    { url = "https://files.pythonhosted.org/packages/90/07/a962d2477331abfdb2c6a8251b65c673dbb07ad707d1882d61562b8b9147/scramp-1.4.8-py3-none-any.whl", hash = "sha256:87c2f15976845a2872fe5490a06097f0d01813cceb53774ea168c911f2ad025c", size = 13121 },
 ]
 
 [[package]]
@@ -3706,27 +3712,27 @@ dependencies = [
     { name = "urllib3", extra = ["socks"] },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/ef/a5727fa7b33d20d296322adf851b76072d8d3513e1b151969d3228437faf/selenium-4.40.0.tar.gz", hash = "sha256:a88f5905d88ad0b84991c2386ea39e2bbde6d6c334be38df5842318ba98eaa8c", upload-time = "2026-01-18T23:12:31.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/ef/a5727fa7b33d20d296322adf851b76072d8d3513e1b151969d3228437faf/selenium-4.40.0.tar.gz", hash = "sha256:a88f5905d88ad0b84991c2386ea39e2bbde6d6c334be38df5842318ba98eaa8c", size = 930444 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/74/eb9d6540aca1911106fa0877b8e9ef24171bc18857937a6b0ffe0586c623/selenium-4.40.0-py3-none-any.whl", hash = "sha256:c8823fc02e2c771d9ad9a0cf899cee7de1a57a6697e3d0b91f67566129f2b729", upload-time = "2026-01-18T23:12:29.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/74/eb9d6540aca1911106fa0877b8e9ef24171bc18857937a6b0ffe0586c623/selenium-4.40.0-py3-none-any.whl", hash = "sha256:c8823fc02e2c771d9ad9a0cf899cee7de1a57a6697e3d0b91f67566129f2b729", size = 9608184 },
 ]
 
 [[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", upload-time = "2023-10-24T04:13:40.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", upload-time = "2023-10-24T04:13:38.866Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
 ]
 
 [[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", upload-time = "2024-12-04T17:35:28.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", upload-time = "2024-12-04T17:35:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]
@@ -3740,45 +3746,45 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/9f/46448c4e41a4c5ee4bdb74b3758af48e5ff0faeffe40f4e301bfc7594894/skops-0.14.0.tar.gz", hash = "sha256:6c8c0e047f691a3a582c3258943eecafcbfd79c8c7eef66260f3703e363254f0", upload-time = "2026-04-20T18:23:55.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/9f/46448c4e41a4c5ee4bdb74b3758af48e5ff0faeffe40f4e301bfc7594894/skops-0.14.0.tar.gz", hash = "sha256:6c8c0e047f691a3a582c3258943eecafcbfd79c8c7eef66260f3703e363254f0", size = 608084 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/0e/3ae19fa941522cd98e119762e7181d371c8dba0b2d72bfaf9522692e329c/skops-0.14.0-py3-none-any.whl", hash = "sha256:60a5db78a9db46ccee2139a0ba13ab5afb1c96f4749b382e75a371291bbe3e36", upload-time = "2026-04-20T18:23:54.018Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0e/3ae19fa941522cd98e119762e7181d371c8dba0b2d72bfaf9522692e329c/skops-0.14.0-py3-none-any.whl", hash = "sha256:60a5db78a9db46ccee2139a0ba13ab5afb1c96f4749b382e75a371291bbe3e36", size = 132198 },
 ]
 
 [[package]]
 name = "smmap"
 version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", upload-time = "2025-01-02T07:14:40.909Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", upload-time = "2025-01-02T07:14:38.724Z" },
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303 },
 ]
 
 [[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", upload-time = "2024-02-25T23:20:04.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", upload-time = "2024-02-25T23:20:01.196Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
 ]
 
 [[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", upload-time = "2021-05-16T22:03:42.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", upload-time = "2021-05-16T22:03:41.177Z" },
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
 ]
 
 [[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016 },
 ]
 
 [[package]]
@@ -3789,25 +3795,25 @@ dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/aa/9ce0f3e7a9829ead5c8ce549392f33a12c4555a6c0609bb27d882e9c7ddf/sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7", upload-time = "2026-01-21T18:03:45.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/aa/9ce0f3e7a9829ead5c8ce549392f33a12c4555a6c0609bb27d882e9c7ddf/sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7", size = 9865393 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/ac/b42ad16800d0885105b59380ad69aad0cce5a65276e269ce2729a2343b6a/sqlalchemy-2.0.46-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:261c4b1f101b4a411154f1da2b76497d73abbfc42740029205d4d01fa1052684", upload-time = "2026-01-21T18:27:30.54Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/60/d8710068cb79f64d002ebed62a7263c00c8fd95f4ebd4b5be8f7ca93f2bc/sqlalchemy-2.0.46-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:181903fe8c1b9082995325f1b2e84ac078b1189e2819380c2303a5f90e114a62", upload-time = "2026-01-21T18:32:33.45Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0f/20c71487c7219ab3aa7421c7c62d93824c97c1460f2e8bb72404b0192d13/sqlalchemy-2.0.46-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:590be24e20e2424a4c3c1b0835e9405fa3d0af5823a1a9fc02e5dff56471515f", upload-time = "2026-01-21T18:44:57.887Z" },
-    { url = "https://files.pythonhosted.org/packages/65/80/d26d00b3b249ae000eee4db206fcfc564bf6ca5030e4747adf451f4b5108/sqlalchemy-2.0.46-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7568fe771f974abadce52669ef3a03150ff03186d8eb82613bc8adc435a03f01", upload-time = "2026-01-21T18:32:35.044Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ee/74dda7506640923821340541e8e45bd3edd8df78664f1f2e0aae8077192b/sqlalchemy-2.0.46-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf7e1e78af38047e08836d33502c7a278915698b7c2145d045f780201679999", upload-time = "2026-01-21T18:44:59.254Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/25/6dcf8abafff1389a21c7185364de145107b7394ecdcb05233815b236330d/sqlalchemy-2.0.46-cp311-cp311-win32.whl", hash = "sha256:9d80ea2ac519c364a7286e8d765d6cd08648f5b21ca855a8017d9871f075542d", upload-time = "2026-01-21T18:33:15.85Z" },
-    { url = "https://files.pythonhosted.org/packages/93/5f/e081490f8523adc0088f777e4ebad3cac21e498ec8a3d4067074e21447a1/sqlalchemy-2.0.46-cp311-cp311-win_amd64.whl", hash = "sha256:585af6afe518732d9ccd3aea33af2edaae4a7aa881af5d8f6f4fe3a368699597", upload-time = "2026-01-21T18:33:17.528Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a1/9c4efa03300926601c19c18582531b45aededfb961ab3c3585f1e24f120b/sqlalchemy-2.0.46-py3-none-any.whl", hash = "sha256:f9c11766e7e7c0a2767dda5acb006a118640c9fc0a4104214b96269bfb78399e", upload-time = "2026-01-21T18:22:10.456Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ac/b42ad16800d0885105b59380ad69aad0cce5a65276e269ce2729a2343b6a/sqlalchemy-2.0.46-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:261c4b1f101b4a411154f1da2b76497d73abbfc42740029205d4d01fa1052684", size = 2154851 },
+    { url = "https://files.pythonhosted.org/packages/a0/60/d8710068cb79f64d002ebed62a7263c00c8fd95f4ebd4b5be8f7ca93f2bc/sqlalchemy-2.0.46-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:181903fe8c1b9082995325f1b2e84ac078b1189e2819380c2303a5f90e114a62", size = 3311241 },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/20c71487c7219ab3aa7421c7c62d93824c97c1460f2e8bb72404b0192d13/sqlalchemy-2.0.46-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:590be24e20e2424a4c3c1b0835e9405fa3d0af5823a1a9fc02e5dff56471515f", size = 3310741 },
+    { url = "https://files.pythonhosted.org/packages/65/80/d26d00b3b249ae000eee4db206fcfc564bf6ca5030e4747adf451f4b5108/sqlalchemy-2.0.46-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7568fe771f974abadce52669ef3a03150ff03186d8eb82613bc8adc435a03f01", size = 3263116 },
+    { url = "https://files.pythonhosted.org/packages/da/ee/74dda7506640923821340541e8e45bd3edd8df78664f1f2e0aae8077192b/sqlalchemy-2.0.46-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf7e1e78af38047e08836d33502c7a278915698b7c2145d045f780201679999", size = 3285327 },
+    { url = "https://files.pythonhosted.org/packages/9f/25/6dcf8abafff1389a21c7185364de145107b7394ecdcb05233815b236330d/sqlalchemy-2.0.46-cp311-cp311-win32.whl", hash = "sha256:9d80ea2ac519c364a7286e8d765d6cd08648f5b21ca855a8017d9871f075542d", size = 2114564 },
+    { url = "https://files.pythonhosted.org/packages/93/5f/e081490f8523adc0088f777e4ebad3cac21e498ec8a3d4067074e21447a1/sqlalchemy-2.0.46-cp311-cp311-win_amd64.whl", hash = "sha256:585af6afe518732d9ccd3aea33af2edaae4a7aa881af5d8f6f4fe3a368699597", size = 2139233 },
+    { url = "https://files.pythonhosted.org/packages/fc/a1/9c4efa03300926601c19c18582531b45aededfb961ab3c3585f1e24f120b/sqlalchemy-2.0.46-py3-none-any.whl", hash = "sha256:f9c11766e7e7c0a2767dda5acb006a118640c9fc0a4104214b96269bfb78399e", size = 1937882 },
 ]
 
 [[package]]
 name = "sqlparse"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138 },
 ]
 
 [[package]]
@@ -3817,9 +3823,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/3c/fa6517610dc641262b77cc7bf994ecd17465812c1b0585fe33e11be758ab/sse_starlette-3.0.3.tar.gz", hash = "sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971", upload-time = "2025-10-30T18:44:20.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/3c/fa6517610dc641262b77cc7bf994ecd17465812c1b0585fe33e11be758ab/sse_starlette-3.0.3.tar.gz", hash = "sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971", size = 21943 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/a0/984525d19ca5c8a6c33911a0c164b11490dd0f90ff7fd689f704f84e9a11/sse_starlette-3.0.3-py3-none-any.whl", hash = "sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431", upload-time = "2025-10-30T18:44:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a0/984525d19ca5c8a6c33911a0c164b11490dd0f90ff7fd689f704f84e9a11/sse_starlette-3.0.3-py3-none-any.whl", hash = "sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431", size = 11765 },
 ]
 
 [[package]]
@@ -3830,9 +3836,9 @@ dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", upload-time = "2025-11-01T15:12:26.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", upload-time = "2025-11-01T15:12:24.387Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", size = 74340 },
 ]
 
 [[package]]
@@ -3842,18 +3848,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mpmath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", upload-time = "2025-04-27T18:05:01.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", upload-time = "2025-04-27T18:04:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353 },
 ]
 
 [[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", upload-time = "2026-02-07T10:45:33.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", upload-time = "2026-02-07T10:45:32.24Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926 },
 ]
 
 [[package]]
@@ -3868,18 +3874,18 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/89/bec5709fb759f9c784bbcb30b2e3497df3f901691d13c2b864dbf6694a17/textual-8.2.4.tar.gz", hash = "sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4", upload-time = "2026-04-19T04:20:45.845Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/89/bec5709fb759f9c784bbcb30b2e3497df3f901691d13c2b864dbf6694a17/textual-8.2.4.tar.gz", hash = "sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4", size = 1848933 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/32/02932f0d597cdbb34e34bf24266ff0f2cf292ccb3aafc37dd9efcb0cc416/textual-8.2.4-py3-none-any.whl", hash = "sha256:a83bd3f0cc7125ca203845af753f9d6b6be030025ecd1b05cc75ebe645b9c4ba", upload-time = "2026-04-19T04:20:49.968Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/02932f0d597cdbb34e34bf24266ff0f2cf292ccb3aafc37dd9efcb0cc416/textual-8.2.4-py3-none-any.whl", hash = "sha256:a83bd3f0cc7125ca203845af753f9d6b6be030025ecd1b05cc75ebe645b9c4ba", size = 724390 },
 ]
 
 [[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", upload-time = "2025-03-13T13:49:23.031Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", upload-time = "2025-03-13T13:49:21.846Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638 },
 ]
 
 [[package]]
@@ -3890,14 +3896,14 @@ dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/02/576ff3a6639e755c4f70997b2d315f56d6d71e0d046f4fb64cb81a3fb099/tiktoken-0.8.0.tar.gz", hash = "sha256:9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2", upload-time = "2024-10-03T22:44:04.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/02/576ff3a6639e755c4f70997b2d315f56d6d71e0d046f4fb64cb81a3fb099/tiktoken-0.8.0.tar.gz", hash = "sha256:9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2", size = 35107 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/1e/ca48e7bfeeccaf76f3a501bd84db1fa28b3c22c9d1a1f41af9fb7579c5f6/tiktoken-0.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d622d8011e6d6f239297efa42a2657043aaed06c4f68833550cac9e9bc723ef1", upload-time = "2024-10-03T22:43:28.315Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/f8/f0101d98d661b34534769c3818f5af631e59c36ac6d07268fbfc89e539ce/tiktoken-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2efaf6199717b4485031b4d6edb94075e4d79177a172f38dd934d911b588d54a", upload-time = "2024-10-03T22:43:29.807Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/3c/2b95391d9bd520a73830469f80a96e3790e6c0a5ac2444f80f20b4b31051/tiktoken-0.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5637e425ce1fc49cf716d88df3092048359a4b3bbb7da762840426e937ada06d", upload-time = "2024-10-04T04:42:53.66Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c4/c4a4360de845217b6aa9709c15773484b50479f36bb50419c443204e5de9/tiktoken-0.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fb0e352d1dbe15aba082883058b3cce9e48d33101bdaac1eccf66424feb5b47", upload-time = "2024-10-03T22:43:31.136Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a3/ef984e976822cd6c2227c854f74d2e60cf4cd6fbfca46251199914746f78/tiktoken-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:56edfefe896c8f10aba372ab5706b9e3558e78db39dd497c940b47bf228bc419", upload-time = "2024-10-03T22:43:32.75Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/86/eea2309dc258fb86c7d9b10db536434fc16420feaa3b6113df18b23db7c2/tiktoken-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:326624128590def898775b722ccc327e90b073714227175ea8febbc920ac0a99", upload-time = "2024-10-03T22:43:34.592Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1e/ca48e7bfeeccaf76f3a501bd84db1fa28b3c22c9d1a1f41af9fb7579c5f6/tiktoken-0.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d622d8011e6d6f239297efa42a2657043aaed06c4f68833550cac9e9bc723ef1", size = 1039700 },
+    { url = "https://files.pythonhosted.org/packages/8c/f8/f0101d98d661b34534769c3818f5af631e59c36ac6d07268fbfc89e539ce/tiktoken-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2efaf6199717b4485031b4d6edb94075e4d79177a172f38dd934d911b588d54a", size = 982413 },
+    { url = "https://files.pythonhosted.org/packages/ac/3c/2b95391d9bd520a73830469f80a96e3790e6c0a5ac2444f80f20b4b31051/tiktoken-0.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5637e425ce1fc49cf716d88df3092048359a4b3bbb7da762840426e937ada06d", size = 1144242 },
+    { url = "https://files.pythonhosted.org/packages/01/c4/c4a4360de845217b6aa9709c15773484b50479f36bb50419c443204e5de9/tiktoken-0.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fb0e352d1dbe15aba082883058b3cce9e48d33101bdaac1eccf66424feb5b47", size = 1176588 },
+    { url = "https://files.pythonhosted.org/packages/f8/a3/ef984e976822cd6c2227c854f74d2e60cf4cd6fbfca46251199914746f78/tiktoken-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:56edfefe896c8f10aba372ab5706b9e3558e78db39dd497c940b47bf228bc419", size = 1237261 },
+    { url = "https://files.pythonhosted.org/packages/1e/86/eea2309dc258fb86c7d9b10db536434fc16420feaa3b6113df18b23db7c2/tiktoken-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:326624128590def898775b722ccc327e90b073714227175ea8febbc920ac0a99", size = 884537 },
 ]
 
 [[package]]
@@ -3907,41 +3913,41 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", upload-time = "2026-01-05T10:45:15.988Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", upload-time = "2026-01-05T10:41:02.158Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", upload-time = "2026-01-05T10:41:00.276Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", upload-time = "2026-01-05T10:40:32.165Z" },
-    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", upload-time = "2026-01-05T10:40:38.847Z" },
-    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", upload-time = "2026-01-05T10:40:56.614Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", upload-time = "2026-01-05T10:40:44.507Z" },
-    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", upload-time = "2026-01-05T10:40:51.139Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", upload-time = "2026-01-05T10:40:58.331Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", upload-time = "2026-01-05T10:41:04.053Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", upload-time = "2026-01-05T10:45:10.673Z" },
-    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", upload-time = "2026-01-05T10:45:12.559Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", upload-time = "2026-01-05T10:45:14.333Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", upload-time = "2026-01-05T10:45:20.593Z" },
-    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", upload-time = "2026-01-05T10:45:18.411Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275 },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472 },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736 },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835 },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673 },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818 },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195 },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982 },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245 },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069 },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263 },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429 },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363 },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786 },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133 },
 ]
 
 [[package]]
 name = "tomli"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", upload-time = "2024-10-02T10:46:13.208Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", upload-time = "2024-10-02T10:46:11.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237 },
 ]
 
 [[package]]
 name = "tomli-w"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/19/b65f1a088ee23e37cdea415b357843eca8b1422a7b11a9eee6e35d4ec273/tomli_w-1.1.0.tar.gz", hash = "sha256:49e847a3a304d516a169a601184932ef0f6b61623fe680f836a2aa7128ed0d33", upload-time = "2024-10-08T11:13:29.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/19/b65f1a088ee23e37cdea415b357843eca8b1422a7b11a9eee6e35d4ec273/tomli_w-1.1.0.tar.gz", hash = "sha256:49e847a3a304d516a169a601184932ef0f6b61623fe680f836a2aa7128ed0d33", size = 6929 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/ac/ce90573ba446a9bbe65838ded066a805234d159b4446ae9f8ec5bbd36cbd/tomli_w-1.1.0-py3-none-any.whl", hash = "sha256:1403179c78193e3184bfaade390ddbd071cba48a32a2e62ba11aae47490c63f7", upload-time = "2024-10-08T11:13:27.897Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ac/ce90573ba446a9bbe65838ded066a805234d159b4446ae9f8ec5bbd36cbd/tomli_w-1.1.0-py3-none-any.whl", hash = "sha256:1403179c78193e3184bfaade390ddbd071cba48a32a2e62ba11aae47490c63f7", size = 6440 },
 ]
 
 [[package]]
@@ -3951,9 +3957,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", upload-time = "2026-02-03T17:35:53.048Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", upload-time = "2026-02-03T17:35:50.982Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374 },
 ]
 
 [[package]]
@@ -3968,9 +3974,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/ce/0041ddd9160aac0031bcf5ab786c7640d795c797e67c438e15cfedf815c8/trio-0.32.0.tar.gz", hash = "sha256:150f29ec923bcd51231e1d4c71c7006e65247d68759dd1c19af4ea815a25806b", upload-time = "2025-10-31T07:18:17.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/ce/0041ddd9160aac0031bcf5ab786c7640d795c797e67c438e15cfedf815c8/trio-0.32.0.tar.gz", hash = "sha256:150f29ec923bcd51231e1d4c71c7006e65247d68759dd1c19af4ea815a25806b", size = 605323 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/bf/945d527ff706233636c73880b22c7c953f3faeb9d6c7e2e85bfbfd0134a0/trio-0.32.0-py3-none-any.whl", hash = "sha256:4ab65984ef8370b79a76659ec87aa3a30c5c7c83ff250b4de88c29a8ab6123c5", upload-time = "2025-10-31T07:18:15.885Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bf/945d527ff706233636c73880b22c7c953f3faeb9d6c7e2e85bfbfd0134a0/trio-0.32.0-py3-none-any.whl", hash = "sha256:4ab65984ef8370b79a76659ec87aa3a30c5c7c83ff250b4de88c29a8ab6123c5", size = 512030 },
 ]
 
 [[package]]
@@ -3985,9 +3991,9 @@ dependencies = [
     { name = "trio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/74/a87aafa40ec3a37089148b859892cbe2eef08d132c816d58a60459be5337/trio-typing-0.10.0.tar.gz", hash = "sha256:065ee684296d52a8ab0e2374666301aec36ee5747ac0e7a61f230250f8907ac3", upload-time = "2023-12-01T02:54:55.508Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/74/a87aafa40ec3a37089148b859892cbe2eef08d132c816d58a60459be5337/trio-typing-0.10.0.tar.gz", hash = "sha256:065ee684296d52a8ab0e2374666301aec36ee5747ac0e7a61f230250f8907ac3", size = 38747 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/ff/9bd795273eb14fac7f6a59d16cc8c4d0948a619a1193d375437c7f50f3eb/trio_typing-0.10.0-py3-none-any.whl", hash = "sha256:6d0e7ec9d837a2fe03591031a172533fbf4a1a95baf369edebfc51d5a49f0264", upload-time = "2023-12-01T02:54:54.1Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ff/9bd795273eb14fac7f6a59d16cc8c4d0948a619a1193d375437c7f50f3eb/trio_typing-0.10.0-py3-none-any.whl", hash = "sha256:6d0e7ec9d837a2fe03591031a172533fbf4a1a95baf369edebfc51d5a49f0264", size = 42224 },
 ]
 
 [[package]]
@@ -3999,9 +4005,9 @@ dependencies = [
     { name = "trio" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", upload-time = "2025-02-25T05:16:58.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", upload-time = "2025-02-25T05:16:57.545Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221 },
 ]
 
 [[package]]
@@ -4014,36 +4020,36 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", upload-time = "2026-01-06T11:21:10.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", upload-time = "2026-01-06T11:21:09.824Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381 },
 ]
 
 [[package]]
 name = "types-certifi"
 version = "2021.10.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", upload-time = "2022-06-09T15:19:05.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", upload-time = "2022-06-09T15:19:03.127Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136 },
 ]
 
 [[package]]
 name = "types-urllib3"
 version = "1.26.25.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", upload-time = "2023-07-20T15:19:31.307Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", upload-time = "2023-07-20T15:19:30.379Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377 },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
 ]
 
 [[package]]
@@ -4054,9 +4060,9 @@ dependencies = [
     { name = "mypy-extensions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", upload-time = "2023-05-24T20:25:47.612Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", upload-time = "2023-05-24T20:25:45.287Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827 },
 ]
 
 [[package]]
@@ -4066,45 +4072,45 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", upload-time = "2025-10-01T02:14:41.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", upload-time = "2025-10-01T02:14:40.154Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
 ]
 
 [[package]]
 name = "tzdata"
 version = "2025.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", upload-time = "2025-12-13T17:45:35.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", upload-time = "2025-12-13T17:45:33.889Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521 },
 ]
 
 [[package]]
 name = "uc-micro-py"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", upload-time = "2026-03-01T06:31:27.526Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", upload-time = "2026-03-01T06:31:26.257Z" },
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383 },
 ]
 
 [[package]]
 name = "uritemplate"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", upload-time = "2025-06-02T15:12:06.318Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", upload-time = "2025-06-02T15:12:03.405Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488 },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
 ]
 
 [package.optional-dependencies]
@@ -4122,64 +4128,64 @@ dependencies = [
     { name = "packaging" },
     { name = "pandas" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/55/8a37bb9ce36541fd353466259a07ccfdfaf25c996f3a71d989af4d4c7ba4/utilsforecast-0.2.15.tar.gz", hash = "sha256:c36d65d698a88d0fadc93d2d6737c304c3776397c60ae551ee17aa678caf3659", upload-time = "2025-12-03T16:29:08.652Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/55/8a37bb9ce36541fd353466259a07ccfdfaf25c996f3a71d989af4d4c7ba4/utilsforecast-0.2.15.tar.gz", hash = "sha256:c36d65d698a88d0fadc93d2d6737c304c3776397c60ae551ee17aa678caf3659", size = 60609 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/11/6c6ee61958b8e60f634b39e2f9a004f5d1c479cb962a2001fc3c72ceed78/utilsforecast-0.2.15-py3-none-any.whl", hash = "sha256:4b43bf5107e3cba13604cd86e93b5cf4906b57105b1900ccf98b8978aabd4150", upload-time = "2025-12-03T16:29:07.144Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/11/6c6ee61958b8e60f634b39e2f9a004f5d1c479cb962a2001fc3c72ceed78/utilsforecast-0.2.15-py3-none-any.whl", hash = "sha256:4b43bf5107e3cba13604cd86e93b5cf4906b57105b1900ccf98b8978aabd4150", size = 40344 },
 ]
 
 [[package]]
 name = "uuid-utils"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/7c/3a926e847516e67bc6838634f2e54e24381105b4e80f9338dc35cca0086b/uuid_utils-0.14.0.tar.gz", hash = "sha256:fc5bac21e9933ea6c590433c11aa54aaca599f690c08069e364eb13a12f670b4", upload-time = "2026-01-20T20:37:15.729Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/7c/3a926e847516e67bc6838634f2e54e24381105b4e80f9338dc35cca0086b/uuid_utils-0.14.0.tar.gz", hash = "sha256:fc5bac21e9933ea6c590433c11aa54aaca599f690c08069e364eb13a12f670b4", size = 22072 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/42/42d003f4a99ddc901eef2fd41acb3694163835e037fb6dde79ad68a72342/uuid_utils-0.14.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f6695c0bed8b18a904321e115afe73b34444bc8451d0ce3244a1ec3b84deb0e5", upload-time = "2026-01-20T20:37:09.843Z" },
-    { url = "https://files.pythonhosted.org/packages/96/e6/775dfb91f74b18f7207e3201eb31ee666d286579990dc69dd50db2d92813/uuid_utils-0.14.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4f0a730bbf2d8bb2c11b93e1005e91769f2f533fa1125ed1f00fd15b6fcc732b", upload-time = "2026-01-20T20:37:18.767Z" },
-    { url = "https://files.pythonhosted.org/packages/17/82/ea5f5e85560b08a1f30cdc65f75e76494dc7aba9773f679e7eaa27370229/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40ce3fd1a4fdedae618fc3edc8faf91897012469169d600133470f49fd699ed3", upload-time = "2026-01-20T20:37:11.794Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/33/54b06415767f4569882e99b6470c6c8eeb97422686a6d432464f9967fd91/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:09ae4a98416a440e78f7d9543d11b11cae4bab538b7ed94ec5da5221481748f2", upload-time = "2026-01-20T20:37:12.818Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/10/a6bce636b8f95e65dc84bf4a58ce8205b8e0a2a300a38cdbc83a3f763d27/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:971e8c26b90d8ae727e7f2ac3ee23e265971d448b3672882f2eb44828b2b8c3e", upload-time = "2026-01-20T20:37:01.512Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/27/84121c51ea72f013f0e03d0886bcdfa96b31c9b83c98300a7bd5cc4fa191/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5cde1fa82804a8f9d2907b7aec2009d440062c63f04abbdb825fce717a5e860", upload-time = "2026-01-20T20:37:22.881Z" },
-    { url = "https://files.pythonhosted.org/packages/90/a4/01c1c7af5e6a44f20b40183e8dac37d6ed83e7dc9e8df85370a15959b804/uuid_utils-0.14.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7343862a2359e0bd48a7f3dfb5105877a1728677818bb694d9f40703264a2db", upload-time = "2026-01-20T20:37:10.808Z" },
-    { url = "https://files.pythonhosted.org/packages/04/f0/65ee43ec617b8b6b1bf2a5aecd56a069a08cca3d9340c1de86024331bde3/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c51e4818fdb08ccec12dc7083a01f49507b4608770a0ab22368001685d59381b", upload-time = "2026-01-20T20:37:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/95/d3/6bf503e3f135a5dfe705a65e6f89f19bccd55ac3fb16cb5d3ec5ba5388b8/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:181bbcccb6f93d80a8504b5bd47b311a1c31395139596edbc47b154b0685b533", upload-time = "2026-01-20T20:37:21.816Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6c/99937dd78d07f73bba831c8dc9469dfe4696539eba2fc269ae1b92752f9e/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:5c8ae96101c3524ba8dbf762b6f05e9e9d896544786c503a727c5bf5cb9af1a7", upload-time = "2026-01-20T20:37:19.691Z" },
-    { url = "https://files.pythonhosted.org/packages/44/fa/bbc9e2c25abd09a293b9b097a0d8fc16acd6a92854f0ec080f1ea7ad8bb3/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:00ac3c6edfdaff7e1eed041f4800ae09a3361287be780d7610a90fdcde9befdc", upload-time = "2026-01-20T20:37:03.117Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/9b/e5e99b324b1b5f0c62882230455786df0bc66f67eff3b452447e703f45d2/uuid_utils-0.14.0-cp39-abi3-win32.whl", hash = "sha256:ec2fd80adf8e0e6589d40699e6f6df94c93edcc16dd999be0438dd007c77b151", upload-time = "2026-01-20T20:37:04.208Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/28/2c7d417ea483b6ff7820c948678fdf2ac98899dc7e43bb15852faa95acaf/uuid_utils-0.14.0-cp39-abi3-win_amd64.whl", hash = "sha256:efe881eb43a5504fad922644cb93d725fd8a6a6d949bd5a4b4b7d1a1587c7fd1", upload-time = "2026-01-20T20:37:16.868Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/86/49e4bdda28e962fbd7266684171ee29b3d92019116971d58783e51770745/uuid_utils-0.14.0-cp39-abi3-win_arm64.whl", hash = "sha256:32b372b8fd4ebd44d3a219e093fe981af4afdeda2994ee7db208ab065cfcd080", upload-time = "2026-01-20T20:37:05.139Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/03/1f1146e32e94d1f260dfabc81e1649102083303fb4ad549775c943425d9a/uuid_utils-0.14.0-pp311-pypy311_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:762e8d67992ac4d2454e24a141a1c82142b5bde10409818c62adbe9924ebc86d", upload-time = "2026-01-20T20:37:24.998Z" },
-    { url = "https://files.pythonhosted.org/packages/87/ba/d5a7469362594d885fd9219fe9e851efbe65101d3ef1ef25ea321d7ce841/uuid_utils-0.14.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:40be5bf0b13aa849d9062abc86c198be6a25ff35316ce0b89fc25f3bac6d525e", upload-time = "2026-01-20T20:37:23.896Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/11/3dafb2a5502586f59fd49e93f5802cd5face82921b3a0f3abb5f357cb879/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:191a90a6f3940d1b7322b6e6cceff4dd533c943659e0a15f788674407856a515", upload-time = "2026-01-20T20:37:17.828Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f2/c8987663f0cdcf4d717a36d85b5db2a5589df0a4e129aa10f16f4380ef48/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4aa4525f4ad82f9d9c842f9a3703f1539c1808affbaec07bb1b842f6b8b96aa5", upload-time = "2026-01-20T20:37:14.286Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/c8/929d81665d83f0b2ffaecb8e66c3091a50f62c7cb5b65e678bd75a96684e/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cdbd82ff20147461caefc375551595ecf77ebb384e46267f128aca45a0f2cdfc", upload-time = "2026-01-20T20:37:08.277Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a0/27d7daa1bfed7163f4ccaf52d7d2f4ad7bb1002a85b45077938b91ee584f/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff57e8a5d540006ce73cf0841a643d445afe78ba12e75ac53a95ca2924a56be", upload-time = "2026-01-20T20:37:07.271Z" },
-    { url = "https://files.pythonhosted.org/packages/63/d4/acad86ce012b42ce18a12f31ee2aa3cbeeb98664f865f05f68c882945913/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3fd9112ca96978361201e669729784f26c71fecc9c13a7f8a07162c31bd4d1e2", upload-time = "2026-01-20T20:36:59.687Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/42/42d003f4a99ddc901eef2fd41acb3694163835e037fb6dde79ad68a72342/uuid_utils-0.14.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f6695c0bed8b18a904321e115afe73b34444bc8451d0ce3244a1ec3b84deb0e5", size = 601786 },
+    { url = "https://files.pythonhosted.org/packages/96/e6/775dfb91f74b18f7207e3201eb31ee666d286579990dc69dd50db2d92813/uuid_utils-0.14.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4f0a730bbf2d8bb2c11b93e1005e91769f2f533fa1125ed1f00fd15b6fcc732b", size = 303943 },
+    { url = "https://files.pythonhosted.org/packages/17/82/ea5f5e85560b08a1f30cdc65f75e76494dc7aba9773f679e7eaa27370229/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40ce3fd1a4fdedae618fc3edc8faf91897012469169d600133470f49fd699ed3", size = 340467 },
+    { url = "https://files.pythonhosted.org/packages/ca/33/54b06415767f4569882e99b6470c6c8eeb97422686a6d432464f9967fd91/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:09ae4a98416a440e78f7d9543d11b11cae4bab538b7ed94ec5da5221481748f2", size = 346333 },
+    { url = "https://files.pythonhosted.org/packages/cb/10/a6bce636b8f95e65dc84bf4a58ce8205b8e0a2a300a38cdbc83a3f763d27/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:971e8c26b90d8ae727e7f2ac3ee23e265971d448b3672882f2eb44828b2b8c3e", size = 470859 },
+    { url = "https://files.pythonhosted.org/packages/8a/27/84121c51ea72f013f0e03d0886bcdfa96b31c9b83c98300a7bd5cc4fa191/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5cde1fa82804a8f9d2907b7aec2009d440062c63f04abbdb825fce717a5e860", size = 341988 },
+    { url = "https://files.pythonhosted.org/packages/90/a4/01c1c7af5e6a44f20b40183e8dac37d6ed83e7dc9e8df85370a15959b804/uuid_utils-0.14.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7343862a2359e0bd48a7f3dfb5105877a1728677818bb694d9f40703264a2db", size = 365784 },
+    { url = "https://files.pythonhosted.org/packages/04/f0/65ee43ec617b8b6b1bf2a5aecd56a069a08cca3d9340c1de86024331bde3/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c51e4818fdb08ccec12dc7083a01f49507b4608770a0ab22368001685d59381b", size = 523750 },
+    { url = "https://files.pythonhosted.org/packages/95/d3/6bf503e3f135a5dfe705a65e6f89f19bccd55ac3fb16cb5d3ec5ba5388b8/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:181bbcccb6f93d80a8504b5bd47b311a1c31395139596edbc47b154b0685b533", size = 615818 },
+    { url = "https://files.pythonhosted.org/packages/df/6c/99937dd78d07f73bba831c8dc9469dfe4696539eba2fc269ae1b92752f9e/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:5c8ae96101c3524ba8dbf762b6f05e9e9d896544786c503a727c5bf5cb9af1a7", size = 580831 },
+    { url = "https://files.pythonhosted.org/packages/44/fa/bbc9e2c25abd09a293b9b097a0d8fc16acd6a92854f0ec080f1ea7ad8bb3/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:00ac3c6edfdaff7e1eed041f4800ae09a3361287be780d7610a90fdcde9befdc", size = 546333 },
+    { url = "https://files.pythonhosted.org/packages/e7/9b/e5e99b324b1b5f0c62882230455786df0bc66f67eff3b452447e703f45d2/uuid_utils-0.14.0-cp39-abi3-win32.whl", hash = "sha256:ec2fd80adf8e0e6589d40699e6f6df94c93edcc16dd999be0438dd007c77b151", size = 177319 },
+    { url = "https://files.pythonhosted.org/packages/d3/28/2c7d417ea483b6ff7820c948678fdf2ac98899dc7e43bb15852faa95acaf/uuid_utils-0.14.0-cp39-abi3-win_amd64.whl", hash = "sha256:efe881eb43a5504fad922644cb93d725fd8a6a6d949bd5a4b4b7d1a1587c7fd1", size = 182566 },
+    { url = "https://files.pythonhosted.org/packages/b8/86/49e4bdda28e962fbd7266684171ee29b3d92019116971d58783e51770745/uuid_utils-0.14.0-cp39-abi3-win_arm64.whl", hash = "sha256:32b372b8fd4ebd44d3a219e093fe981af4afdeda2994ee7db208ab065cfcd080", size = 182809 },
+    { url = "https://files.pythonhosted.org/packages/f1/03/1f1146e32e94d1f260dfabc81e1649102083303fb4ad549775c943425d9a/uuid_utils-0.14.0-pp311-pypy311_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:762e8d67992ac4d2454e24a141a1c82142b5bde10409818c62adbe9924ebc86d", size = 587430 },
+    { url = "https://files.pythonhosted.org/packages/87/ba/d5a7469362594d885fd9219fe9e851efbe65101d3ef1ef25ea321d7ce841/uuid_utils-0.14.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:40be5bf0b13aa849d9062abc86c198be6a25ff35316ce0b89fc25f3bac6d525e", size = 298106 },
+    { url = "https://files.pythonhosted.org/packages/8a/11/3dafb2a5502586f59fd49e93f5802cd5face82921b3a0f3abb5f357cb879/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:191a90a6f3940d1b7322b6e6cceff4dd533c943659e0a15f788674407856a515", size = 333423 },
+    { url = "https://files.pythonhosted.org/packages/7c/f2/c8987663f0cdcf4d717a36d85b5db2a5589df0a4e129aa10f16f4380ef48/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4aa4525f4ad82f9d9c842f9a3703f1539c1808affbaec07bb1b842f6b8b96aa5", size = 338659 },
+    { url = "https://files.pythonhosted.org/packages/d1/c8/929d81665d83f0b2ffaecb8e66c3091a50f62c7cb5b65e678bd75a96684e/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cdbd82ff20147461caefc375551595ecf77ebb384e46267f128aca45a0f2cdfc", size = 467029 },
+    { url = "https://files.pythonhosted.org/packages/8e/a0/27d7daa1bfed7163f4ccaf52d7d2f4ad7bb1002a85b45077938b91ee584f/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff57e8a5d540006ce73cf0841a643d445afe78ba12e75ac53a95ca2924a56be", size = 333298 },
+    { url = "https://files.pythonhosted.org/packages/63/d4/acad86ce012b42ce18a12f31ee2aa3cbeeb98664f865f05f68c882945913/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3fd9112ca96978361201e669729784f26c71fecc9c13a7f8a07162c31bd4d1e2", size = 359217 },
 ]
 
 [[package]]
 name = "uv"
 version = "0.11.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/7d/17750123a8c8e324627534fe1ae2e7a46689db8492f1a834ab4fd229a7d8/uv-0.11.7.tar.gz", hash = "sha256:46d971489b00bdb27e0aa715e4a5cd4ef2c28ea5b6ef78f2b67bf861eb44b405", upload-time = "2026-04-15T21:42:55.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/7d/17750123a8c8e324627534fe1ae2e7a46689db8492f1a834ab4fd229a7d8/uv-0.11.7.tar.gz", hash = "sha256:46d971489b00bdb27e0aa715e4a5cd4ef2c28ea5b6ef78f2b67bf861eb44b405", size = 4083385 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/5b/2bb2ab6fe6c78c2be10852482ef0cae5f3171460a6e5e24c32c9a0843163/uv-0.11.7-py3-none-linux_armv6l.whl", hash = "sha256:f422d39530516b1dfb28bb6e90c32bb7dacd50f6a383cd6e40c1a859419fbc8c", upload-time = "2026-04-15T21:43:14.494Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f5/36ff27b01e60a88712628c8a5a6003b8e418883c24e084e506095844a797/uv-0.11.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8b2fe1ec6775dad10183e3fdce430a5b37b7857d49763c884f3a67eaa8ca6f8a", upload-time = "2026-04-15T21:42:30.225Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/fa/f379be661316698f877e78f4c51e5044be0b6f390803387237ad92c4057f/uv-0.11.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:162fa961a9a081dcea6e889c79f738a5ae56507047e4672964972e33c301bea9", upload-time = "2026-04-15T21:42:44.942Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/fbed29775b0612f4f5679d3226268f1a347161abc1727b4080fb41d9f46f/uv-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5985a15a92bd9a170fc1947abb1fbc3e9828c5a430ad85b5bed8356c20b67a71", upload-time = "2026-04-15T21:42:22.57Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/de/989a69634a869a22322770120557c2d8cbba5b77ec7cfad326b4ec0f0547/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:fab0bb43fbbc0ee5b5fee212078d2300c371b725faff7cf72eeaafa0bff0606b", upload-time = "2026-04-15T21:43:26.52Z" },
-    { url = "https://files.pythonhosted.org/packages/24/08/c1af05ea602eb4eb75d86badb6b0594cc104c3ca83ccf06d9ed4dd2186ad/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:23d457d6731ebdb83f1bffebe4894edab2ef43c1ec5488433c74300db4958924", upload-time = "2026-04-15T21:42:41.32Z" },
-    { url = "https://files.pythonhosted.org/packages/68/99/e246962da06383e992ecab55000c62a50fb36efef855ea7264fad4816bf4/uv-0.11.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d6a17507b8139b8803f445a03fd097f732ce8356b1b7b13cdb4dd8ef7f4b2e0", upload-time = "2026-04-15T21:42:37.777Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2d/b0b68083859579ce811996c1480765ec6a2442b44c451eaef53e6218fbae/uv-0.11.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd48823ca4b505124389f49ae50626ba9f57212b9047738efc95126ed5f3844d", upload-time = "2026-04-15T21:43:18.762Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/19/5970e89d9e458fd3c4966bbc586a685a1c0ab0a8bf334503f63fa20b925b/uv-0.11.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb91f52ee67e10d5290f2c2897e2171357f1a10966de38d83eefa93d96843b0c", upload-time = "2026-04-15T21:43:02.721Z" },
-    { url = "https://files.pythonhosted.org/packages/83/eb/4e1557daf6693cb446ed28185664ad6682fd98c6dbac9e433cbc35df450a/uv-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e4d5e31bea86e1b6e0f5a0f95e14e80018e6f6c0129256d2915a4b3d793644d", upload-time = "2026-04-15T21:42:18.828Z" },
-    { url = "https://files.pythonhosted.org/packages/68/55/3b517ec8297f110d6981f525cccf26f86e30883fbb9c282769cffbcdcfca/uv-0.11.7-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ceae53b202ea92bc954759bc7c7570cdcd5c3512fce15701198c19fd2dfb8605", upload-time = "2026-04-15T21:43:10.664Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/30/7d93a0312d60e147722967036dc8ea37baab4802784bddc22464cb707deb/uv-0.11.7-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:f97e9f4e4d44fb5c4dfaa05e858ef3414a96416a2e4af270ecd88a3e5fb049a9", upload-time = "2026-04-15T21:42:26.538Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/89/d49480bdab7725d36982793857e461d471bde8e1b7f438ffccee677a7bf8/uv-0.11.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:750ee5b96959b807cf442b73dd8b55111862d63f258f896787ea5f06b68aaca9", upload-time = "2026-04-15T21:42:52.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/9f/c57dc03b48be17b564e304eb9ff982890c12dfb888b1ce370788733329ab/uv-0.11.7-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f394331f0507e80ee732cb3df737589de53bed999dd02a6d24682f08c2f8ac4f", upload-time = "2026-04-15T21:42:34.094Z" },
-    { url = "https://files.pythonhosted.org/packages/13/ba/b87e358b629a68258527e3490e73b7b148770f4d2257842dea3b7981d4e8/uv-0.11.7-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0df59ab0c6a4b14a763e8445e1c303af9abeb53cdfa4428daf9ff9642c0a3cce", upload-time = "2026-04-15T21:43:22.529Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/74/16d229e1d8574bcbafa6dc643ac20b70c3e581f42ac31a6f4fd53035ffe3/uv-0.11.7-py3-none-win32.whl", hash = "sha256:553e67cc766d013ce24353fecd4ea5533d2aedcfd35f9fac430e07b1d1f23ed4", upload-time = "2026-04-15T21:42:58.702Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/1d/b73e473da616ac758b8918fb218febcc46ddf64cba9e03894dfa226b28bd/uv-0.11.7-py3-none-win_amd64.whl", hash = "sha256:5674dfb5944513f4b3735b05c2deba6b1b01151f46729d533d413a9a905f8c5d", upload-time = "2026-04-15T21:42:48.813Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bb/e6bfdea92ed270f3445a5a3c17599d041b3f2dbc5026c09e02830a03bbaf/uv-0.11.7-py3-none-win_arm64.whl", hash = "sha256:6158b7e39464f1aa1e040daa0186cae4749a78b5cd80ac769f32ca711b8976b1", upload-time = "2026-04-15T21:43:06.732Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5b/2bb2ab6fe6c78c2be10852482ef0cae5f3171460a6e5e24c32c9a0843163/uv-0.11.7-py3-none-linux_armv6l.whl", hash = "sha256:f422d39530516b1dfb28bb6e90c32bb7dacd50f6a383cd6e40c1a859419fbc8c", size = 23757265 },
+    { url = "https://files.pythonhosted.org/packages/b2/f5/36ff27b01e60a88712628c8a5a6003b8e418883c24e084e506095844a797/uv-0.11.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8b2fe1ec6775dad10183e3fdce430a5b37b7857d49763c884f3a67eaa8ca6f8a", size = 23184529 },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/f379be661316698f877e78f4c51e5044be0b6f390803387237ad92c4057f/uv-0.11.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:162fa961a9a081dcea6e889c79f738a5ae56507047e4672964972e33c301bea9", size = 21780167 },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/fbed29775b0612f4f5679d3226268f1a347161abc1727b4080fb41d9f46f/uv-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5985a15a92bd9a170fc1947abb1fbc3e9828c5a430ad85b5bed8356c20b67a71", size = 23609640 },
+    { url = "https://files.pythonhosted.org/packages/ad/de/989a69634a869a22322770120557c2d8cbba5b77ec7cfad326b4ec0f0547/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:fab0bb43fbbc0ee5b5fee212078d2300c371b725faff7cf72eeaafa0bff0606b", size = 23322484 },
+    { url = "https://files.pythonhosted.org/packages/24/08/c1af05ea602eb4eb75d86badb6b0594cc104c3ca83ccf06d9ed4dd2186ad/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:23d457d6731ebdb83f1bffebe4894edab2ef43c1ec5488433c74300db4958924", size = 23326385 },
+    { url = "https://files.pythonhosted.org/packages/68/99/e246962da06383e992ecab55000c62a50fb36efef855ea7264fad4816bf4/uv-0.11.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d6a17507b8139b8803f445a03fd097f732ce8356b1b7b13cdb4dd8ef7f4b2e0", size = 24985751 },
+    { url = "https://files.pythonhosted.org/packages/45/2d/b0b68083859579ce811996c1480765ec6a2442b44c451eaef53e6218fbae/uv-0.11.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd48823ca4b505124389f49ae50626ba9f57212b9047738efc95126ed5f3844d", size = 25724160 },
+    { url = "https://files.pythonhosted.org/packages/4e/19/5970e89d9e458fd3c4966bbc586a685a1c0ab0a8bf334503f63fa20b925b/uv-0.11.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb91f52ee67e10d5290f2c2897e2171357f1a10966de38d83eefa93d96843b0c", size = 25028512 },
+    { url = "https://files.pythonhosted.org/packages/83/eb/4e1557daf6693cb446ed28185664ad6682fd98c6dbac9e433cbc35df450a/uv-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e4d5e31bea86e1b6e0f5a0f95e14e80018e6f6c0129256d2915a4b3d793644d", size = 24933975 },
+    { url = "https://files.pythonhosted.org/packages/68/55/3b517ec8297f110d6981f525cccf26f86e30883fbb9c282769cffbcdcfca/uv-0.11.7-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ceae53b202ea92bc954759bc7c7570cdcd5c3512fce15701198c19fd2dfb8605", size = 23706403 },
+    { url = "https://files.pythonhosted.org/packages/dc/30/7d93a0312d60e147722967036dc8ea37baab4802784bddc22464cb707deb/uv-0.11.7-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:f97e9f4e4d44fb5c4dfaa05e858ef3414a96416a2e4af270ecd88a3e5fb049a9", size = 24495797 },
+    { url = "https://files.pythonhosted.org/packages/8c/89/d49480bdab7725d36982793857e461d471bde8e1b7f438ffccee677a7bf8/uv-0.11.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:750ee5b96959b807cf442b73dd8b55111862d63f258f896787ea5f06b68aaca9", size = 24580471 },
+    { url = "https://files.pythonhosted.org/packages/b6/9f/c57dc03b48be17b564e304eb9ff982890c12dfb888b1ce370788733329ab/uv-0.11.7-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f394331f0507e80ee732cb3df737589de53bed999dd02a6d24682f08c2f8ac4f", size = 24113637 },
+    { url = "https://files.pythonhosted.org/packages/13/ba/b87e358b629a68258527e3490e73b7b148770f4d2257842dea3b7981d4e8/uv-0.11.7-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0df59ab0c6a4b14a763e8445e1c303af9abeb53cdfa4428daf9ff9642c0a3cce", size = 25119850 },
+    { url = "https://files.pythonhosted.org/packages/4b/74/16d229e1d8574bcbafa6dc643ac20b70c3e581f42ac31a6f4fd53035ffe3/uv-0.11.7-py3-none-win32.whl", hash = "sha256:553e67cc766d013ce24353fecd4ea5533d2aedcfd35f9fac430e07b1d1f23ed4", size = 22918454 },
+    { url = "https://files.pythonhosted.org/packages/a6/1d/b73e473da616ac758b8918fb218febcc46ddf64cba9e03894dfa226b28bd/uv-0.11.7-py3-none-win_amd64.whl", hash = "sha256:5674dfb5944513f4b3735b05c2deba6b1b01151f46729d533d413a9a905f8c5d", size = 25447744 },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/e6bfdea92ed270f3445a5a3c17599d041b3f2dbc5026c09e02830a03bbaf/uv-0.11.7-py3-none-win_arm64.whl", hash = "sha256:6158b7e39464f1aa1e040daa0186cae4749a78b5cd80ac769f32ca711b8976b1", size = 23941816 },
 ]
 
 [[package]]
@@ -4190,9 +4196,9 @@ dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", upload-time = "2025-12-21T14:16:22.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", upload-time = "2025-12-21T14:16:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502 },
 ]
 
 [package.optional-dependencies]
@@ -4210,23 +4216,23 @@ standard = [
 name = "uvloop"
 version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", upload-time = "2025-10-16T22:17:19.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", upload-time = "2025-10-16T22:16:21.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", upload-time = "2025-10-16T22:16:22.558Z" },
-    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", upload-time = "2025-10-16T22:16:23.903Z" },
-    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", upload-time = "2025-10-16T22:16:25.246Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", upload-time = "2025-10-16T22:16:26.819Z" },
-    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", upload-time = "2025-10-16T22:16:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420 },
+    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677 },
+    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819 },
+    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529 },
+    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267 },
+    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105 },
 ]
 
 [[package]]
 name = "waitress"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", upload-time = "2024-11-16T20:02:35.195Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", upload-time = "2024-11-16T20:02:33.858Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232 },
 ]
 
 [[package]]
@@ -4236,66 +4242,66 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", upload-time = "2025-10-14T15:06:21.08Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", upload-time = "2025-10-14T15:04:32.899Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", upload-time = "2025-10-14T15:04:33.761Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", upload-time = "2025-10-14T15:04:34.679Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", upload-time = "2025-10-14T15:04:35.963Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", upload-time = "2025-10-14T15:04:37.091Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", upload-time = "2025-10-14T15:04:38.39Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", upload-time = "2025-10-14T15:04:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", upload-time = "2025-10-14T15:04:40.643Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", upload-time = "2025-10-14T15:04:41.789Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", upload-time = "2025-10-14T15:04:42.718Z" },
-    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", upload-time = "2025-10-14T15:04:43.624Z" },
-    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", upload-time = "2025-10-14T15:04:44.516Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", upload-time = "2025-10-14T15:04:45.883Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", upload-time = "2025-10-14T15:06:10.264Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", upload-time = "2025-10-14T15:06:11.28Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", upload-time = "2025-10-14T15:06:12.321Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", upload-time = "2025-10-14T15:06:13.372Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529 },
+    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384 },
+    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789 },
+    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521 },
+    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722 },
+    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088 },
+    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923 },
+    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080 },
+    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432 },
+    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046 },
+    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473 },
+    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598 },
+    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210 },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250 },
+    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117 },
+    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493 },
+    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546 },
 ]
 
 [[package]]
 name = "wcwidth"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", upload-time = "2026-06-08T05:57:23.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", upload-time = "2026-06-08T05:57:21.413Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092 },
 ]
 
 [[package]]
 name = "websocket-client"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", upload-time = "2025-10-07T21:16:36.495Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", upload-time = "2025-10-07T21:16:34.951Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616 },
 ]
 
 [[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", upload-time = "2026-01-10T09:23:47.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", upload-time = "2026-01-10T09:22:34.539Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", upload-time = "2026-01-10T09:22:36.332Z" },
-    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", upload-time = "2026-01-10T09:22:37.602Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", upload-time = "2026-01-10T09:22:38.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", upload-time = "2026-01-10T09:22:39.893Z" },
-    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", upload-time = "2026-01-10T09:22:41.016Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", upload-time = "2026-01-10T09:22:42.442Z" },
-    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", upload-time = "2026-01-10T09:22:43.654Z" },
-    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", upload-time = "2026-01-10T09:22:44.941Z" },
-    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", upload-time = "2026-01-10T09:23:36.166Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", upload-time = "2026-01-10T09:23:37.409Z" },
-    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", upload-time = "2026-01-10T09:23:39.158Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", upload-time = "2026-01-10T09:23:41.031Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", upload-time = "2026-01-10T09:23:42.259Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", upload-time = "2026-01-10T09:23:45.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340 },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022 },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319 },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631 },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870 },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361 },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615 },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246 },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684 },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947 },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260 },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071 },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968 },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735 },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
 ]
 
 [[package]]
@@ -4305,9 +4311,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", upload-time = "2026-01-08T17:49:23.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", upload-time = "2026-01-08T17:49:21.859Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025 },
 ]
 
 [[package]]
@@ -4317,9 +4323,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/24/a2eb353a6edac9a0303977c4cb048134959dd2a51b48a269dfc9dde00c8a/wheel-0.46.3.tar.gz", hash = "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803", upload-time = "2026-01-22T12:39:49.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/24/a2eb353a6edac9a0303977c4cb048134959dd2a51b48a269dfc9dde00c8a/wheel-0.46.3.tar.gz", hash = "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803", size = 60605 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl", hash = "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d", upload-time = "2026-01-22T12:39:48.099Z" },
+    { url = "https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl", hash = "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d", size = 30557 },
 ]
 
 [[package]]
@@ -4329,41 +4335,41 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/08/49181903bb52523f5e5e0b4ffc172c9bcc7edc7cda9bd626173fa99b46cf/whenever-0.7.3.tar.gz", hash = "sha256:fc2b3756c35a0694c4159ad877405949ec283623fd2082b66cdafab6e883e65b", upload-time = "2025-03-19T14:41:19.234Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/08/49181903bb52523f5e5e0b4ffc172c9bcc7edc7cda9bd626173fa99b46cf/whenever-0.7.3.tar.gz", hash = "sha256:fc2b3756c35a0694c4159ad877405949ec283623fd2082b66cdafab6e883e65b", size = 181498 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/d3/d717d8e981443374145c083264be86097cf3e4771a64be151060b783ad40/whenever-0.7.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a1a639965b27663d180c0c15b26f6222b69b964e0e58a52ac88923454e0c8cdc", upload-time = "2025-03-19T14:40:59.127Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/c4/514457fd557a6f79aaf64dd9e58d49622e4ab914960ce3934dbf2b09532f/whenever-0.7.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e596def47c9162e85c7b7d467c61dfde1d80303f9338957eed1e97dc20aff380", upload-time = "2025-03-19T14:40:51.934Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/e6/4cc9684f62d154d066031eae0f835b9dd27557a8e8e0627456df7f4d937a/whenever-0.7.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:410ab94597fe10e1da23da4ecad35ed045d925eb38b678415e28764f5b577f47", upload-time = "2025-03-19T14:39:37.053Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/40/1789f5d03dcbb5fdab6193c521aeb866e8786d1eb823046b0acc9ed70fd8/whenever-0.7.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6daa9be0ad5ab6e2a74bff8a1631c5fc9c68395f9b20f554707031e3805c220f", upload-time = "2025-03-19T14:39:52.358Z" },
-    { url = "https://files.pythonhosted.org/packages/78/cd/6c879ff0499350380fbba335968634315d1eb790f1f6939625a4beb88019/whenever-0.7.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2f2292e1002568e7f7f8f2a798c181243587e7ae12639b6127674b61e0b38959", upload-time = "2025-03-19T14:40:07.988Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f8/36fcaa11e15996eed31401a15c4fe97aa2c11118c51b4b81ae3430451c69/whenever-0.7.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a56bb88ac415518e3c0f73622c811be75e85fd3651a3c8da61457a93f8a44bc9", upload-time = "2025-03-19T14:40:15.708Z" },
-    { url = "https://files.pythonhosted.org/packages/63/75/696701d8aa8851344e1173117a547e311600f84201f37d5e2b8748407d25/whenever-0.7.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14b233287e254b3bc8eb7f0a333a6ccc52bc16dcf852c25e065541ed72fa189a", upload-time = "2025-03-19T14:40:37.737Z" },
-    { url = "https://files.pythonhosted.org/packages/da/12/429cc7dbb826c7c1a1a21cb6b9957f1cce928108aeb3222e8864a309a421/whenever-0.7.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:875e2294dfe147b3212aa2fac9be28d46ef9434d2f94fd7dea78e8e5f609dcce", upload-time = "2025-03-19T14:40:23.814Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/ab/8ec464d5fa2900fc0ed05fcecf4fb04e7f243f2acc257759acd5427bbb8f/whenever-0.7.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5d07f7bb5a09f9c6f499b4c35065c4e64a04e30f02f0592db6f05c54f079ed9", upload-time = "2025-03-19T14:39:44.381Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/11/0133587208622a86c1da7da8073e3e7a2726205df779cefd4324191bed01/whenever-0.7.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5c87952f542ede1bea94a1884058160db3e9833053369f0cde6adbc4351a8e19", upload-time = "2025-03-19T14:40:00.905Z" },
-    { url = "https://files.pythonhosted.org/packages/05/f7/75813ae2b90290985077b2eed5adc091c3a3a75ff291c2bc6f4f24d6fccb/whenever-0.7.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:89b66c7e5475d80a79193ff1fe3f01d60ec87416da2f25a5cf0b3c3677498125", upload-time = "2025-03-19T14:40:30.245Z" },
-    { url = "https://files.pythonhosted.org/packages/21/d2/380c53000f9a7ba5b4bb63818cf9055f8a7e65c1607e08b94cf70e0c303d/whenever-0.7.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:075d2d419a962c877511eda949694b4d964701469f7b6b74634b2341c1d9581d", upload-time = "2025-03-19T14:40:44.55Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/87/288609c11bba020d8c3af27c1b5a63013866ddce3da799ec93442a91d10d/whenever-0.7.3-cp311-cp311-win32.whl", hash = "sha256:d7a6706aa54a1b74ecaa0c853c897a9ab02b9ebf044bbd3873bcbd9d1984d770", upload-time = "2025-03-19T14:41:06.439Z" },
-    { url = "https://files.pythonhosted.org/packages/36/b1/cfc6c26492ddc8c2b9ed4a4ecb47dae00e1749f6e041f5400332446ddd2c/whenever-0.7.3-cp311-cp311-win_amd64.whl", hash = "sha256:78d19379b50006ed20f0cb705e71e4d8edac71459018be56d78d0bafc9ab8a38", upload-time = "2025-03-19T14:41:13.06Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d3/d717d8e981443374145c083264be86097cf3e4771a64be151060b783ad40/whenever-0.7.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a1a639965b27663d180c0c15b26f6222b69b964e0e58a52ac88923454e0c8cdc", size = 375454 },
+    { url = "https://files.pythonhosted.org/packages/4b/c4/514457fd557a6f79aaf64dd9e58d49622e4ab914960ce3934dbf2b09532f/whenever-0.7.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e596def47c9162e85c7b7d467c61dfde1d80303f9338957eed1e97dc20aff380", size = 366699 },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/4cc9684f62d154d066031eae0f835b9dd27557a8e8e0627456df7f4d937a/whenever-0.7.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:410ab94597fe10e1da23da4ecad35ed045d925eb38b678415e28764f5b577f47", size = 424022 },
+    { url = "https://files.pythonhosted.org/packages/f1/40/1789f5d03dcbb5fdab6193c521aeb866e8786d1eb823046b0acc9ed70fd8/whenever-0.7.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6daa9be0ad5ab6e2a74bff8a1631c5fc9c68395f9b20f554707031e3805c220f", size = 461340 },
+    { url = "https://files.pythonhosted.org/packages/78/cd/6c879ff0499350380fbba335968634315d1eb790f1f6939625a4beb88019/whenever-0.7.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2f2292e1002568e7f7f8f2a798c181243587e7ae12639b6127674b61e0b38959", size = 456151 },
+    { url = "https://files.pythonhosted.org/packages/21/f8/36fcaa11e15996eed31401a15c4fe97aa2c11118c51b4b81ae3430451c69/whenever-0.7.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a56bb88ac415518e3c0f73622c811be75e85fd3651a3c8da61457a93f8a44bc9", size = 486805 },
+    { url = "https://files.pythonhosted.org/packages/63/75/696701d8aa8851344e1173117a547e311600f84201f37d5e2b8748407d25/whenever-0.7.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14b233287e254b3bc8eb7f0a333a6ccc52bc16dcf852c25e065541ed72fa189a", size = 418402 },
+    { url = "https://files.pythonhosted.org/packages/da/12/429cc7dbb826c7c1a1a21cb6b9957f1cce928108aeb3222e8864a309a421/whenever-0.7.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:875e2294dfe147b3212aa2fac9be28d46ef9434d2f94fd7dea78e8e5f609dcce", size = 464267 },
+    { url = "https://files.pythonhosted.org/packages/1e/ab/8ec464d5fa2900fc0ed05fcecf4fb04e7f243f2acc257759acd5427bbb8f/whenever-0.7.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5d07f7bb5a09f9c6f499b4c35065c4e64a04e30f02f0592db6f05c54f079ed9", size = 605586 },
+    { url = "https://files.pythonhosted.org/packages/f9/11/0133587208622a86c1da7da8073e3e7a2726205df779cefd4324191bed01/whenever-0.7.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5c87952f542ede1bea94a1884058160db3e9833053369f0cde6adbc4351a8e19", size = 723803 },
+    { url = "https://files.pythonhosted.org/packages/05/f7/75813ae2b90290985077b2eed5adc091c3a3a75ff291c2bc6f4f24d6fccb/whenever-0.7.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:89b66c7e5475d80a79193ff1fe3f01d60ec87416da2f25a5cf0b3c3677498125", size = 630017 },
+    { url = "https://files.pythonhosted.org/packages/21/d2/380c53000f9a7ba5b4bb63818cf9055f8a7e65c1607e08b94cf70e0c303d/whenever-0.7.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:075d2d419a962c877511eda949694b4d964701469f7b6b74634b2341c1d9581d", size = 589079 },
+    { url = "https://files.pythonhosted.org/packages/a2/87/288609c11bba020d8c3af27c1b5a63013866ddce3da799ec93442a91d10d/whenever-0.7.3-cp311-cp311-win32.whl", hash = "sha256:d7a6706aa54a1b74ecaa0c853c897a9ab02b9ebf044bbd3873bcbd9d1984d770", size = 293106 },
+    { url = "https://files.pythonhosted.org/packages/36/b1/cfc6c26492ddc8c2b9ed4a4ecb47dae00e1749f6e041f5400332446ddd2c/whenever-0.7.3-cp311-cp311-win_amd64.whl", hash = "sha256:78d19379b50006ed20f0cb705e71e4d8edac71459018be56d78d0bafc9ab8a38", size = 278647 },
 ]
 
 [[package]]
 name = "wrapt"
 version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", upload-time = "2025-08-12T05:53:21.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", upload-time = "2025-08-12T05:51:45.79Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", upload-time = "2025-08-12T05:51:34.629Z" },
-    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", upload-time = "2025-08-12T05:51:56.074Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", upload-time = "2025-08-12T05:52:32.134Z" },
-    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", upload-time = "2025-08-12T05:52:11.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", upload-time = "2025-08-12T05:52:12.626Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", upload-time = "2025-08-12T05:52:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", upload-time = "2025-08-12T05:53:03.936Z" },
-    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", upload-time = "2025-08-12T05:53:02.885Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", upload-time = "2025-08-12T05:52:53.368Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", upload-time = "2025-08-12T05:53:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482 },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674 },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959 },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376 },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604 },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782 },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076 },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457 },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745 },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806 },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591 },
 ]
 
 [[package]]
@@ -4373,46 +4379,46 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", upload-time = "2025-11-20T18:18:01.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", upload-time = "2025-11-20T18:18:00.454Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405 },
 ]
 
 [[package]]
 name = "xlsxwriter"
 version = "3.2.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", upload-time = "2025-09-16T00:16:21.63Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", upload-time = "2025-09-16T00:16:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315 },
 ]
 
 [[package]]
 name = "xxhash"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", upload-time = "2025-10-02T14:37:08.097Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/d4/cc2f0400e9154df4b9964249da78ebd72f318e35ccc425e9f403c392f22a/xxhash-3.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a", upload-time = "2025-10-02T14:34:14.037Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/ec/1cc11cd13e26ea8bc3cb4af4eaadd8d46d5014aebb67be3f71fb0b68802a/xxhash-3.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2b6821e94346f96db75abaa6e255706fb06ebd530899ed76d32cd99f20dc52fa", upload-time = "2025-10-02T14:34:15.484Z" },
-    { url = "https://files.pythonhosted.org/packages/04/5f/19fe357ea348d98ca22f456f75a30ac0916b51c753e1f8b2e0e6fb884cce/xxhash-3.6.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d0a9751f71a1a65ce3584e9cae4467651c7e70c9d31017fa57574583a4540248", upload-time = "2025-10-02T14:34:16.541Z" },
-    { url = "https://files.pythonhosted.org/packages/90/3b/d1f1a8f5442a5fd8beedae110c5af7604dc37349a8e16519c13c19a9a2de/xxhash-3.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b29ee68625ab37b04c0b40c3fafdf24d2f75ccd778333cfb698f65f6c463f62", upload-time = "2025-10-02T14:34:17.878Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ef/3a9b05eb527457d5db13a135a2ae1a26c80fecd624d20f3e8dcc4cb170f3/xxhash-3.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6812c25fe0d6c36a46ccb002f40f27ac903bf18af9f6dd8f9669cb4d176ab18f", upload-time = "2025-10-02T14:34:19.182Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/18/ccc194ee698c6c623acbf0f8c2969811a8a4b6185af5e824cd27b9e4fd3e/xxhash-3.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4ccbff013972390b51a18ef1255ef5ac125c92dc9143b2d1909f59abc765540e", upload-time = "2025-10-02T14:34:20.659Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/86/cf2c0321dc3940a7aa73076f4fd677a0fb3e405cb297ead7d864fd90847e/xxhash-3.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:297b7fbf86c82c550e12e8fb71968b3f033d27b874276ba3624ea868c11165a8", upload-time = "2025-10-02T14:34:22.431Z" },
-    { url = "https://files.pythonhosted.org/packages/82/fb/96213c8560e6f948a1ecc9a7613f8032b19ee45f747f4fca4eb31bb6d6ed/xxhash-3.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dea26ae1eb293db089798d3973a5fc928a18fdd97cc8801226fae705b02b14b0", upload-time = "2025-10-02T14:34:23.937Z" },
-    { url = "https://files.pythonhosted.org/packages/40/aa/4395e669b0606a096d6788f40dbdf2b819d6773aa290c19e6e83cbfc312f/xxhash-3.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7a0b169aafb98f4284f73635a8e93f0735f9cbde17bd5ec332480484241aaa77", upload-time = "2025-10-02T14:34:25.644Z" },
-    { url = "https://files.pythonhosted.org/packages/67/74/b044fcd6b3d89e9b1b665924d85d3f400636c23590226feb1eb09e1176ce/xxhash-3.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:08d45aef063a4531b785cd72de4887766d01dc8f362a515693df349fdb825e0c", upload-time = "2025-10-02T14:34:27.203Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fd/3ce73bf753b08cb19daee1eb14aa0d7fe331f8da9c02dd95316ddfe5275e/xxhash-3.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:929142361a48ee07f09121fe9e96a84950e8d4df3bb298ca5d88061969f34d7b", upload-time = "2025-10-02T14:34:28.409Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/b3/5a4241309217c5c876f156b10778f3ab3af7ba7e3259e6d5f5c7d0129eb2/xxhash-3.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:51312c768403d8540487dbbfb557454cfc55589bbde6424456951f7fcd4facb3", upload-time = "2025-10-02T14:34:29.696Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/01/99bfbc15fb9abb9a72b088c1d95219fc4782b7d01fc835bd5744d66dd0b8/xxhash-3.6.0-cp311-cp311-win32.whl", hash = "sha256:d1927a69feddc24c987b337ce81ac15c4720955b667fe9b588e02254b80446fd", upload-time = "2025-10-02T14:34:31.028Z" },
-    { url = "https://files.pythonhosted.org/packages/65/79/9d24d7f53819fe301b231044ea362ce64e86c74f6e8c8e51320de248b3e5/xxhash-3.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:26734cdc2d4ffe449b41d186bbeac416f704a482ed835d375a5c0cb02bc63fef", upload-time = "2025-10-02T14:34:32.062Z" },
-    { url = "https://files.pythonhosted.org/packages/30/4e/15cd0e3e8772071344eab2961ce83f6e485111fed8beb491a3f1ce100270/xxhash-3.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:d72f67ef8bf36e05f5b6c65e8524f265bd61071471cd4cf1d36743ebeeeb06b7", upload-time = "2025-10-02T14:34:33.555Z" },
-    { url = "https://files.pythonhosted.org/packages/93/1e/8aec23647a34a249f62e2398c42955acd9b4c6ed5cf08cbea94dc46f78d2/xxhash-3.6.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0f7b7e2ec26c1666ad5fc9dbfa426a6a3367ceaf79db5dd76264659d509d73b0", upload-time = "2025-10-02T14:37:01.743Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/0b/b14510b38ba91caf43006209db846a696ceea6a847a0c9ba0a5b1adc53d6/xxhash-3.6.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5dc1e14d14fa0f5789ec29a7062004b5933964bb9b02aae6622b8f530dc40296", upload-time = "2025-10-02T14:37:02.879Z" },
-    { url = "https://files.pythonhosted.org/packages/50/55/15a7b8a56590e66ccd374bbfa3f9ffc45b810886c8c3b614e3f90bd2367c/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13", upload-time = "2025-10-02T14:37:04.44Z" },
-    { url = "https://files.pythonhosted.org/packages/62/b2/5ac99a041a29e58e95f907876b04f7067a0242cb85b5f39e726153981503/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd", upload-time = "2025-10-02T14:37:05.869Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d9/8d95e906764a386a3d3b596f3c68bb63687dfca806373509f51ce8eea81f/xxhash-3.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d", upload-time = "2025-10-02T14:37:06.966Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d4/cc2f0400e9154df4b9964249da78ebd72f318e35ccc425e9f403c392f22a/xxhash-3.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a", size = 32844 },
+    { url = "https://files.pythonhosted.org/packages/5e/ec/1cc11cd13e26ea8bc3cb4af4eaadd8d46d5014aebb67be3f71fb0b68802a/xxhash-3.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2b6821e94346f96db75abaa6e255706fb06ebd530899ed76d32cd99f20dc52fa", size = 30809 },
+    { url = "https://files.pythonhosted.org/packages/04/5f/19fe357ea348d98ca22f456f75a30ac0916b51c753e1f8b2e0e6fb884cce/xxhash-3.6.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d0a9751f71a1a65ce3584e9cae4467651c7e70c9d31017fa57574583a4540248", size = 194665 },
+    { url = "https://files.pythonhosted.org/packages/90/3b/d1f1a8f5442a5fd8beedae110c5af7604dc37349a8e16519c13c19a9a2de/xxhash-3.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b29ee68625ab37b04c0b40c3fafdf24d2f75ccd778333cfb698f65f6c463f62", size = 213550 },
+    { url = "https://files.pythonhosted.org/packages/c4/ef/3a9b05eb527457d5db13a135a2ae1a26c80fecd624d20f3e8dcc4cb170f3/xxhash-3.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6812c25fe0d6c36a46ccb002f40f27ac903bf18af9f6dd8f9669cb4d176ab18f", size = 212384 },
+    { url = "https://files.pythonhosted.org/packages/0f/18/ccc194ee698c6c623acbf0f8c2969811a8a4b6185af5e824cd27b9e4fd3e/xxhash-3.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4ccbff013972390b51a18ef1255ef5ac125c92dc9143b2d1909f59abc765540e", size = 445749 },
+    { url = "https://files.pythonhosted.org/packages/a5/86/cf2c0321dc3940a7aa73076f4fd677a0fb3e405cb297ead7d864fd90847e/xxhash-3.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:297b7fbf86c82c550e12e8fb71968b3f033d27b874276ba3624ea868c11165a8", size = 193880 },
+    { url = "https://files.pythonhosted.org/packages/82/fb/96213c8560e6f948a1ecc9a7613f8032b19ee45f747f4fca4eb31bb6d6ed/xxhash-3.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dea26ae1eb293db089798d3973a5fc928a18fdd97cc8801226fae705b02b14b0", size = 210912 },
+    { url = "https://files.pythonhosted.org/packages/40/aa/4395e669b0606a096d6788f40dbdf2b819d6773aa290c19e6e83cbfc312f/xxhash-3.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7a0b169aafb98f4284f73635a8e93f0735f9cbde17bd5ec332480484241aaa77", size = 198654 },
+    { url = "https://files.pythonhosted.org/packages/67/74/b044fcd6b3d89e9b1b665924d85d3f400636c23590226feb1eb09e1176ce/xxhash-3.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:08d45aef063a4531b785cd72de4887766d01dc8f362a515693df349fdb825e0c", size = 210867 },
+    { url = "https://files.pythonhosted.org/packages/bc/fd/3ce73bf753b08cb19daee1eb14aa0d7fe331f8da9c02dd95316ddfe5275e/xxhash-3.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:929142361a48ee07f09121fe9e96a84950e8d4df3bb298ca5d88061969f34d7b", size = 414012 },
+    { url = "https://files.pythonhosted.org/packages/ba/b3/5a4241309217c5c876f156b10778f3ab3af7ba7e3259e6d5f5c7d0129eb2/xxhash-3.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:51312c768403d8540487dbbfb557454cfc55589bbde6424456951f7fcd4facb3", size = 191409 },
+    { url = "https://files.pythonhosted.org/packages/c0/01/99bfbc15fb9abb9a72b088c1d95219fc4782b7d01fc835bd5744d66dd0b8/xxhash-3.6.0-cp311-cp311-win32.whl", hash = "sha256:d1927a69feddc24c987b337ce81ac15c4720955b667fe9b588e02254b80446fd", size = 30574 },
+    { url = "https://files.pythonhosted.org/packages/65/79/9d24d7f53819fe301b231044ea362ce64e86c74f6e8c8e51320de248b3e5/xxhash-3.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:26734cdc2d4ffe449b41d186bbeac416f704a482ed835d375a5c0cb02bc63fef", size = 31481 },
+    { url = "https://files.pythonhosted.org/packages/30/4e/15cd0e3e8772071344eab2961ce83f6e485111fed8beb491a3f1ce100270/xxhash-3.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:d72f67ef8bf36e05f5b6c65e8524f265bd61071471cd4cf1d36743ebeeeb06b7", size = 27861 },
+    { url = "https://files.pythonhosted.org/packages/93/1e/8aec23647a34a249f62e2398c42955acd9b4c6ed5cf08cbea94dc46f78d2/xxhash-3.6.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0f7b7e2ec26c1666ad5fc9dbfa426a6a3367ceaf79db5dd76264659d509d73b0", size = 30662 },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/b14510b38ba91caf43006209db846a696ceea6a847a0c9ba0a5b1adc53d6/xxhash-3.6.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5dc1e14d14fa0f5789ec29a7062004b5933964bb9b02aae6622b8f530dc40296", size = 41056 },
+    { url = "https://files.pythonhosted.org/packages/50/55/15a7b8a56590e66ccd374bbfa3f9ffc45b810886c8c3b614e3f90bd2367c/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13", size = 36251 },
+    { url = "https://files.pythonhosted.org/packages/62/b2/5ac99a041a29e58e95f907876b04f7067a0242cb85b5f39e726153981503/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd", size = 32481 },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/8d95e906764a386a3d3b596f3c68bb63687dfca806373509f51ce8eea81f/xxhash-3.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d", size = 31565 },
 ]
 
 [[package]]
@@ -4424,25 +4430,25 @@ dependencies = [
     { name = "multidict" },
     { name = "propcache" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71", upload-time = "2025-10-06T14:12:55.963Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71", size = 187169 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/27/5ab13fc84c76a0250afd3d26d5936349a35be56ce5785447d6c423b26d92/yarl-1.22.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1ab72135b1f2db3fed3997d7e7dc1b80573c67138023852b6efb336a5eae6511", upload-time = "2025-10-06T14:09:16.298Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/a1/d065d51d02dc02ce81501d476b9ed2229d9a990818332242a882d5d60340/yarl-1.22.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:669930400e375570189492dc8d8341301578e8493aec04aebc20d4717f899dd6", upload-time = "2025-10-06T14:09:17.786Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/da/8da9f6a53f67b5106ffe902c6fa0164e10398d4e150d85838b82f424072a/yarl-1.22.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:792a2af6d58177ef7c19cbf0097aba92ca1b9cb3ffdd9c7470e156c8f9b5e028", upload-time = "2025-10-06T14:09:19.662Z" },
-    { url = "https://files.pythonhosted.org/packages/68/fe/2c1f674960c376e29cb0bec1249b117d11738db92a6ccc4a530b972648db/yarl-1.22.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ea66b1c11c9150f1372f69afb6b8116f2dd7286f38e14ea71a44eee9ec51b9d", upload-time = "2025-10-06T14:09:21.402Z" },
-    { url = "https://files.pythonhosted.org/packages/95/26/812a540e1c3c6418fec60e9bbd38e871eaba9545e94fa5eff8f4a8e28e1e/yarl-1.22.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3e2daa88dc91870215961e96a039ec73e4937da13cf77ce17f9cad0c18df3503", upload-time = "2025-10-06T14:09:22.98Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/f5/5777b19e26fdf98563985e481f8be3d8a39f8734147a6ebf459d0dab5a6b/yarl-1.22.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba440ae430c00eee41509353628600212112cd5018d5def7e9b05ea7ac34eb65", upload-time = "2025-10-06T14:09:24.655Z" },
-    { url = "https://files.pythonhosted.org/packages/86/08/24bd2477bd59c0bbd994fe1d93b126e0472e4e3df5a96a277b0a55309e89/yarl-1.22.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e6438cc8f23a9c1478633d216b16104a586b9761db62bfacb6425bac0a36679e", upload-time = "2025-10-06T14:09:26.617Z" },
-    { url = "https://files.pythonhosted.org/packages/46/00/71b90ed48e895667ecfb1eaab27c1523ee2fa217433ed77a73b13205ca4b/yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c52a6e78aef5cf47a98ef8e934755abf53953379b7d53e68b15ff4420e6683d", upload-time = "2025-10-06T14:09:28.544Z" },
-    { url = "https://files.pythonhosted.org/packages/30/2d/f715501cae832651d3282387c6a9236cd26bd00d0ff1e404b3dc52447884/yarl-1.22.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3b06bcadaac49c70f4c88af4ffcfbe3dc155aab3163e75777818092478bcbbe7", upload-time = "2025-10-06T14:09:30.568Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f9/a678c992d78e394e7126ee0b0e4e71bd2775e4334d00a9278c06a6cce96a/yarl-1.22.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:6944b2dc72c4d7f7052683487e3677456050ff77fcf5e6204e98caf785ad1967", upload-time = "2025-10-06T14:09:32.528Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/d1/b49454411a60edb6fefdcad4f8e6dbba7d8019e3a508a1c5836cba6d0781/yarl-1.22.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d5372ca1df0f91a86b047d1277c2aaf1edb32d78bbcefffc81b40ffd18f027ed", upload-time = "2025-10-06T14:09:34.634Z" },
-    { url = "https://files.pythonhosted.org/packages/87/e5/40d7a94debb8448c7771a916d1861d6609dddf7958dc381117e7ba36d9e8/yarl-1.22.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:51af598701f5299012b8416486b40fceef8c26fc87dc6d7d1f6fc30609ea0aa6", upload-time = "2025-10-06T14:09:36.268Z" },
-    { url = "https://files.pythonhosted.org/packages/35/d8/611cc282502381ad855448643e1ad0538957fc82ae83dfe7762c14069e14/yarl-1.22.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b266bd01fedeffeeac01a79ae181719ff848a5a13ce10075adbefc8f1daee70e", upload-time = "2025-10-06T14:09:37.872Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/df/fadd00fb1c90e1a5a8bd731fa3d3de2e165e5a3666a095b04e31b04d9cb6/yarl-1.22.0-cp311-cp311-win32.whl", hash = "sha256:a9b1ba5610a4e20f655258d5a1fdc7ebe3d837bb0e45b581398b99eb98b1f5ca", upload-time = "2025-10-06T14:09:39.359Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/f7/149bb6f45f267cb5c074ac40c01c6b3ea6d8a620d34b337f6321928a1b4d/yarl-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:078278b9b0b11568937d9509b589ee83ef98ed6d561dfe2020e24a9fd08eaa2b", upload-time = "2025-10-06T14:09:41.068Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/13/88b78b93ad3f2f0b78e13bfaaa24d11cbc746e93fe76d8c06bf139615646/yarl-1.22.0-cp311-cp311-win_arm64.whl", hash = "sha256:b6a6f620cfe13ccec221fa312139135166e47ae169f8253f72a0abc0dae94376", upload-time = "2025-10-06T14:09:42.712Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", upload-time = "2025-10-06T14:12:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/5ab13fc84c76a0250afd3d26d5936349a35be56ce5785447d6c423b26d92/yarl-1.22.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1ab72135b1f2db3fed3997d7e7dc1b80573c67138023852b6efb336a5eae6511", size = 141607 },
+    { url = "https://files.pythonhosted.org/packages/6a/a1/d065d51d02dc02ce81501d476b9ed2229d9a990818332242a882d5d60340/yarl-1.22.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:669930400e375570189492dc8d8341301578e8493aec04aebc20d4717f899dd6", size = 94027 },
+    { url = "https://files.pythonhosted.org/packages/c1/da/8da9f6a53f67b5106ffe902c6fa0164e10398d4e150d85838b82f424072a/yarl-1.22.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:792a2af6d58177ef7c19cbf0097aba92ca1b9cb3ffdd9c7470e156c8f9b5e028", size = 94963 },
+    { url = "https://files.pythonhosted.org/packages/68/fe/2c1f674960c376e29cb0bec1249b117d11738db92a6ccc4a530b972648db/yarl-1.22.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ea66b1c11c9150f1372f69afb6b8116f2dd7286f38e14ea71a44eee9ec51b9d", size = 368406 },
+    { url = "https://files.pythonhosted.org/packages/95/26/812a540e1c3c6418fec60e9bbd38e871eaba9545e94fa5eff8f4a8e28e1e/yarl-1.22.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3e2daa88dc91870215961e96a039ec73e4937da13cf77ce17f9cad0c18df3503", size = 336581 },
+    { url = "https://files.pythonhosted.org/packages/0b/f5/5777b19e26fdf98563985e481f8be3d8a39f8734147a6ebf459d0dab5a6b/yarl-1.22.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba440ae430c00eee41509353628600212112cd5018d5def7e9b05ea7ac34eb65", size = 388924 },
+    { url = "https://files.pythonhosted.org/packages/86/08/24bd2477bd59c0bbd994fe1d93b126e0472e4e3df5a96a277b0a55309e89/yarl-1.22.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e6438cc8f23a9c1478633d216b16104a586b9761db62bfacb6425bac0a36679e", size = 392890 },
+    { url = "https://files.pythonhosted.org/packages/46/00/71b90ed48e895667ecfb1eaab27c1523ee2fa217433ed77a73b13205ca4b/yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c52a6e78aef5cf47a98ef8e934755abf53953379b7d53e68b15ff4420e6683d", size = 365819 },
+    { url = "https://files.pythonhosted.org/packages/30/2d/f715501cae832651d3282387c6a9236cd26bd00d0ff1e404b3dc52447884/yarl-1.22.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3b06bcadaac49c70f4c88af4ffcfbe3dc155aab3163e75777818092478bcbbe7", size = 363601 },
+    { url = "https://files.pythonhosted.org/packages/f8/f9/a678c992d78e394e7126ee0b0e4e71bd2775e4334d00a9278c06a6cce96a/yarl-1.22.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:6944b2dc72c4d7f7052683487e3677456050ff77fcf5e6204e98caf785ad1967", size = 358072 },
+    { url = "https://files.pythonhosted.org/packages/2c/d1/b49454411a60edb6fefdcad4f8e6dbba7d8019e3a508a1c5836cba6d0781/yarl-1.22.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d5372ca1df0f91a86b047d1277c2aaf1edb32d78bbcefffc81b40ffd18f027ed", size = 385311 },
+    { url = "https://files.pythonhosted.org/packages/87/e5/40d7a94debb8448c7771a916d1861d6609dddf7958dc381117e7ba36d9e8/yarl-1.22.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:51af598701f5299012b8416486b40fceef8c26fc87dc6d7d1f6fc30609ea0aa6", size = 381094 },
+    { url = "https://files.pythonhosted.org/packages/35/d8/611cc282502381ad855448643e1ad0538957fc82ae83dfe7762c14069e14/yarl-1.22.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b266bd01fedeffeeac01a79ae181719ff848a5a13ce10075adbefc8f1daee70e", size = 370944 },
+    { url = "https://files.pythonhosted.org/packages/2d/df/fadd00fb1c90e1a5a8bd731fa3d3de2e165e5a3666a095b04e31b04d9cb6/yarl-1.22.0-cp311-cp311-win32.whl", hash = "sha256:a9b1ba5610a4e20f655258d5a1fdc7ebe3d837bb0e45b581398b99eb98b1f5ca", size = 81804 },
+    { url = "https://files.pythonhosted.org/packages/b5/f7/149bb6f45f267cb5c074ac40c01c6b3ea6d8a620d34b337f6321928a1b4d/yarl-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:078278b9b0b11568937d9509b589ee83ef98ed6d561dfe2020e24a9fd08eaa2b", size = 86858 },
+    { url = "https://files.pythonhosted.org/packages/2b/13/88b78b93ad3f2f0b78e13bfaaa24d11cbc746e93fe76d8c06bf139615646/yarl-1.22.0-cp311-cp311-win_arm64.whl", hash = "sha256:b6a6f620cfe13ccec221fa312139135166e47ae169f8253f72a0abc0dae94376", size = 81637 },
+    { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814 },
 ]
 
 [[package]]
@@ -4453,41 +4459,41 @@ dependencies = [
     { name = "defusedxml" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", upload-time = "2026-01-29T09:09:17.088Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", upload-time = "2026-01-29T09:09:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227 },
 ]
 
 [[package]]
 name = "zipp"
 version = "3.23.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", upload-time = "2025-06-08T17:06:39.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", upload-time = "2025-06-08T17:06:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276 },
 ]
 
 [[package]]
 name = "zstandard"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", upload-time = "2025-09-14T22:15:54.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", upload-time = "2025-09-14T22:16:26.137Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", upload-time = "2025-09-14T22:16:27.973Z" },
-    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", upload-time = "2025-09-14T22:16:29.523Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", upload-time = "2025-09-14T22:16:31.811Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", upload-time = "2025-09-14T22:16:33.486Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", upload-time = "2025-09-14T22:16:35.277Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", upload-time = "2025-09-14T22:16:37.141Z" },
-    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", upload-time = "2025-09-14T22:16:38.807Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", upload-time = "2025-09-14T22:16:40.523Z" },
-    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", upload-time = "2025-09-14T22:16:43.3Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", upload-time = "2025-09-14T22:16:45.292Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", upload-time = "2025-09-14T22:16:47.076Z" },
-    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", upload-time = "2025-09-14T22:16:49.316Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", upload-time = "2025-09-14T22:16:51.328Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", upload-time = "2025-09-14T22:16:55.005Z" },
-    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", upload-time = "2025-09-14T22:16:52.753Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", upload-time = "2025-09-14T22:16:53.878Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254 },
+    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559 },
+    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020 },
+    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126 },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390 },
+    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914 },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635 },
+    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277 },
+    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377 },
+    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493 },
+    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018 },
+    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672 },
+    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753 },
+    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047 },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484 },
+    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183 },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533 },
 ]

--- a/src/build.py
+++ b/src/build.py
@@ -29,7 +29,7 @@ class Builder:
             
             # Install dependencies
             logger.info("Installing npm dependencies...")
-            subprocess.run(["npm", "install"], check=True)
+            subprocess.run(["npm", "ci"], check=True)
             
             # Copy documentation markdown files to frontend public folder before building
             frontend_public_docs = self.frontend_dir / "public" / "docs"

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -127,7 +127,7 @@ def build_frontend(root_dir, api_url=None):
 
     Runs the root package.json npm lifecycle (prebuild → build → postbuild):
     docs are copied into frontend/public/docs, the React app is built with
-    npm install + npm run build, and frontend_static/ is recreated from the
+    npm ci + npm run build, and frontend_static/ is recreated from the
     build output (including docs). Aborts the deployment if the build fails.
 
     VITE_API_URL is pinned via the process environment, which in Vite takes

--- a/src/docs/internal-dbu-tagging-plan.md
+++ b/src/docs/internal-dbu-tagging-plan.md
@@ -1,0 +1,135 @@
+# Plan: tag Kasal-created resources for real internal $DBU
+
+## Goal
+
+Get **real $DBU** (from `system.billing.usage`) for the Databricks resources Kasal
+**creates**, by stamping a `custom_tag` at creation time. Billing can then be
+filtered `WHERE custom_tags.app = 'kasal'` to attribute cost to Kasal precisely.
+
+This is the **complement** to the HTTP-header approach (see the
+`kasal_consumption_tracking` repo), not a replacement. Read the scope honestly:
+
+| Resource | Kasal's relationship | This plan covers it? |
+|----------|----------------------|----------------------|
+| **Lakebase instance** | Kasal **creates** it (`lakebase_service.create_instance`) | ✅ yes — tag at create |
+| **Vector Search endpoint** | Kasal **creates** it (`databricks_vector_endpoint_repository.create_endpoint`) | ✅ yes — tag at create |
+| **Databricks App** (Kasal itself) | deployed via bundle | ✅ yes — tag in `app.yaml` / bundle |
+| **Model serving / LLM** | Kasal only **connects** to shared `databricks-*` endpoints | ❌ **no** — not ours to tag → use the HTTP-header token→$ path instead |
+| Connect-to-**existing** Lakebase/VS | Kasal didn't create it | ❌ no — can't tag another owner's resource |
+
+**Known limits (state these up front):**
+1. Tagging covers only Kasal-**created** resources. Anything Kasal *connects to*
+   (shared serving endpoints — the largest cost line; user-supplied existing
+   Lakebase/VS) is out of scope here; the token-fingerprint cost layer handles
+   serving, and connect-to-existing is inherently not Kasal-attributable via tags.
+2. `custom_tags` are **free-form and user-editable** — a tag is an attribution
+   *convention*, not a trust boundary. Someone could tag a non-Kasal resource
+   `app=kasal` or strip the tag. Treat tag-based $ as "resources Kasal provisioned
+   under its own SP", not a guaranteed exhaustive total.
+3. Reading `system.billing.usage` requires SELECT on it in the workspace where the
+   resources live — an access grant, separate from this code change.
+
+---
+
+## Code changes
+
+Use a single shared constant so the tag is consistent and greppable.
+
+### 0. Shared tag constant (new)
+Add to `src/utils/telemetry.py` (next to `KASAL_BASE`):
+```python
+# Resource tag stamped on Databricks resources Kasal CREATES, so their cost is
+# attributable in system.billing.usage (WHERE custom_tags.app = 'kasal').
+KASAL_RESOURCE_TAGS = {"app": "kasal", "created_by": "kasal"}
+```
+
+### 1. Lakebase instance — `services/lakebase_service.py::create_instance` (~L359)
+`DatabaseInstance` accepts `custom_tags` (verify against the installed
+`databricks-sdk` version; the field may be `custom_tags: Dict[str,str]`). Change:
+```python
+from src.utils.telemetry import KASAL_RESOURCE_TAGS
+instance = w.database.create_database_instance(
+    DatabaseInstance(
+        name=instance_name,
+        capacity=capacity,
+        retention_window_in_days=retention_days,
+        node_count=node_count if node_count > 1 else None,
+        custom_tags=KASAL_RESOURCE_TAGS,     # NEW  (guard: only if the SDK field exists)
+    )
+)
+```
+If the SDK's `DatabaseInstance` has no `custom_tags`, tag via the update/patch API
+after creation, or fall back to a budget policy (below).
+
+### 2. Vector Search endpoint — `repositories/databricks_vector_endpoint_repository.py::create_endpoint` (~L36)
+The endpoint is created by a raw REST `payload`. Add tags to the body (confirm the
+`/api/2.0/vector-search/endpoints` create schema supports `custom_tags`):
+```python
+from src.utils.telemetry import KASAL_RESOURCE_TAGS
+payload = {
+    "name": endpoint_data.name,
+    "endpoint_type": ...,
+    "custom_tags": [                          # NEW  (list-of-{key,value} per the API)
+        {"key": k, "value": v} for k, v in KASAL_RESOURCE_TAGS.items()
+    ],
+}
+```
+> Verify the exact shape — some VS endpoints don't accept tags at create; if so this
+> line is a no-op and VS cost stays log-volume-only (document it).
+
+### 3. Databricks App (Kasal itself)
+Two paths, both real:
+- **Budget policy (preferred for cost):** the export already wires
+  `budget_policy_id` into `app.yaml` (`quickstart.py::update_databricks_yml_app_name`).
+  A budget policy *is* the first-class cost-attribution mechanism for Apps — prefer
+  a `kasal` budget policy over a free-form tag. Ensure the deploy attaches one.
+- **Tag:** if using tags, add `custom_tags` to the app resource in the bundle
+  (`src/deploy.py` / `app.yaml`) as `{"app": "kasal"}`.
+
+### 4. (Optional) Serving endpoints Kasal *does* create
+Kasal mostly connects, but `agentbricks`/deployment paths may create serving
+endpoints. Where a `create_serving_endpoint`/deploy call exists, add the same tags.
+Foundation `databricks-*` endpoints are NOT created by Kasal — do not attempt.
+
+---
+
+## Verification (once deployed + billing access granted)
+
+In the workspace where Kasal's resources live:
+```sql
+SELECT billing_origin_product, sku_name,
+       SUM(usage_quantity) AS dbus
+FROM system.billing.usage
+WHERE usage_date >= current_date() - 30
+  AND custom_tags.app = 'kasal'          -- the tag from KASAL_RESOURCE_TAGS
+GROUP BY billing_origin_product, sku_name
+ORDER BY dbus DESC;
+```
+Non-empty rows = tagging works and cost is Kasal-attributable. This becomes the
+"real $DBU" companion to the token-fingerprint serving $.
+
+---
+
+## Rollout order
+
+1. **Ship the tag constant + Lakebase/VS/App create-time tags** (this doc). Low risk,
+   additive — a create-time tag can't break creation if the SDK accepts it, and is a
+   guarded no-op if it doesn't.
+2. **New resources get tagged from then on** (existing untagged resources stay
+   untagged — optionally backfill via ALTER/patch if the APIs allow).
+3. **Request SELECT on `system.billing.usage`** for the Kasal workspace(s).
+4. **Add a billing-based `$DBU` source** to `kasal_consumption_tracking` filtered by
+   `custom_tags.app='kasal'` — the tagged-resource cost line, alongside the
+   token-fingerprint serving $ that's already built.
+
+## Why this is only half the picture (and that's OK)
+
+- **Serving/LLM (biggest cost):** solved by the HTTP header — `Kasal tokens ×
+  per-model price`, no tag possible or needed.
+- **Kasal-created Lakebase/VS/App:** solved by this tagging plan → real billing $.
+- **Connect-to-existing / shared:** not tag-attributable; log volume is the honest
+  ceiling.
+
+Together the header path + this tagging plan cover the two cost lines that CAN be
+turned into real dollars. Neither alone is complete; both together are the honest
+maximum for internal Kasal cost.

--- a/src/docs/kasal-platform-feedback-for-product-teams.md
+++ b/src/docs/kasal-platform-feedback-for-product-teams.md
@@ -1,0 +1,258 @@
+# Kasal → Databricks product teams: field-proven asks
+
+**Audience:** Databricks product managers (and their leadership) for Lakebase, Vector
+Search, Genie/AI-BI, Model Serving, Unity Catalog, Databricks Apps, MLflow, and Agent
+Bricks / Mosaic AI Agent Framework.
+
+**What this is.** Kasal is a Databricks-native agent platform built in the field and
+shipped to real customers. It runs *as* a Databricks App and uses the Databricks stack
+end to end. To deliver it we had to build a number of agentic-AI capabilities
+ourselves. This document lists those capabilities, why a customer needed each one, and
+what we would ask the platform to absorb.
+
+**What this is not.** Not a critique, and not a scorecard. Every item here is
+something we built *because a customer engagement required it on a deadline* — which
+makes each one a piece of validated demand rather than a hypothesis. Where our
+implementation is partial or a workaround, we say so explicitly; those notes are the
+most useful part of the document.
+
+**Why it should matter to a PM:** Kasal is a working proof that these capabilities
+drive consumption of Databricks products. The memory subsystem is why customers turn
+on Vector Search and Lakebase. The migration pipeline is why they create Unity Catalog
+Metric Views, Lakeview dashboards, and Genie spaces. The demand is already priced in.
+
+---
+
+## 1. One-page summary
+
+| # | Capability we built | Customer need behind it | Platform product it pulls through | Our ask |
+|---|---|---|---|---|
+| 1 | **Agent memory** (short-term, long-term, entity, document) | Agents that remember across runs, isolated per tenant | **Vector Search**, **Lakebase** | A first-class agent-memory service with tenant scoping |
+| 2 | **Human-in-the-loop gates** | Regulated customers cannot let agents act unreviewed | Apps, Jobs | A platform HITL primitive: pause / approve / timeout / resume |
+| 3 | **Agent security scanning** | Security review blocked go-live until we could show injection + secret-leak controls | Model Serving, AI Gateway | Platform-side guardrails + a tool capability manifest |
+| 4 | **OBO identity through the agent stack** | Every agent action must run as the *end user*, not a service principal | UC, Genie, Vector Search, Lakebase | OBO propagation preserved across async / subprocess boundaries |
+| 5 | **Multi-step orchestration** (flows, DAGs, scheduling) | Real work is multi-crew with branching and gates, run on a schedule | Apps, Jobs | Composable multi-agent orchestration, not just single agents |
+| 6 | **Per-step observability** (traces, tokens, cost) | "What did the agent do, and what did it cost?" | **MLflow**, UC | Agent-step-level trace + cost attribution out of the box |
+| 7 | **Agent-authored UI** (A2UI) | Agent output needs to be a dashboard/document, not a chat blob | Apps, Lakeview | A standard contract for agent-generated UI surfaces |
+| 8 | **Export / portability** | Customers will not adopt what they cannot own and run themselves | Apps, DABs | Export-to-owned-asset from managed agent products |
+| 9 | **Power BI → Unity Catalog migration** | Migrating BI estates off Power BI is the reason we are in the door | **UC Metric Views**, **Lakeview**, **Genie**, SQL Warehouses | Platform-supported semantic-layer migration |
+
+Products Kasal already integrates: Databricks Apps, Unity Catalog (incl. Metric
+Views), Vector Search, Genie/AI-BI, Model Serving + Foundation Model APIs, AI Gateway,
+Lakebase, MLflow, SQL Warehouses, Jobs, Volumes, Lakeview, Secrets, Agent Bricks,
+Databricks SDK, OBO/OAuth/SPN. (Evidence: `src/utils/telemetry.py` `KasalProduct`
+enum; OAuth scopes in `src/deploy.py`.)
+
+---
+
+## 2. The asks, with evidence
+
+### 2.1 Agent memory → pulls through Vector Search + Lakebase
+**Need.** Customers expect an agent to remember prior runs, and expect strict
+separation between tenants. CrewAI's default memory is local files, which is neither
+governed nor multi-tenant.
+
+**What we built.** Four memory types (short-term, long-term, entity, document) behind
+one backend interface, with three interchangeable backends: **Databricks Vector
+Search**, **Lakebase (Postgres + pgvector)**, and a local fallback. Memory survives
+across runs because the crew identity is a deterministic hash of crew structure, and
+every record is `group_id`-scoped.
+`engines/crewai/memory/{memory_backend_factory,databricks_storage_backend,lakebase_storage_backend,crew_memory_service}.py`
+
+**Why a PM should care.** This is the single biggest driver of Vector Search and
+Lakebase usage in our deployments — memory is *why* a customer provisions them.
+
+**Honest caveat.** Entity extraction is unreliable on some Databricks-served models
+and falls back to another model. That is a model-behaviour issue, not a storage one.
+
+**Ask.** A managed agent-memory service with tenant scoping and pluggable storage, so
+every agent builder is not re-implementing this.
+
+---
+
+### 2.2 Human-in-the-loop → the blocker for regulated adoption
+**Need.** In regulated customers, an agent that writes or acts without review cannot
+go live. This is a gating requirement, not a nice-to-have.
+
+**What we built.** Approval gates as nodes inside a flow: execution pauses, an
+approval record is created with an allowed-approver list and a timeout, webhooks fire
+on gate events, and on rejection the flow either fails or retries the prior step.
+`models/hitl_approval.py`, `services/{hitl_service,hitl_webhook_service,hitl_timeout_service}.py`
+
+**Ask.** A platform HITL primitive — pause, approve/reject, timeout, resume — usable
+from any agent product. We believe this is the most commonly requested missing piece
+for agentic AI in the enterprise, and we have the customer evidence behind that claim.
+
+---
+
+### 2.3 Agent security → what security review actually asks for
+**Need.** Security review asked concrete questions before go-live: can a prompt
+override the agent's instructions; can a secret leak into a trace; which tools can
+combine into an exfiltration path.
+
+**What we built.** A scanner pipeline covering prompt-injection heuristics (tiered
+severity), secret-leak detection with redaction before persistence, and a **tool
+capability manifest** that flags the "lethal trifecta" (reads sensitive data + ingests
+untrusted content + can communicate externally) plus destructive-operation tools.
+`engines/crewai/security/{scanner_pipeline,prompt_injection_detector,secret_leak_detector,tool_capability_manifest}.py`
+
+**Honest caveat — important.** These are **log-only**. They detect and warn; they do
+not block. We deliberately did not put a heuristic in a blocking path. So this is
+evidence of the *requirement*, not a claim that we solved enforcement.
+
+**Ask.** Platform-side guardrails on the serving/gateway path, and a standard tool
+capability manifest so risk can be assessed declaratively rather than per-tool.
+
+---
+
+### 2.4 OBO identity through the whole agent stack
+**Need.** Governance only holds if the agent queries as the *end user*. A service
+principal that can see everything defeats Unity Catalog.
+
+**What we built.** An auth chain (OBO user token → OAuth → PAT → env) threaded down to
+every Databricks call, including through async offloads and spawned subprocesses,
+where the user context is easily lost. `utils/databricks_auth.py`; group isolation in
+`models/group.py` and `services/group_service.py`.
+
+**Honest caveat.** Keeping OBO alive across async and subprocess boundaries is subtle
+and we have fixed real bugs where the token silently dropped and calls fell back to a
+service principal — i.e. a *governance* bug, not just a functional one.
+
+**Ask.** First-class OBO propagation guarantees in agent frameworks and SDKs, so
+identity cannot be silently downgraded.
+
+---
+
+### 2.5 Multi-step orchestration
+**Need.** Real customer work is not one agent answering once. It is several units of
+work with branching, approval gates, and a schedule.
+
+**What we built.** Three execution paths behind one interface — an in-process
+single-agent path for chat latency, and subprocess-isolated crew and flow (DAG) paths
+— plus cron scheduling. `engines/crewai/paths/{light_agent,crew,flow}/`,
+`models/schedule.py`.
+
+**Ask.** Composable orchestration primitives (graph, gate, schedule, isolation) rather
+than only a single-agent abstraction.
+
+---
+
+### 2.6 Per-step observability and cost attribution
+**Need.** "What did the agent actually do, and what did it cost?" — asked in every
+review, by both engineering and finance.
+
+**What we built.** Per-step traces (agent, task, tool) with OTel span structure,
+MLflow autologging with secret redaction before export, live streaming to the UI, and
+token/usage capture per LLM call — all `group_id`-scoped.
+`models/execution_trace.py`, `engines/crewai/infra/mlflow_integration.py`,
+`services/{execution_trace_service,trace_broadcast_service}.py`
+
+**Related field note.** We separately built internal consumption tracking and found
+that per-product agent cost attribution is only cleanly derivable for token-billed
+products; for uptime-billed products it required inference. If agent-level cost
+attribution were a platform feature, that guesswork disappears.
+
+**Ask.** Agent-step-level tracing and cost attribution as a default, not an
+integration exercise.
+
+---
+
+### 2.7 Agent-authored UI (A2UI)
+**Need.** For BI-adjacent work the useful output is a dashboard, document, or
+presentation — not a paragraph of chat.
+
+**What we built.** A JSON surface contract (component tree + data bindings) that an
+agent emits and a renderer draws, covering conversation, document, presentation,
+dashboard, mindmap and other surface kinds, with a component registry (tables, charts,
+maps, embeds). Renderer is vendored into every export so surfaces stay portable.
+`engines/crewai/exporters/templates/databricks_app/frontend/src/a2ui/`
+
+**Ask.** A standard contract for agent-generated UI, so agent output can render
+consistently across Apps and AI/BI instead of each team inventing one.
+
+---
+
+### 2.8 Openness and export — the adoption question
+**Need.** The most common enterprise objection we hear is ownership: *"if we build on
+this, can we still run it ourselves?"* Customers commit faster when the answer is yes.
+
+**What we built.** An agent built in Kasal exports to a **deployable Databricks App**
+(with DABs bundle, config YAML, bundled tools, vendored UI), a **Databricks notebook**,
+or a **standalone Python project**. `engines/crewai/exporters/`
+
+**On Agent Bricks specifically — stated carefully.** We integrate Agent Bricks as a
+callable tool, so a Databricks-native agent can participate in a Kasal workflow
+(`repositories/agentbricks_repository.py`,
+`engines/crewai/tools/custom/agentbricks_tool.py`). What we cannot currently do is the
+reverse: compose Agent Bricks agents into an external orchestration graph as
+first-class citizens, or export one as a customer-owned asset. That asymmetry is a
+recurring adoption objection in our deals — customers ask what happens if they want to
+move. We raise this as demand signal, not criticism: the integration surface that
+exists is what let us adopt Agent Bricks at all.
+
+**Ask.** Two-way openness for managed agent products — callable *and* composable
+*and* exportable to an asset the customer owns.
+
+---
+
+### 2.9 Power BI → Unity Catalog migration (the wedge)
+**Need.** Migrating a BI estate off Power BI is frequently the reason we are in the
+room. The blocker is never the data; it is thousands of DAX measures.
+
+**What we built.** An end-to-end pipeline: extract measures and M-queries from the
+Power BI APIs → transpile DAX to SQL (deterministic pattern registry plus a
+skill-corpus LLM path) → resolve measure dependencies → emit **Unity Catalog Metric
+View** YAML and deploy SQL → optionally generate **Lakeview** dashboards and **Genie**
+spaces. `converters/services/powerbi/`, `converters/pipeline.py`,
+`engines/crewai/tools/custom/metric_view_utils/`
+
+**Why a PM should care.** This converts a Power BI estate directly into Unity Catalog
+Metric Views, Lakeview dashboards, and Genie spaces — the migration is the adoption
+event for three products at once.
+
+**Honest caveat, and it is the interesting part.** Not every measure converts. Some
+DAX has no metric-view equivalent (slicer-driven scalars, display-only formatting,
+disconnected-slicer dispatch). We therefore treat honest reporting as a feature: every
+non-converted measure is surfaced with its original DAX and the reason, reviewers can
+triage it in the UI, and a re-evaluation sweep re-tests previously-failed measures
+whenever transpilation capability improves. **We would rather show a customer a
+truthful gap than a silently wrong metric** — and the same principle would serve any
+platform migration tooling.
+
+---
+
+## 3. What we are deliberately not claiming
+
+Included because it is what makes the rest credible:
+
+- **Our guardrails do not block.** Detection and logging only.
+- **The migration converter is not 100%.** A meaningful share of complex DAX still
+  needs a human; we report it rather than hide it.
+- **Kasal is not all our own work.** Orchestration builds on CrewAI; LLM routing on
+  litellm; tracing on OpenTelemetry. Our contribution is the Databricks-native
+  integration, governance, and productisation.
+- **We are not claiming these gaps are unknown to you.** Several are likely already on
+  roadmaps. The contribution here is evidence of *sequence and priority* from real
+  deployments.
+- **Kasal is not a product.** It is a field asset. Everything here is offered as input,
+  and we would rather hand a capability over than keep owning it.
+
+---
+
+## 4. What we would ask for next
+
+1. **Tell us what is already coming.** Where a roadmap item exists, we will drop our
+   implementation and adopt yours — we would prefer to carry less.
+2. **Use us as a design partner.** Kasal has real customers exercising these paths
+   daily; that is a fast feedback loop for a pre-GA primitive.
+3. **Prioritisation input.** If we had to rank by "blocks enterprise adoption today":
+   **HITL** first, **agent memory** second, **enforcing guardrails** third, **two-way
+   openness/export** fourth.
+4. **Take the migration asks.** Semantic-layer migration drives UC Metric View, Genie
+   and Lakeview adoption; it deserves platform investment beyond a field asset.
+
+---
+
+*Every capability above is implemented and running; file paths are given so any claim
+can be checked in the repository. Where something is partial, the caveat is stated
+inline rather than in a footnote.*

--- a/src/docs/powerbi/README.md
+++ b/src/docs/powerbi/README.md
@@ -32,6 +32,10 @@ The tables below map common goals to the tools and guide that cover them.
 - [Simple migration story](./02-simple-migration-story.md)
 - [PBI → UCMV pipeline architecture](./ucmv-pipeline-architecture.md): end-to-end walkthrough — extraction → config → M-query path → LLM-first DAX translation with skill files → deploy, with the code location of each stage
 
+### Operations & troubleshooting
+
+- [Rate limits & throttling](./rate-limits-and-throttling.md): what to do when a run hits `REQUEST_LIMIT_EXCEEDED` — quota tier bump, Provisioned Throughput, and off-hours/retry, chosen by run cadence
+
 ### Case studies and examples
 
 - [Power BI analytics Q&A full case study](./powerbi-analytics-qa-case-study.md): 3-agent crew, context enrichment, business_mappings, field_synonyms, active_filters

--- a/src/docs/powerbi/rate-limits-and-throttling.md
+++ b/src/docs/powerbi/rate-limits-and-throttling.md
@@ -1,0 +1,93 @@
+# Rate Limits & Throttling — Power BI → UC Metric View Tool
+
+**Runbook for `REQUEST_LIMIT_EXCEEDED` during a UCMV generation run.**
+
+## The symptom
+
+A run slows to a crawl or fails, and `execution_logs` / `flow.log` show:
+
+```
+litellm.RateLimitError: databricksException - {"error_code":"REQUEST_LIMIT_EXCEEDED",
+"message":"REQUEST_LIMIT_EXCEEDED: Exceeded workspace input tokens per minute rate
+limit for databricks-claude-opus-4-8. Work with your Databricks account team to
+request a higher FMAPI rate limit tier."}
+...
+[DatabricksRetryLLM] rate_limit in _handle_non_streaming (attempt N/5) ... Retrying in 120.0s
+```
+
+Two failure shapes follow from sustained throttling:
+- **Silent stall** — the run sits in 120 s retry back-offs for many minutes (looks
+  "hung" but isn't).
+- **Downstream failure** — the run drags on long enough that the user/OBO token TTL
+  lapses, and a later call fails with `Embedding API error 403: Invalid Token`,
+  ending the flow.
+
+## Why it happens
+
+The workspace's **Foundation Model API (FMAPI) pay-per-token endpoint** enforces a
+shared **input-tokens-per-minute (TPM)** ceiling per model (e.g.
+`databricks-claude-opus-4-8`). A large report drives a lot of tokens per minute
+across several paths (crew-agent reasoning, DAX→SQL translation, M→SQL recovery,
+crew-memory embeddings), and the sum exceeds the TPM ceiling — especially when other
+users in the same workspace are also hitting the same model.
+
+**Important framing:** UCMV generation is an **occasional drafting / migration task**,
+not a runtime path. So optimize for "succeed a handful of times," not "sustained
+throughput."
+
+## What the tool already does (no action needed)
+
+These token-demand reductions are built in — you do **not** need to do anything for them:
+- **Batched DAX→SQL translation** — measures are translated in batches (one LLM call
+  per ~12 measures) instead of one call per measure, so the ~14 k-token skill corpus
+  is amortised across the batch (~10× fewer input tokens). Databricks silently drops
+  Anthropic prompt caching, so batching — not caching — is what keeps the token cost down.
+- **Fail-open retry with back-off** — a throttled call retries and recovers; one
+  stuck call no longer hangs the run indefinitely.
+
+So the levers below are the **operator** options when throttling still occurs.
+
+## What to do when you hit throttling
+
+### 1. Raise the ceiling (quota — ~free) — do this first
+
+Request a **higher FMAPI rate-limit tier** for the workspace (exactly what the error
+message advises). It lifts the per-minute cap on the shared endpoint; usage stays
+**pay-per-token**, so there's no new cost model — just a higher ceiling. Fastest infra
+lever. Go through your Databricks account team.
+
+### 2. Dedicated capacity (pay — the robust option)
+
+Provision a **Provisioned Throughput (PT)** serving endpoint for the model. Capacity is
+**reserved** and billed by throughput (DBUs/hour), and is **not** subject to the shared
+per-minute limit → throttling disappears entirely.
+
+- **Right for:** bulk onboarding — many reports / many tenants in a window.
+- **How to use economically:** spin PT **up for the onboarding window and release it
+  afterwards.** Do **not** run it permanently for an occasional drafting job — that's
+  over-provisioning.
+
+### 3. Operational stopgaps (no change, good for one-offs)
+
+- **Run off-hours.** The TPM limit is **per-workspace and shared**, so running when
+  colleagues aren't also hitting the same model gives real headroom.
+- **Retry / run again.** The tool already backs off and recovers; simply re-running
+  once the per-minute window resets often gets a one-off draft through. Fragile, but
+  fine for a non-real-time tool.
+
+## Choosing the right mode by cadence
+
+| How often you run | Recommended approach |
+|---|---|
+| A few reports (one-off drafting) | Quota bump (#1) + off-hours / retry (#3). **Don't** pay for permanent PT. |
+| Bulk onboarding (many reports/tenants) | **Temporary** Provisioned Throughput (#2) for the onboarding window, then release. |
+| Frequent / ongoing | Provisioned Throughput or a dedicated endpoint (#2). |
+
+## Quick checklist
+
+1. Confirm it's throttling: `REQUEST_LIMIT_EXCEEDED` on a specific model in the logs.
+2. One-off? → run off-hours and/or re-run (#3).
+3. Recurring or time-critical? → request a higher FMAPI tier (#1).
+4. Bulk onboarding? → temporary Provisioned Throughput for the window (#2).
+5. Still failing after the token expired mid-run (`Embedding API error 403`)? → that's
+   a *consequence* of a too-long throttled run; fixing the throttling (above) also fixes it.

--- a/src/docs/powerbi/thin-report-and-source-resolution.md
+++ b/src/docs/powerbi/thin-report-and-source-resolution.md
@@ -1,0 +1,118 @@
+# Power BI: thin reports, source tables, and what Kasal can convert
+
+When Kasal converts a Power BI model into UC Metric Views, the single most
+important factor for how much converts is **whether the model carries its source
+tables**. This guide explains why some models convert fully, why others produce few
+or no metric views, how to tell which case you are in, and what to do about it.
+
+> **The short version:** a UC Metric View must be built on a physical table
+> (`catalog.schema.table`). If your Power BI model contains the queries that point at
+> those tables (its "M-Queries"), Kasal finds them automatically and conversion works
+> well. If your report is a **thin layer on a separate/upstream semantic model**, the
+> source tables are not in what Kasal extracted — so point Kasal at the **underlying
+> model** instead of the thin report. If the underlying model is unreachable, you can
+> supply the table names manually, but **some tables/measures may be missing**.
+
+---
+
+## 1. Three kinds of Power BI model (and how well each converts)
+
+| Your model is… | Contains source tables (M-Queries)? | Kasal result |
+|---|---|---|
+| **A. Report on a real data connection** (Get Data → Databricks / SQL / etc.) | ✅ yes — Power BI wrote the M-Query for you | **Converts well, automatically.** Source tables auto-detected. |
+| **B. Thin report on a separate/upstream semantic model** (live connection to a published dataset, an Analysis Services / lakehouse model) | ❌ no — the model with the queries lives elsewhere | **Few or no metric views** unless you point Kasal at the upstream model. |
+| **C. Hand-entered / calculated tables** ("Enter Data", DAX calculated tables) | ❌ no physical table exists at all | **Not convertible** — the data lives only inside the report. |
+
+Case A is the common, happy path. Case B is the one this guide is really about — it
+looks like a failure but usually isn't: the data *is* convertible, you were just
+pointed at the wrong artifact. Case C genuinely cannot be converted (there is no
+warehouse table behind it).
+
+---
+
+## 2. Why a thin report (case B) produces few/no metric views
+
+A thin report contains **measures and slicers**, but **not** the physical tables —
+those live in the upstream model it connects to. Kasal extracts what the report
+carries, finds no source tables (no M-Queries) and no physical column references,
+and therefore cannot build metric views on them. It falls back to emitting a raw
+extract of the measures instead of inventing tables it can't see.
+
+This is Kasal behaving correctly — it will **not** guess a table name and emit SQL
+that might be silently wrong. The fix is to give it the model that actually has the
+tables.
+
+---
+
+## 3. How to check which case you are in
+
+**Fastest — run the conversion and read the signature.** If Kasal produces **0
+metric views** and the extract shows **no M-Queries / no source tables** and mostly
+slicer-style measures (`SELECTEDVALUE`, `SWITCH`), you are in **case B** (thin
+report). A healthy case-A model produces metric views with real `source:` tables.
+
+**In the Power BI Service (UI, no code):**
+- Open the workspace → select the report → **Lineage view**. A thin report shows an
+  arrow to a **separate dataset** (often in another workspace) — that dataset is your
+  underlying model.
+- Or report → **Settings** → it names the dataset it is built on. If that dataset is
+  not the one you pointed Kasal at, that is the model to use.
+
+**Via the Power BI REST API (what a future Kasal version will automate):**
+```
+GET /v1.0/myorg/groups/{workspace_id}/reports/{report_id}
+      → returns "datasetId"  (the dataset THIS report uses)
+GET /v1.0/myorg/groups/{workspace_id}/datasets/{dataset_id}
+      → indicates whether it is a live connection / DirectQuery to another dataset
+```
+If the report's `datasetId` lives in another workspace, or the dataset is a
+DirectQuery-to-dataset, that **target** is the model to convert.
+
+---
+
+## 4. What to do about a thin report
+
+**Preferred — point Kasal at the underlying model.** A thin report and its upstream
+model are two different datasets with two different `dataset_id`s. Run the
+conversion against the **upstream model's** `dataset_id` (the one lineage points to),
+not the thin report's. That model contains the M-Queries, physical tables, and
+relationships — i.e. the full case-A experience. **No manual mapping needed.**
+
+**Fallback — supply the source tables manually.** If you cannot reach the upstream
+model (e.g. it is an external Analysis Services cube, or you lack access to that
+dataset), you can provide a **source-table override map** in the Config Editor:
+each report table → its physical `catalog.schema.table`. Kasal then builds
+best-effort metric views for the measures that are real aggregations.
+
+> ⚠️ **Best-effort has limits — tables and measures may be missing.** When Kasal
+> works from a thin report (with or without a manual override map) rather than the
+> full underlying model, it can only convert what it can resolve:
+> - Tables you don't map are **skipped**.
+> - Measures that are slicer/selector logic (`SELECTEDVALUE`, `SWITCH`,
+>   `ALLSELECTED`), or that reference other measures, or that use table operations
+>   (`COUNTROWS(SUMMARIZE(...))`) may **not convert** — they have no static SQL
+>   equivalent.
+> - Every best-effort measure is flagged `TODO: verify` and must be reviewed before
+>   deployment.
+> This path is a head start, not a complete migration. For completeness, use the
+> underlying model.
+
+---
+
+## 5. Summary decision guide
+
+```
+Ran conversion → got metric views with real source tables?
+├─ Yes → Case A. You're done; review measures normally.
+└─ No / very few, no M-Queries in the extract → Case B or C.
+     ├─ Does lineage show an upstream dataset you can access?
+     │    ├─ Yes → re-run against that dataset_id (best result).  ← do this
+     │    └─ No  → supply a source-table override map (best-effort;
+     │             expect missing tables/measures, all flagged TODO: verify).
+     └─ Tables are hand-entered / calculated only → Case C, not convertible.
+```
+
+**Bottom line:** most "no metric views" outcomes are a thin report pointed at the
+wrong artifact, not a conversion failure. Point Kasal at the underlying semantic
+model and it converts like any other; only fall back to manual source mapping when
+that model is genuinely out of reach — and expect gaps when you do.

--- a/src/docs/powerbi/ucmv-coverage-evaluation-and-roadmap.md
+++ b/src/docs/powerbi/ucmv-coverage-evaluation-and-roadmap.md
@@ -1,0 +1,105 @@
+# PBI → UCMV: coverage evaluation and best-effort roadmap (SC / PAAT / DCC)
+
+Consolidated summary of three CCHBC dataset runs (2026-07-28), each analysed
+against the current `feat/pbi-ucmv-fixes-v2` behaviour, plus the concrete repo
+changes they imply. Source analyses live with the run artifacts
+(`EVALUATION_README.md` / `DIAGNOSTIC_README.md` per dataset); this doc is the
+in-repo, actionable digest.
+
+## TL;DR
+
+| Dataset | Model type | Source tables (M-Query) | Measures resolved to SQL | UCMVs | Best-effort ceiling |
+|---------|-----------|:-----------------------:|:------------------------:|:-----:|:-------------------:|
+| **SC** | dimensional data model | ✅ 86/86 transpiled + validated | full | **30 views, 476/476 measures, 100%** | n/a (already works) |
+| **PAAT** | report skin on external warehouse | ❌ 0/50 | **46** (ready) | 0 (fallback) | ~10–19% |
+| **DCC** | KPI / data-quality report | ❌ 0/17 | **0** | 0 (fallback) | ~0–5% |
+
+- **SC is the success baseline.** With real transpiled source tables, the pipeline
+  emits perfect measures (100% exact SQL match to ground truth) and improved on the
+  prior run (91% → 100%; +41 measures recovered). Coverage of *all* source measures
+  = 74% (476 emitted / 642); the other 166 are honestly documented as not-emitted.
+- **PAAT / DCC produce no UCMVs — correctly, not as a bug.** Both are Power BI
+  *report* layers, not data models: no M-Query source tables, no physical column
+  refs. The pipeline reaches its designed fallback (`_build_fallback_extract`) and
+  emits raw material instead of silently-wrong views.
+
+## Why PAAT and DCC are hard (and what's fixable)
+
+Both lack the three things SC had: M-Query source tables, physical `table_refs`, and
+measures that reduce to single-table aggregates.
+
+- **Fixable with customer input:** supply the physical source-table names
+  (`fact_source_map`). This unlocks PAAT's 46 already-resolved measures. It is a
+  *prerequisite* for DCC but not sufficient.
+- **Fixable with real engineering (DCC-specific):** measure-on-measure composition
+  (40% of DCC measures reference other measures) + a `COUNTROWS`/`SUMMARIZE`/
+  `CALCULATETABLE` → SQL translator.
+- **Never fixable:** slicer/selector measures (`SELECTEDVALUE`/`SWITCH`/`ALLSELECTED`
+  — 20% PAAT, 32% DCC), disconnected/parameter tables, and text/format measures.
+  These are report interaction state, not data — no static SQL equivalent exists.
+
+## What to adapt in the repo
+
+Ordered by leverage. Phases 1–3 are the shared "best-effort UCMV" feature that
+turns PAAT's "0 views + JSON dump" into "a few real fact views + an honest gap".
+All gated behind an explicit `allow_best_effort` flag so today's default contract
+("never emit silently-wrong SQL") is unchanged when off.
+
+### 1. `fact_source_map` supply mechanism — THE unlock (no code path works without it)
+- **`pipeline_config_generator_tool.py`** — add `fact_source_map` and
+  `allow_best_effort` to the `config_keys` tuple (~L110–121); read via `_get(...)`.
+  Flows through `tool_configs`, no API route change.
+- **`generate_config.py`** — allow `source_table` to come from `fact_source_map`
+  when M-Query extraction yielded nothing (today `mquery_expression` is empty for
+  these datasets, so `_enrich_source_tables_from_mquery` has nothing to parse).
+- **UI** (`PipelineConfigGeneratorConfigSelector.tsx`) — `allow_best_effort` Switch +
+  a key→value editor (PBI table → physical table); mirror the warehouse-enrichment
+  toggle wiring.
+
+### 2. Best-effort view generation
+- **`uc_metric_view_generator_tool.py`** — before building `output` (~L369), when
+  `yaml_output` is empty AND `allow_best_effort` AND `fact_source_map` present, call
+  a new `_build_best_effort_views(...)`. It emits one thin UCMV per supplied source
+  from measures that ALREADY resolved to real aggregatable SQL (reuse
+  `measure_resolutions`; reuse the `base_expr` + `FILTER (WHERE …)` assembly from
+  `generate_config.py` L708–712). Every emitted measure carries a `TODO: verify`
+  comment — it is a draft produced without a validated transpiled source.
+- Never emit a `TODO`/selector measure as SQL — those go to not-emitted (step 3).
+
+### 3. Honest not-emitted documentation (reuse SC machinery)
+- Extend `_build_fallback_extract(...)` to also render the SC-style
+  `# ─── Not emitted as measures (N) — grouped by reason ───` block per source, so
+  the existing `evaluate_ucmv.py` coverage counter scores PAAT/DCC for free. Reason
+  buckets: `selector logic`, `unresolved ref`, `measure-on-measure`,
+  `disconnected/no source`, `text/format`.
+
+### 4. (DCC-only, larger, defer) measure composition + table-expression translation
+- **Phase 5 — measure composition:** inline `[Measure]` references by resolving each
+  referenced measure's own SQL (dependency graph). Extend the existing SC
+  `MEASURE(...)` composition. Only helps once leaf measures resolve to real columns.
+- **Phase 6 — table-expression translator:** `COUNTROWS`/`SUMMARIZE`/`CALCULATETABLE`
+  → SQL `COUNT`/`GROUP BY`/subquery. Substantial DAX-engine work; gated, best-effort,
+  `TODO: verify`. `ALLSELECTED`/slicer-context measures stay out of scope.
+- **ROI note:** Phases 5–6 buy DCC only ~0–5% coverage. Build only if
+  measure-on-measure KPI models prove a common customer pattern.
+
+### 5. Automated evaluation harness (adopt as CI, no product code)
+- `evaluate_ucmv.py` (measure-vs-measure vs a validated set) is the eval. Gates:
+  **correctness** `recall==100 && mismatch==0` (never emit wrong SQL) and
+  **coverage never-regress** `coverage_pct >= previous`. Coverage <100% is expected
+  (untranslatable DAX); the gate is that it must not drop.
+
+## Recommendation
+
+Build **1–3** first (the PAAT best-effort feature) behind `allow_best_effort`;
+it is high-leverage, low-risk, and reuses existing machinery. Defer **4** (DCC
+composition/table-expr) until there's demand — its ceiling is low. Set customer
+expectations up front: for report-layer models, UCMV coverage is inherently bounded,
+and physical source-table names are a required input Kasal cannot invent.
+
+---
+
+_Digest of: SC `EVALUATION_README.md` (30 views, 100% measure match, 74% coverage,
++41 vs prior run); PAAT `DIAGNOSTIC_README.md` (46 resolvable, ~10–19% ceiling);
+DCC `DIAGNOSTIC_README.md` (0 resolvable, measure-on-measure web, ~0–5% ceiling).
+Analyses run 2026-07-28/29 on CCHBC crew outputs._

--- a/src/docs/powerbi/ucmv-coverage-evaluation-and-roadmap.md
+++ b/src/docs/powerbi/ucmv-coverage-evaluation-and-roadmap.md
@@ -38,12 +38,37 @@ measures that reduce to single-table aggregates.
   — 20% PAAT, 32% DCC), disconnected/parameter tables, and text/format measures.
   These are report interaction state, not data — no static SQL equivalent exists.
 
+## The better fix first: resolve the upstream semantic model
+
+PAAT/DCC are **thin reports on an upstream/external semantic model** — the model
+that holds the M-Queries and physical tables is a *separate dataset*, not the one
+these runs extracted. So the highest-value fix is **not** to manually re-supply the
+missing sources; it is to **extract the underlying model's `dataset_id`** (which has
+everything, like SC did). Kasal already extracts by `dataset_id` via `executeQueries`
+(`powerbi_semantic_model_dax_tool.py`), so this is largely an *input* choice today
+and an *automation* opportunity tomorrow:
+
+- **Today (operational):** point the run at the upstream model's `dataset_id`
+  (found via Power BI lineage / `GET /reports/{id}` → `datasetId`). Full case-A
+  extraction, no code change.
+- **Feature (automate):** thin-report detection + upstream resolution — when
+  extraction finds no M-Queries, read the report's `datasetId`, check whether it is a
+  live-connection / DirectQuery-to-dataset, and **follow it to the base model** before
+  extracting. The REST surface exists (`/reports/{id}`, `/datasets/{id}`); Kasal does
+  not chase the upstream link yet — that is the gap.
+
+`fact_source_map` (below) is the **fallback-of-the-fallback**: only for when the
+upstream model is genuinely unreachable (external AAS/SSAS cube, or no access to the
+dataset). See the customer-facing guide **`thin-report-and-source-resolution.md`**
+(exposed in the in-app Documentation → Power BI migration).
+
 ## What to adapt in the repo
 
 Ordered by leverage. Phases 1–3 are the shared "best-effort UCMV" feature that
 turns PAAT's "0 views + JSON dump" into "a few real fact views + an honest gap".
 All gated behind an explicit `allow_best_effort` flag so today's default contract
-("never emit silently-wrong SQL") is unchanged when off.
+("never emit silently-wrong SQL") is unchanged when off. **Prefer upstream-model
+resolution (above) over best-effort whenever the base model is reachable.**
 
 ### 1. `fact_source_map` supply mechanism — THE unlock (no code path works without it)
 - **`pipeline_config_generator_tool.py`** — add `fact_source_map` and

--- a/src/docs/powerbi/ucmv-reevaluation-recoverable-measures.md
+++ b/src/docs/powerbi/ucmv-reevaluation-recoverable-measures.md
@@ -1,0 +1,130 @@
+# UCMV Re-evaluation — surfacing newly-recoverable measures
+
+## Why
+
+Kasal's DAX→UC-Metric-View capability keeps improving: new patterns in
+`dax_translator.py`, a better LLM-first path in `dax_llm_fallback.py`, and an
+evolving skill corpus under `metric_view_utils/skills/`. But those gains only ever
+helped **new** conversions. A model converted last month still shows the measures
+that failed *back then*, even though the transpiler can handle several of them today.
+
+This feature closes that loop: for each already-converted model, re-try **only the
+measures that previously failed** with today's transpiler, and surface the ones that
+are now translatable so a human can choose to re-transpile them.
+
+Credit: idea from Kyle Hale.
+
+## What makes it feasible
+
+Everything needed is already persisted (no new extraction round-trip, no PowerBI API
+calls):
+
+| Stored where | What |
+|---|---|
+| `PowerBIExtraction` (`src/models/powerbi_extraction.py`) | `measures` (with DAX), `admin_tables` (M-queries), `relationships`, **`proposed_config`** (the pipeline config), keyed by `workspace_id`/`dataset_id`/`report_id`, `group_id`, `created_at` |
+| `ConversionHistory` (`src/models/conversion.py`) | `input_data`, `output_data`, `configuration` per conversion |
+| UCMV generator output | `untranslatable_items[]` — per measure: `original_name`, `dax_expression`, `skip_reason`, `category`, `dax_class`, `referenced_by` |
+| `PowerBIExtractionRepository` | `get_latest_for_dataset()`, `find_by_group()` already exist |
+
+## Design decisions (and one rejected idea)
+
+**Re-try only previously-FAILED measures.** Never re-transpile a measure that already
+succeeded — that risks silently changing a validated measure. Hard rule.
+
+**Trigger on a capability fingerprint + actual re-run, NOT on a skill-file diff.**
+The tempting version ("what's new in the skill files?") was rejected:
+1. Most capability gains are in **code** (`dax_translator` patterns, the LLM-first
+   path, emitters) — not the `.md` skill files. Diffing skills alone misses them.
+2. Mapping "this skill paragraph changed" → "measure X now works" is guesswork; it
+   would propose measures that still fail and miss ones that now work.
+
+Instead: hash the whole capability surface (skill corpus + translator/fallback source
++ registered pattern names) into a **fingerprint**. If it hasn't changed since the
+stored run, there is nothing to gain — skip. If it has, **just re-run the transpiler
+and compare**. Ground truth beats inference, and the deterministic fast-path makes it
+cheap.
+
+**Note:** `ConversionHistory.converter_version` exists as a column but is never
+written anywhere in the codebase, so it cannot be the gate today. The fingerprint
+replaces it (and we record it going forward).
+
+**Cost + noise controls:**
+- **Category gate** — `_categorize_untranslatable` (yaml_emitter) already separates
+  *impossible* (display artifact, slicer/scalar helper, prior-year time-intelligence,
+  disconnected-slicer dispatch) from *expressible* (fixed-LOD/ALLEXCEPT,
+  group-then-aggregate/SUMMARIZE, top-N/TOPN, distinct-count, complex-DAX). Retry the
+  expressible buckets; skip the impossible ones by default (`include_impossible` opt-in).
+- **Deterministic-first** — run `translate(..., trivial_only=True)` first; only escalate
+  to the LLM path when explicitly enabled (`use_llm`), so a scheduled sweep across many
+  datasets doesn't silently burn tokens.
+- **Impact ordering** — sort by `referenced_by` desc so high-dependency measures surface
+  first.
+- **Suppression via review annotations** — the "Not transpiled" review panel already
+  persists `untranslatable_review` (status `wont_fix` / `hand_written`). Those are
+  skipped, so the sweep stops proposing what a human already dismissed.
+
+**Proposes only — never auto-applies.** The tool produces a report. Re-transpiling
+happens through the existing UCMV routes, human-triggered.
+
+## Implementation
+
+### 1. `metric_view_utils/capability_version.py` (new)
+- `pattern_names()` — registered translator pattern names (capability surface).
+- `capability_fingerprint()` — stable short hash over: every skill-corpus file's
+  content, the source of `dax_translator.py` + `dax_llm_fallback.py`, and the pattern
+  names. Cached per process. Fail-open (returns a sentinel on error — never blocks).
+- `capability_summary()` — `{fingerprint, pattern_count, skill_files}` for the report.
+
+### 2. `metric_view_utils/reevaluate.py` (new)
+- `RETRYABLE_CATEGORIES` / `IMPOSSIBLE_CATEGORIES` — the category gate, aligned with
+  `_categorize_untranslatable`'s buckets.
+- `is_retryable(item, include_impossible=False)` — category + annotation suppression.
+- `reevaluate_measures(untranslatable_items, config, *, review=None,
+  include_impossible=False, use_llm=False, limit=None)` →
+  `{newly_translatable: [...], still_failing: [...], skipped: [...], counts: {...}}`.
+  Builds one `DAXTranslator(config)` from the stored `proposed_config` and calls
+  `translate()` per previously-failed measure; a non-empty `sql_expr` = recovered.
+  Each recovered row carries `new_sql`, the `previous_skip_reason`, and `referenced_by`.
+
+### 3. `UCMVReevaluationTool` (new custom tool)
+Loads the latest `PowerBIExtraction` per dataset (group-scoped), pulls its stored
+untranslatable items + `proposed_config`, runs `reevaluate_measures`, and emits:
+```json
+{"capability": {...}, "datasets": [{"dataset_id", "workspace_id", "view_names",
+ "fingerprint_changed", "newly_translatable": [...], "still_failing_count",
+ "skipped_count"}], "summary": {"datasets_scanned", "measures_recovered", ...}}
+```
+Schedulable or manually triggered by a crew. Read-only w.r.t. UCMV state.
+
+### 4. Frontend `ReevaluationResultViewer.tsx` (new)
+Detection helper + per-dataset accordions listing recovered measures: **Measure |
+Previously failed because | New SQL | Used by**. Wired into `ShowResult` alongside the
+existing UCMV/Validator viewers. Read-only proposal.
+
+## Critical files
+
+- `src/backend/src/engines/crewai/tools/custom/metric_view_utils/capability_version.py` (new)
+- `src/backend/src/engines/crewai/tools/custom/metric_view_utils/reevaluate.py` (new)
+- `src/backend/src/engines/crewai/tools/custom/ucmv_reevaluation_tool.py` (new)
+- `src/frontend/src/components/Jobs/ReevaluationResultViewer.tsx` (new)
+- `src/frontend/src/components/Jobs/ShowResult.tsx` (wire the viewer)
+- Reused: `metric_view_utils/dax_translator.py`, `yaml_emitter._categorize_untranslatable`,
+  `repositories/powerbi_extraction_repository.py`
+
+## Verification
+
+- Backend: `.venv/bin/python -m pytest tests/unit/engines/crewai/tools/custom/ -k "reevaluat or capability" -q`
+- Frontend: `npm run test:run -- src/components/Jobs/ReevaluationResultViewer.test.tsx`, then `npm run tsc` && `npm run lint`
+- End-to-end: run the re-evaluation tool against a group that has prior extractions →
+  report lists datasets with recovered measures + their new SQL; a dataset whose
+  fingerprint is unchanged reports `fingerprint_changed: false` with nothing proposed.
+
+## Known limitations
+
+- **Cost**: escalating to the LLM path per retried measure costs tokens; that is why
+  `use_llm` is opt-in and the category gate exists.
+- **Stale `proposed_config`**: if the underlying UC tables changed since the original
+  run, recovered SQL may not validate — the report is a *proposal*, and re-transpiling
+  through the normal route re-validates.
+- **"Latest per dataset"** is `created_at` desc; a dataset converted from multiple
+  reports may need `report_id` disambiguation.

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -211,7 +211,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -574,7 +573,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -618,9 +616,42 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -630,6 +661,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -692,7 +724,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -736,7 +767,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1130,7 +1160,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -1367,6 +1396,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -1434,6 +1464,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -1777,6 +1808,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1794,6 +1826,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1811,6 +1844,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1828,6 +1862,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1845,6 +1880,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1862,6 +1898,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1879,6 +1916,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1896,6 +1934,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1913,6 +1952,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1930,6 +1970,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1947,6 +1988,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1964,6 +2006,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1978,6 +2021,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
@@ -1994,6 +2038,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -2006,6 +2051,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2023,6 +2069,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2054,6 +2101,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2695,7 +2743,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2842,7 +2889,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -3100,7 +3146,6 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -3274,7 +3319,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3887,7 +3931,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4656,15 +4699,13 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cytoscape": {
       "version": "3.33.1",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5075,7 +5116,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5647,7 +5687,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6790,7 +6829,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -7479,7 +7517,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7760,8 +7797,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -14931,7 +14967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -15309,7 +15344,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15322,7 +15356,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -15517,7 +15550,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15756,8 +15788,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -16543,6 +16574,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.137.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -16577,7 +16609,8 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/rollup-plugin-visualizer": {
       "version": "5.14.0",
@@ -17637,7 +17670,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18050,7 +18082,6 @@
       "deprecated": "Use 7.3.1 for migration purposes. For the most recent updates, migrate to Vite 8 once you're ready.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.73.0",
         "fdir": "^6.4.4",
@@ -18388,7 +18419,6 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -18804,7 +18834,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/frontend/public/docs/powerbi/thin-report-and-source-resolution.md
+++ b/src/frontend/public/docs/powerbi/thin-report-and-source-resolution.md
@@ -1,0 +1,118 @@
+# Power BI: thin reports, source tables, and what Kasal can convert
+
+When Kasal converts a Power BI model into UC Metric Views, the single most
+important factor for how much converts is **whether the model carries its source
+tables**. This guide explains why some models convert fully, why others produce few
+or no metric views, how to tell which case you are in, and what to do about it.
+
+> **The short version:** a UC Metric View must be built on a physical table
+> (`catalog.schema.table`). If your Power BI model contains the queries that point at
+> those tables (its "M-Queries"), Kasal finds them automatically and conversion works
+> well. If your report is a **thin layer on a separate/upstream semantic model**, the
+> source tables are not in what Kasal extracted — so point Kasal at the **underlying
+> model** instead of the thin report. If the underlying model is unreachable, you can
+> supply the table names manually, but **some tables/measures may be missing**.
+
+---
+
+## 1. Three kinds of Power BI model (and how well each converts)
+
+| Your model is… | Contains source tables (M-Queries)? | Kasal result |
+|---|---|---|
+| **A. Report on a real data connection** (Get Data → Databricks / SQL / etc.) | ✅ yes — Power BI wrote the M-Query for you | **Converts well, automatically.** Source tables auto-detected. |
+| **B. Thin report on a separate/upstream semantic model** (live connection to a published dataset, an Analysis Services / lakehouse model) | ❌ no — the model with the queries lives elsewhere | **Few or no metric views** unless you point Kasal at the upstream model. |
+| **C. Hand-entered / calculated tables** ("Enter Data", DAX calculated tables) | ❌ no physical table exists at all | **Not convertible** — the data lives only inside the report. |
+
+Case A is the common, happy path. Case B is the one this guide is really about — it
+looks like a failure but usually isn't: the data *is* convertible, you were just
+pointed at the wrong artifact. Case C genuinely cannot be converted (there is no
+warehouse table behind it).
+
+---
+
+## 2. Why a thin report (case B) produces few/no metric views
+
+A thin report contains **measures and slicers**, but **not** the physical tables —
+those live in the upstream model it connects to. Kasal extracts what the report
+carries, finds no source tables (no M-Queries) and no physical column references,
+and therefore cannot build metric views on them. It falls back to emitting a raw
+extract of the measures instead of inventing tables it can't see.
+
+This is Kasal behaving correctly — it will **not** guess a table name and emit SQL
+that might be silently wrong. The fix is to give it the model that actually has the
+tables.
+
+---
+
+## 3. How to check which case you are in
+
+**Fastest — run the conversion and read the signature.** If Kasal produces **0
+metric views** and the extract shows **no M-Queries / no source tables** and mostly
+slicer-style measures (`SELECTEDVALUE`, `SWITCH`), you are in **case B** (thin
+report). A healthy case-A model produces metric views with real `source:` tables.
+
+**In the Power BI Service (UI, no code):**
+- Open the workspace → select the report → **Lineage view**. A thin report shows an
+  arrow to a **separate dataset** (often in another workspace) — that dataset is your
+  underlying model.
+- Or report → **Settings** → it names the dataset it is built on. If that dataset is
+  not the one you pointed Kasal at, that is the model to use.
+
+**Via the Power BI REST API (what a future Kasal version will automate):**
+```
+GET /v1.0/myorg/groups/{workspace_id}/reports/{report_id}
+      → returns "datasetId"  (the dataset THIS report uses)
+GET /v1.0/myorg/groups/{workspace_id}/datasets/{dataset_id}
+      → indicates whether it is a live connection / DirectQuery to another dataset
+```
+If the report's `datasetId` lives in another workspace, or the dataset is a
+DirectQuery-to-dataset, that **target** is the model to convert.
+
+---
+
+## 4. What to do about a thin report
+
+**Preferred — point Kasal at the underlying model.** A thin report and its upstream
+model are two different datasets with two different `dataset_id`s. Run the
+conversion against the **upstream model's** `dataset_id` (the one lineage points to),
+not the thin report's. That model contains the M-Queries, physical tables, and
+relationships — i.e. the full case-A experience. **No manual mapping needed.**
+
+**Fallback — supply the source tables manually.** If you cannot reach the upstream
+model (e.g. it is an external Analysis Services cube, or you lack access to that
+dataset), you can provide a **source-table override map** in the Config Editor:
+each report table → its physical `catalog.schema.table`. Kasal then builds
+best-effort metric views for the measures that are real aggregations.
+
+> ⚠️ **Best-effort has limits — tables and measures may be missing.** When Kasal
+> works from a thin report (with or without a manual override map) rather than the
+> full underlying model, it can only convert what it can resolve:
+> - Tables you don't map are **skipped**.
+> - Measures that are slicer/selector logic (`SELECTEDVALUE`, `SWITCH`,
+>   `ALLSELECTED`), or that reference other measures, or that use table operations
+>   (`COUNTROWS(SUMMARIZE(...))`) may **not convert** — they have no static SQL
+>   equivalent.
+> - Every best-effort measure is flagged `TODO: verify` and must be reviewed before
+>   deployment.
+> This path is a head start, not a complete migration. For completeness, use the
+> underlying model.
+
+---
+
+## 5. Summary decision guide
+
+```
+Ran conversion → got metric views with real source tables?
+├─ Yes → Case A. You're done; review measures normally.
+└─ No / very few, no M-Queries in the extract → Case B or C.
+     ├─ Does lineage show an upstream dataset you can access?
+     │    ├─ Yes → re-run against that dataset_id (best result).  ← do this
+     │    └─ No  → supply a source-table override map (best-effort;
+     │             expect missing tables/measures, all flagged TODO: verify).
+     └─ Tables are hand-entered / calculated only → Case C, not convertible.
+```
+
+**Bottom line:** most "no metric views" outcomes are a thin report pointed at the
+wrong artifact, not a conversion failure. Point Kasal at the underlying semantic
+model and it converts like any other; only fall back to manual source mapping when
+that model is genuinely out of reach — and expect gaps when you do.

--- a/src/frontend/src/api/PromptOptimizationService.test.ts
+++ b/src/frontend/src/api/PromptOptimizationService.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for PromptOptimizationService.
+ *
+ * Covers every method's endpoint, payload shape (undefined-stripping for
+ * optional fields), URL encoding of judge names, and response mapping
+ * (list unwrapping with empty-list fallbacks, boolean coercion).
+ */
+
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { PromptOptimizationService } from './PromptOptimizationService';
+import apiClient from '../config/api/ApiConfig';
+
+vi.mock('../config/api/ApiConfig', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockGet = apiClient.get as Mock;
+const mockPost = apiClient.post as Mock;
+const mockPut = apiClient.put as Mock;
+const mockDelete = apiClient.delete as Mock;
+
+const JSON_HEADERS = { headers: { 'Content-Type': 'application/json' } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('startOptimization', () => {
+  it('posts the request to /optimize and returns the ack', async () => {
+    const ack = { run_id: 'r1', status: 'pending', dataset_size: 5 };
+    mockPost.mockResolvedValueOnce({ data: ack });
+    const request = { template_name: 'detect_intent', examples: ['a', 'b'] };
+    const result = await PromptOptimizationService.startOptimization(request);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/prompt-optimization/optimize',
+      request,
+      JSON_HEADERS,
+    );
+    expect(result).toEqual(ack);
+  });
+});
+
+describe('startCrewOptimization', () => {
+  it('posts the request to /optimize-crew', async () => {
+    const ack = { run_id: 'r2', status: 'pending', dataset_size: 1 };
+    mockPost.mockResolvedValueOnce({ data: ack });
+    const request = { crew_id: 'c1', max_metric_calls: 10 };
+    const result = await PromptOptimizationService.startCrewOptimization(request);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/prompt-optimization/optimize-crew',
+      request,
+      JSON_HEADERS,
+    );
+    expect(result).toEqual(ack);
+  });
+});
+
+describe('listRuns', () => {
+  it('unwraps the runs array', async () => {
+    const runs = [{ run_id: 'r1' }];
+    mockGet.mockResolvedValueOnce({ data: { runs } });
+    expect(await PromptOptimizationService.listRuns()).toEqual(runs);
+    expect(mockGet).toHaveBeenCalledWith('/prompt-optimization/runs');
+  });
+
+  it('returns [] when the payload is empty', async () => {
+    mockGet.mockResolvedValueOnce({ data: undefined });
+    expect(await PromptOptimizationService.listRuns()).toEqual([]);
+  });
+});
+
+describe('getRun', () => {
+  it('fetches a single run by id', async () => {
+    const run = { run_id: 'r1', status: 'completed' };
+    mockGet.mockResolvedValueOnce({ data: run });
+    expect(await PromptOptimizationService.getRun('r1')).toEqual(run);
+    expect(mockGet).toHaveBeenCalledWith('/prompt-optimization/runs/r1');
+  });
+});
+
+describe('listCrewEvals', () => {
+  it('unwraps evals for the crew', async () => {
+    const evals = [{ trace_id: 't1', deliverable: 'x', assessment_count: 0 }];
+    mockGet.mockResolvedValueOnce({ data: { evals } });
+    expect(await PromptOptimizationService.listCrewEvals('crew1')).toEqual(evals);
+    expect(mockGet).toHaveBeenCalledWith('/prompt-optimization/crew-evals/crew1');
+  });
+
+  it('returns [] when the payload is empty', async () => {
+    mockGet.mockResolvedValueOnce({ data: {} });
+    expect(await PromptOptimizationService.listCrewEvals('crew1')).toEqual([]);
+  });
+});
+
+describe('addEvalFeedback', () => {
+  it('posts grade, comment and expectation to the trace feedback endpoint', async () => {
+    mockPost.mockResolvedValueOnce({ data: { ok: true } });
+    const ok = await PromptOptimizationService.addEvalFeedback(
+      't1',
+      7,
+      'good but wrong region',
+      'german side only',
+    );
+    expect(ok).toBe(true);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/prompt-optimization/crew-evals/t1/feedback',
+      { value: 7, comment: 'good but wrong region', expectation: 'german side only' },
+      JSON_HEADERS,
+    );
+  });
+
+  it('strips empty optional fields to undefined', async () => {
+    mockPost.mockResolvedValueOnce({ data: { ok: true } });
+    await PromptOptimizationService.addEvalFeedback('t1', undefined, '', '');
+    expect(mockPost).toHaveBeenCalledWith(
+      '/prompt-optimization/crew-evals/t1/feedback',
+      { value: undefined, comment: undefined, expectation: undefined },
+      JSON_HEADERS,
+    );
+  });
+
+  it('keeps a zero grade (0 is a valid harsh grade, not "missing")', async () => {
+    mockPost.mockResolvedValueOnce({ data: { ok: true } });
+    await PromptOptimizationService.addEvalFeedback('t1', 0);
+    const body = mockPost.mock.calls[0][1];
+    expect(body.value).toBe(0);
+  });
+
+  it('coerces a missing ok to false', async () => {
+    mockPost.mockResolvedValueOnce({ data: {} });
+    expect(await PromptOptimizationService.addEvalFeedback('t1', 5)).toBe(false);
+  });
+});
+
+describe('judges', () => {
+  it('listJudges unwraps the judges array with [] fallback', async () => {
+    const judges = [{ name: 'acc' }];
+    mockGet.mockResolvedValueOnce({ data: { judges } });
+    expect(await PromptOptimizationService.listJudges()).toEqual(judges);
+    expect(mockGet).toHaveBeenCalledWith('/prompt-optimization/judges');
+    mockGet.mockResolvedValueOnce({ data: undefined });
+    expect(await PromptOptimizationService.listJudges()).toEqual([]);
+  });
+
+  it('createJudge posts name/instructions and strips empty model/crew', async () => {
+    mockPost.mockResolvedValueOnce({ data: { name: 'acc' } });
+    await PromptOptimizationService.createJudge('acc', 'criteria');
+    expect(mockPost).toHaveBeenCalledWith(
+      '/prompt-optimization/judges',
+      { name: 'acc', instructions: 'criteria', model: undefined, crew_id: undefined },
+      JSON_HEADERS,
+    );
+  });
+
+  it('createJudge forwards model and crew id when provided', async () => {
+    mockPost.mockResolvedValueOnce({ data: { name: 'acc' } });
+    await PromptOptimizationService.createJudge('acc', 'criteria', 'qwen', 'crew-1');
+    expect(mockPost.mock.calls[0][1]).toEqual({
+      name: 'acc',
+      instructions: 'criteria',
+      model: 'qwen',
+      crew_id: 'crew-1',
+    });
+  });
+
+  it('assignJudge posts the crew id under the encoded judge name', async () => {
+    mockPost.mockResolvedValueOnce({ data: { full_name: 'crew_x__my judge' } });
+    await PromptOptimizationService.assignJudge('my judge', 'crew-1');
+    expect(mockPost).toHaveBeenCalledWith(
+      '/prompt-optimization/judges/my%20judge/assign',
+      { crew_id: 'crew-1' },
+      JSON_HEADERS,
+    );
+  });
+
+  it('updateJudge PUTs changes and strips empty fields', async () => {
+    mockPut.mockResolvedValueOnce({ data: { name: 'acc' } });
+    await PromptOptimizationService.updateJudge('crew_x__acc', {
+      instructions: 'new criteria',
+    });
+    expect(mockPut).toHaveBeenCalledWith(
+      '/prompt-optimization/judges/crew_x__acc',
+      { instructions: 'new criteria', model: undefined },
+      JSON_HEADERS,
+    );
+  });
+
+  it('deleteJudge deletes by encoded name and coerces ok', async () => {
+    mockDelete.mockResolvedValueOnce({ data: { ok: true } });
+    expect(await PromptOptimizationService.deleteJudge('a judge')).toBe(true);
+    expect(mockDelete).toHaveBeenCalledWith(
+      '/prompt-optimization/judges/a%20judge',
+    );
+    mockDelete.mockResolvedValueOnce({ data: {} });
+    expect(await PromptOptimizationService.deleteJudge('a judge')).toBe(false);
+  });
+});
+
+describe('run control', () => {
+  it('cancelRun posts to the cancel endpoint and coerces the flag', async () => {
+    mockPost.mockResolvedValueOnce({ data: { cancelling: true } });
+    expect(await PromptOptimizationService.cancelRun('r1')).toBe(true);
+    expect(mockPost).toHaveBeenCalledWith('/prompt-optimization/runs/r1/cancel');
+    mockPost.mockResolvedValueOnce({ data: {} });
+    expect(await PromptOptimizationService.cancelRun('r1')).toBe(false);
+  });
+
+  it('applyRun posts to the apply endpoint and coerces the flag', async () => {
+    mockPost.mockResolvedValueOnce({ data: { applied: true } });
+    expect(await PromptOptimizationService.applyRun('r1')).toBe(true);
+    expect(mockPost).toHaveBeenCalledWith('/prompt-optimization/runs/r1/apply');
+  });
+});

--- a/src/frontend/src/api/PromptOptimizationService.ts
+++ b/src/frontend/src/api/PromptOptimizationService.ts
@@ -177,6 +177,24 @@ export class PromptOptimizationService {
     return response.data;
   }
 
+  /** Update a judge's instructions and/or model (full registry name).
+   *  Editing a crew-scoped copy changes what that crew's runs use; editing a
+   *  library judge leaves already-assigned copies untouched. */
+  static async updateJudge(
+    name: string,
+    changes: { instructions?: string; model?: string },
+  ): Promise<LLMJudge> {
+    const response = await apiClient.put<LLMJudge>(
+      `/prompt-optimization/judges/${encodeURIComponent(name)}`,
+      {
+        instructions: changes.instructions || undefined,
+        model: changes.model || undefined,
+      },
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    return response.data;
+  }
+
   static async deleteJudge(name: string): Promise<boolean> {
     const response = await apiClient.delete<{ ok: boolean }>(
       `/prompt-optimization/judges/${encodeURIComponent(name)}`,

--- a/src/frontend/src/api/PromptOptimizationService.ts
+++ b/src/frontend/src/api/PromptOptimizationService.ts
@@ -1,0 +1,197 @@
+import apiClient from '../config/api/ApiConfig';
+
+/*
+ * Prompt optimization (GEPA via managed MLflow). A run mines training
+ * examples from the LLM interaction log (or takes them inline), searches
+ * for a better seeded template, and proposes it for explicit
+ * review-and-apply as a group-scoped template override.
+ */
+
+export interface PromptOptimizationStart {
+  run_id: string;
+  status: string;
+  dataset_size: number;
+}
+
+export interface PromptOptimizationRun {
+  run_id: string;
+  template_name: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+  dataset_size: number;
+  model?: string | null;
+  initial_score?: number | null;
+  final_score?: number | null;
+  baseline_template?: string | null;
+  optimized_template?: string | null;
+  error?: string | null;
+  applied: boolean;
+  created_at?: string | null;
+  kind?: 'template' | 'crew' | null;
+  crew_id?: string | null;
+  baseline_fields?: Record<string, string> | null;
+  optimized_fields?: Record<string, string> | null;
+  executions_used?: number | null;
+  execution_cap?: number | null;
+}
+
+export interface LLMJudge {
+  /** Display name (crew prefix stripped). */
+  name: string;
+  /** Registry name (crew-scoped judges carry a crew prefix). */
+  full_name?: string;
+  /** Crew id prefix when the judge is assigned to a crew; null = shared library. */
+  crew_id?: string | null;
+  model?: string | null;
+  instructions?: string;
+}
+
+export interface CrewEval {
+  trace_id: string;
+  timestamp_ms?: number | null;
+  deliverable: string;
+  assessment_count: number;
+}
+
+export interface CrewOptimizationRequest {
+  crew_id: string;
+  model?: string;
+  judge_model?: string;
+  reflection_model?: string;
+  guidance?: string;
+  max_metric_calls?: number;
+  execution_timeout_seconds?: number;
+}
+
+export interface StartOptimizationRequest {
+  template_name: string;
+  model?: string;
+  judge_model?: string;
+  reflection_model?: string;
+  examples?: string[];
+  lookback_days?: number;
+  max_examples?: number;
+  max_metric_calls?: number;
+}
+
+export class PromptOptimizationService {
+  static async startOptimization(
+    request: StartOptimizationRequest,
+  ): Promise<PromptOptimizationStart> {
+    const response = await apiClient.post<PromptOptimizationStart>(
+      '/prompt-optimization/optimize',
+      request,
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    return response.data;
+  }
+
+  /** GEPA over a saved crew — every evaluation EXECUTES the crew for real. */
+  static async startCrewOptimization(
+    request: CrewOptimizationRequest,
+  ): Promise<PromptOptimizationStart> {
+    const response = await apiClient.post<PromptOptimizationStart>(
+      '/prompt-optimization/optimize-crew',
+      request,
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    return response.data;
+  }
+
+  static async listRuns(): Promise<PromptOptimizationRun[]> {
+    const response = await apiClient.get<{ runs: PromptOptimizationRun[] }>(
+      '/prompt-optimization/runs',
+    );
+    return response.data?.runs || [];
+  }
+
+  static async getRun(runId: string): Promise<PromptOptimizationRun> {
+    const response = await apiClient.get<PromptOptimizationRun>(
+      `/prompt-optimization/runs/${runId}`,
+    );
+    return response.data;
+  }
+
+  /** Optimization-evaluation answers for a crew (local MLflow traces). */
+  static async listCrewEvals(crewId: string): Promise<CrewEval[]> {
+    const response = await apiClient.get<{ evals: CrewEval[] }>(
+      `/prompt-optimization/crew-evals/${crewId}`,
+    );
+    return response.data?.evals || [];
+  }
+
+  /** Grade an evaluation answer (Feedback) and/or state what it SHOULD have
+   *  contained (Expectation) — both stored as MLflow assessments. */
+  static async addEvalFeedback(
+    traceId: string,
+    value?: number,
+    comment?: string,
+    expectation?: string,
+  ): Promise<boolean> {
+    const response = await apiClient.post<{ ok: boolean }>(
+      `/prompt-optimization/crew-evals/${traceId}/feedback`,
+      {
+        value: value ?? undefined,
+        comment: comment || undefined,
+        expectation: expectation || undefined,
+      },
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    return Boolean(response.data?.ok);
+  }
+
+  /** LLM judges registered on the local MLflow experiment. */
+  static async listJudges(): Promise<LLMJudge[]> {
+    const response = await apiClient.get<{ judges: LLMJudge[] }>(
+      '/prompt-optimization/judges',
+    );
+    return response.data?.judges || [];
+  }
+
+  /** Create + register an LLM judge (plain-language criteria). With crewId
+   *  the judge is assigned to that crew; without, it joins the shared library. */
+  static async createJudge(
+    name: string,
+    instructions: string,
+    model?: string,
+    crewId?: string,
+  ): Promise<LLMJudge> {
+    const response = await apiClient.post<LLMJudge>(
+      '/prompt-optimization/judges',
+      { name, instructions, model: model || undefined, crew_id: crewId || undefined },
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    return response.data;
+  }
+
+  /** Assign a shared library judge to a crew (registers a crew-scoped copy). */
+  static async assignJudge(name: string, crewId: string): Promise<LLMJudge> {
+    const response = await apiClient.post<LLMJudge>(
+      `/prompt-optimization/judges/${encodeURIComponent(name)}/assign`,
+      { crew_id: crewId },
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    return response.data;
+  }
+
+  static async deleteJudge(name: string): Promise<boolean> {
+    const response = await apiClient.delete<{ ok: boolean }>(
+      `/prompt-optimization/judges/${encodeURIComponent(name)}`,
+    );
+    return Boolean(response.data?.ok);
+  }
+
+  /** Request a running optimization to stop (honored before the next crew execution). */
+  static async cancelRun(runId: string): Promise<boolean> {
+    const response = await apiClient.post<{ cancelling: boolean }>(
+      `/prompt-optimization/runs/${runId}/cancel`,
+    );
+    return Boolean(response.data?.cancelling);
+  }
+
+  static async applyRun(runId: string): Promise<boolean> {
+    const response = await apiClient.post<{ applied: boolean }>(
+      `/prompt-optimization/runs/${runId}/apply`,
+    );
+    return Boolean(response.data?.applied);
+  }
+}

--- a/src/frontend/src/api/PromptOptimizationService.ts
+++ b/src/frontend/src/api/PromptOptimizationService.ts
@@ -32,6 +32,10 @@ export interface PromptOptimizationRun {
   optimized_fields?: Record<string, string> | null;
   executions_used?: number | null;
   execution_cap?: number | null;
+  /** Crew runs: human grades/expectations harvested into this run's judge + reflection. */
+  human_feedback_count?: number | null;
+  /** Crew runs: distinct candidate prompt sets actually executed. */
+  candidates_tried?: number | null;
 }
 
 export interface LLMJudge {

--- a/src/frontend/src/components/Common/UCMetricViewGeneratorConfigSelector.tsx
+++ b/src/frontend/src/components/Common/UCMetricViewGeneratorConfigSelector.tsx
@@ -49,6 +49,12 @@ export interface UCMetricViewGeneratorConfig {
   oauth_client_id?: string;
   access_token?: string;
   pbi_api_base_url?: string;
+  // Admin Service Principal — optional 3rd fallback tier for MQuery extraction
+  // (retries the Admin Scanner itself with admin rights when the primary
+  // credentials above and the Fabric TMDL fallback both fail). Distinct from
+  // client_id/client_secret; mirrors Pipeline Config Generator's admin creds.
+  admin_client_id?: string;
+  admin_client_secret?: string;
   // JSON mode (paste JSONs directly)
   measures_json?: string;
   mquery_json?: string;
@@ -151,6 +157,8 @@ export const UCMetricViewGeneratorConfigSelector: React.FC<UCMetricViewGenerator
         updatedConfig.password = undefined;
         updatedConfig.access_token = undefined;
         updatedConfig.pbi_api_base_url = undefined;
+        updatedConfig.admin_client_id = undefined;
+        updatedConfig.admin_client_secret = undefined;
       } else if (newMode === 'api') {
         updatedConfig.measures_json = undefined;
         updatedConfig.mquery_json = undefined;
@@ -477,6 +485,41 @@ export const UCMetricViewGeneratorConfigSelector: React.FC<UCMetricViewGenerator
             helperText="Custom Power BI API base URL (leave empty for default)"
             size="small"
           />
+
+          <Divider sx={{ my: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              Admin Service Principal (optional MQuery fallback)
+            </Typography>
+          </Divider>
+          <Alert severity="info" variant="outlined" sx={{ mb: 1 }}>
+            <Typography variant="caption">
+              Optional — only used if MQuery extraction fails via the credentials above AND Fabric TMDL
+              (e.g. the primary credentials lack tenant-admin API rights). Retries the Admin Scanner with
+              this Service Principal. Same admin Service Principal you use for the Pipeline Config
+              Generator&apos;s Admin credentials.
+            </Typography>
+          </Alert>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <TextField
+              label="Admin Client ID (Optional)"
+              value={value.admin_client_id || ''}
+              onChange={(e) => handleFieldChange('admin_client_id', e.target.value)}
+              disabled={disabled}
+              fullWidth
+              helperText="Power BI Admin Service Principal with Tenant.Read.All"
+              size="small"
+            />
+            <TextField
+              label="Admin Client Secret (Optional)"
+              value={value.admin_client_secret || ''}
+              onChange={(e) => handleFieldChange('admin_client_secret', e.target.value)}
+              disabled={disabled}
+              fullWidth
+              type="password"
+              helperText="Admin Service Principal secret"
+              size="small"
+            />
+          </Box>
         </>
       )}
 

--- a/src/frontend/src/components/Configuration/Configuration.tsx
+++ b/src/frontend/src/components/Configuration/Configuration.tsx
@@ -42,7 +42,7 @@ import ModelConfiguration from './Models';
 import APIKeys from './APIKeys/APIKeys';
 import ObjectManagement from './ObjectManagement';
 import ToolsConfiguration from './Tools/ToolsConfiguration';
-import PromptConfiguration from './PromptConfiguration';
+import Prompts from './Prompts';
 import DatabricksConfiguration from './DatabricksConfiguration';
 import MCPConfiguration from './MCP/MCPConfiguration';
 import EnginesConfiguration from './Engines';
@@ -301,7 +301,7 @@ function Configuration({ onClose }: ConfigurationProps): JSX.Element {
         group: 'workspace'
       });
       baseNavItems.push({
-        label: t('configuration.prompts.tab', { defaultValue: 'Prompt Instructions' }),
+        label: t('configuration.prompts.tab', { defaultValue: 'Prompts' }),
         icon: <TextFormatIcon fontSize="small" />,
         index: currentIndex++,
         group: 'workspace'
@@ -796,11 +796,11 @@ function Configuration({ onClose }: ConfigurationProps): JSX.Element {
               );
             }
 
-            // Prompt Instructions
-            if (item.label === t('configuration.prompts.tab', { defaultValue: 'Prompt Instructions' })) {
+            // Prompts — instructions (view/edit) + GEPA optimization, one surface
+            if (item.label === t('configuration.prompts.tab', { defaultValue: 'Prompts' })) {
               return (
                 <ContentPanel key={item.index} value={activeSection} index={item.index}>
-                  <PromptConfiguration />
+                  <Prompts />
                 </ContentPanel>
               );
             }

--- a/src/frontend/src/components/Configuration/PromptConfiguration.test.tsx
+++ b/src/frontend/src/components/Configuration/PromptConfiguration.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for PromptConfiguration.
+ *
+ * Covers the PR-introduced behavior: the per-template Optimize (✨) action
+ * appears ONLY for templates wired in OPTIMIZABLE_TEMPLATES and only when an
+ * onOptimize handler is provided, and clicking it hands the template name to
+ * the parent. Also covers the base list rendering and the edit dialog opening.
+ */
+
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PromptConfiguration from './PromptConfiguration';
+import { PromptService } from '../../api/PromptService';
+
+vi.mock('../../api/PromptService', () => {
+  const instance = {
+    getAllPrompts: vi.fn(),
+    updatePrompt: vi.fn(),
+    resetPromptTemplates: vi.fn(),
+  };
+  return {
+    PromptService: {
+      getInstance: () => instance,
+    },
+  };
+});
+
+const service = PromptService.getInstance() as unknown as {
+  getAllPrompts: Mock;
+  updatePrompt: Mock;
+  resetPromptTemplates: Mock;
+};
+
+const PROMPTS = [
+  {
+    id: 1,
+    name: 'detect_intent',
+    description: 'Routes chat intents',
+    template: 'You are an intent detector.',
+  },
+  {
+    id: 2,
+    name: 'improve_prompt',
+    description: 'Not optimizable',
+    template: 'You improve prompts.',
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  service.getAllPrompts.mockResolvedValue(PROMPTS);
+});
+
+describe('PromptConfiguration', () => {
+  it('renders the fetched prompt list', async () => {
+    render(<PromptConfiguration />);
+    expect(await screen.findByText('detect_intent')).toBeInTheDocument();
+    expect(screen.getByText('improve_prompt')).toBeInTheDocument();
+  });
+
+  it('shows the Optimize action only for optimizable templates', async () => {
+    render(<PromptConfiguration onOptimize={vi.fn()} />);
+    await screen.findByText('detect_intent');
+    // One optimizable row (detect_intent) → exactly one optimize button.
+    const optimizeButtons = screen.getAllByRole('button', {
+      name: /optimize/i,
+    });
+    expect(optimizeButtons).toHaveLength(1);
+  });
+
+  it('hides all Optimize actions when no handler is provided', async () => {
+    render(<PromptConfiguration />);
+    await screen.findByText('detect_intent');
+    expect(
+      screen.queryByRole('button', { name: /optimize/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hands the template name to onOptimize on click', async () => {
+    const onOptimize = vi.fn();
+    render(<PromptConfiguration onOptimize={onOptimize} />);
+    await screen.findByText('detect_intent');
+    await userEvent.click(screen.getByRole('button', { name: /optimize/i }));
+    expect(onOptimize).toHaveBeenCalledWith('detect_intent');
+  });
+
+  it('opens the edit dialog with the template content', async () => {
+    render(<PromptConfiguration />);
+    await screen.findByText('detect_intent');
+    const editButtons = screen.getAllByTestId('EditIcon');
+    await userEvent.click(editButtons[0].closest('button') as HTMLElement);
+    await waitFor(() =>
+      expect(
+        screen.getByDisplayValue('You are an intent detector.'),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/frontend/src/components/Configuration/PromptConfiguration.tsx
+++ b/src/frontend/src/components/Configuration/PromptConfiguration.tsx
@@ -21,9 +21,20 @@ import {
 import { useTranslation } from 'react-i18next';
 import EditIcon from '@mui/icons-material/Edit';
 import RestoreIcon from '@mui/icons-material/RestoreOutlined';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import { Tooltip } from '@mui/material';
 import { PromptService, PromptTemplate } from '../../api/PromptService';
+import { OPTIMIZABLE_TEMPLATES } from './optimizableTemplates';
 
-const PromptConfiguration: React.FC = () => {
+const OPTIMIZABLE_NAMES = new Set(OPTIMIZABLE_TEMPLATES.map((tpl) => tpl.name));
+
+interface PromptConfigurationProps {
+  /** When provided, optimizable templates get an Optimize action that hands
+   *  the template name to the parent (which opens the Optimization view). */
+  onOptimize?: (templateName: string) => void;
+}
+
+const PromptConfiguration: React.FC<PromptConfigurationProps> = ({ onOptimize }) => {
   const { t } = useTranslation();
   const [prompts, setPrompts] = useState<PromptTemplate[]>([]);
   const [loading, setLoading] = useState(true);
@@ -148,14 +159,11 @@ const PromptConfiguration: React.FC = () => {
 
   return (
     <Box>
-      <Typography variant="h6" gutterBottom>
-        {t('configuration.prompts.title', { defaultValue: 'Prompt Instructions' })}
-      </Typography>
-      <Typography variant="body2" color="textSecondary" paragraph>
-        {t('configuration.prompts.description', { defaultValue: 'Edit the system prompt instructions used by Kasal agents.' })}
-      </Typography>
-
-      <Box display="flex" justifyContent="flex-end" mb={2}>
+      {/* No panel title — the hosting Prompts tab already names this view. */}
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="body2" color="textSecondary">
+          {t('configuration.prompts.description', { defaultValue: 'Edit the system prompt instructions used by Kasal agents.' })}
+        </Typography>
         <Button
           startIcon={<RestoreIcon />}
           variant="outlined"
@@ -172,9 +180,18 @@ const PromptConfiguration: React.FC = () => {
             <React.Fragment key={prompt.id}>
               <ListItem
                 secondaryAction={
-                  <IconButton edge="end" onClick={() => handleEditClick(prompt)}>
-                    <EditIcon />
-                  </IconButton>
+                  <>
+                    {onOptimize && OPTIMIZABLE_NAMES.has(prompt.name) && (
+                      <Tooltip title={t('configuration.prompts.optimize', { defaultValue: 'Optimize with GEPA' })}>
+                        <IconButton onClick={() => onOptimize(prompt.name)}>
+                          <AutoFixHighIcon />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                    <IconButton edge="end" onClick={() => handleEditClick(prompt)}>
+                      <EditIcon />
+                    </IconButton>
+                  </>
                 }
               >
                 <ListItemText

--- a/src/frontend/src/components/Configuration/PromptOptimization.test.tsx
+++ b/src/frontend/src/components/Configuration/PromptOptimization.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for PromptOptimization.
+ *
+ * Covers the fixedTemplate scoping introduced with the Prompts surface: the
+ * template picker is hidden and the run list filtered to the target template,
+ * plus the start flow's request payload and error surfacing.
+ */
+
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PromptOptimization from './PromptOptimization';
+import { PromptOptimizationService } from '../../api/PromptOptimizationService';
+import { ModelService } from '../../api/ModelService';
+
+vi.mock('../../api/PromptOptimizationService', () => ({
+  PromptOptimizationService: {
+    listRuns: vi.fn(),
+    startOptimization: vi.fn(),
+    applyRun: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/ModelService', () => {
+  const instance = { getEnabledModels: vi.fn() };
+  return { ModelService: { getInstance: () => instance } };
+});
+
+const listRuns = PromptOptimizationService.listRuns as Mock;
+const startOptimization = PromptOptimizationService.startOptimization as Mock;
+const getEnabledModels = ModelService.getInstance().getEnabledModels as Mock;
+
+const RUNS = [
+  {
+    run_id: 'run-intent',
+    template_name: 'detect_intent',
+    status: 'completed',
+    dataset_size: 5,
+    applied: false,
+    initial_score: 0.5,
+    final_score: 0.9,
+    baseline_template: 'OLD',
+    optimized_template: 'NEW',
+  },
+  {
+    run_id: 'run-agent',
+    template_name: 'generate_agent',
+    status: 'completed',
+    dataset_size: 5,
+    applied: false,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getEnabledModels.mockResolvedValue({ 'qwen-30b': {} });
+  listRuns.mockResolvedValue(RUNS);
+});
+
+describe('PromptOptimization', () => {
+  it('unscoped: shows the template picker and every run', async () => {
+    render(<PromptOptimization />);
+    await waitFor(() => expect(listRuns).toHaveBeenCalled());
+    expect((await screen.findAllByText(/detect_intent/)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/generate_agent/).length).toBeGreaterThan(0);
+    // The template select is present (labelled options from OPTIMIZABLE_TEMPLATES)
+    expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('fixedTemplate: hides the picker and filters runs to the target', async () => {
+    render(<PromptOptimization fixedTemplate="detect_intent" />);
+    await waitFor(() => expect(listRuns).toHaveBeenCalled());
+    await screen.findByText(/detect_intent/);
+    expect(screen.queryByText(/generate_agent/)).not.toBeInTheDocument();
+    // Only the model select remains.
+    expect(screen.getAllByRole('combobox')).toHaveLength(1);
+  });
+
+  it('starts an optimization for the scoped template', async () => {
+    startOptimization.mockResolvedValue({
+      run_id: 'r-new',
+      status: 'pending',
+      dataset_size: 7,
+    });
+    render(<PromptOptimization fixedTemplate="detect_intent" />);
+    await waitFor(() => expect(listRuns).toHaveBeenCalled());
+    await userEvent.click(screen.getByRole('button', { name: /start|optimize/i }));
+    await waitFor(() => expect(startOptimization).toHaveBeenCalled());
+    const request = startOptimization.mock.calls[0][0];
+    expect(request.template_name).toBe('detect_intent');
+    expect(request.max_metric_calls).toBeGreaterThan(0);
+  });
+
+  it('surfaces a backend rejection detail on start failure', async () => {
+    startOptimization.mockRejectedValue({
+      response: { data: { detail: 'Need at least 4 examples' } },
+    });
+    render(<PromptOptimization fixedTemplate="detect_intent" />);
+    await waitFor(() => expect(listRuns).toHaveBeenCalled());
+    await userEvent.click(screen.getByRole('button', { name: /start|optimize/i }));
+    expect(
+      await screen.findByText(/Need at least 4 examples/),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/Configuration/PromptOptimization.tsx
+++ b/src/frontend/src/components/Configuration/PromptOptimization.tsx
@@ -1,0 +1,355 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Divider,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Snackbar,
+  TextField,
+  Typography,
+} from '@mui/material';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { useTranslation } from 'react-i18next';
+import {
+  PromptOptimizationRun,
+  PromptOptimizationService,
+} from '../../api/PromptOptimizationService';
+import { ModelService } from '../../api/ModelService';
+
+import { OPTIMIZABLE_TEMPLATES } from './optimizableTemplates';
+
+const POLL_INTERVAL_MS = 5000;
+
+const statusColor = (
+  status: PromptOptimizationRun['status'],
+): 'default' | 'info' | 'success' | 'error' => {
+  switch (status) {
+    case 'completed':
+      return 'success';
+    case 'failed':
+      return 'error';
+    case 'running':
+      return 'info';
+    default:
+      return 'default';
+  }
+};
+
+interface PromptOptimizationProps {
+  /** Scope the panel to one template (set when opened from a template row's
+   *  Optimize action): the picker is locked and runs are filtered to it. */
+  fixedTemplate?: string;
+}
+
+const PromptOptimization: React.FC<PromptOptimizationProps> = ({ fixedTemplate }) => {
+  const { t } = useTranslation();
+  const [templateName, setTemplateName] = useState(
+    fixedTemplate && OPTIMIZABLE_TEMPLATES.some((tpl) => tpl.name === fixedTemplate)
+      ? fixedTemplate
+      : OPTIMIZABLE_TEMPLATES[0].name,
+  );
+
+  // Follow the scoped template when the dialog is reopened for another row.
+  useEffect(() => {
+    if (fixedTemplate && OPTIMIZABLE_TEMPLATES.some((tpl) => tpl.name === fixedTemplate)) {
+      setTemplateName(fixedTemplate);
+    }
+  }, [fixedTemplate]);
+  const [model, setModel] = useState('');
+  const [models, setModels] = useState<string[]>([]);
+  const [budget, setBudget] = useState(40);
+  const [starting, setStarting] = useState(false);
+  const [runs, setRuns] = useState<PromptOptimizationRun[]>([]);
+  const [expandedRun, setExpandedRun] = useState<string | null>(null);
+  const [applying, setApplying] = useState<string | null>(null);
+  const [notification, setNotification] = useState({
+    open: false,
+    message: '',
+    severity: 'success' as 'success' | 'error',
+  });
+  const pollRef = useRef<number | null>(null);
+
+  const refreshRuns = useCallback(async () => {
+    try {
+      setRuns(await PromptOptimizationService.listRuns());
+    } catch {
+      /* transient — keep the last known list */
+    }
+  }, []);
+
+  // Load enabled models for the model picker + initial runs.
+  useEffect(() => {
+    (async () => {
+      try {
+        const enabled = await ModelService.getInstance().getEnabledModels();
+        setModels(Object.keys(enabled));
+      } catch {
+        setModels([]);
+      }
+      await refreshRuns();
+    })();
+  }, [refreshRuns]);
+
+  // Poll while any run is active.
+  const hasActiveRun = runs.some((r) => r.status === 'pending' || r.status === 'running');
+  useEffect(() => {
+    if (!hasActiveRun) return;
+    pollRef.current = window.setInterval(refreshRuns, POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) window.clearInterval(pollRef.current);
+    };
+  }, [hasActiveRun, refreshRuns]);
+
+  const handleStart = async () => {
+    setStarting(true);
+    try {
+      const started = await PromptOptimizationService.startOptimization({
+        template_name: templateName,
+        model: model || undefined,
+        max_metric_calls: budget,
+      });
+      setNotification({
+        open: true,
+        message: t('configuration.promptOptimization.started', {
+          defaultValue: `Optimization started on ${started.dataset_size} examples`,
+        }),
+        severity: 'success',
+      });
+      setExpandedRun(started.run_id);
+      await refreshRuns();
+    } catch (error: unknown) {
+      const detail =
+        (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+        'Failed to start optimization';
+      setNotification({ open: true, message: detail, severity: 'error' });
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const handleApply = async (runId: string) => {
+    setApplying(runId);
+    try {
+      await PromptOptimizationService.applyRun(runId);
+      setNotification({
+        open: true,
+        message: t('configuration.promptOptimization.applied', {
+          defaultValue:
+            'Optimized template applied as a group override — see Prompt Instructions',
+        }),
+        severity: 'success',
+      });
+      await refreshRuns();
+    } catch {
+      setNotification({ open: true, message: 'Failed to apply template', severity: 'error' });
+    } finally {
+      setApplying(null);
+    }
+  };
+
+  // Scoped mode shows only the target template's runs.
+  const visibleRuns = fixedTemplate
+    ? runs.filter((r) => r.template_name === fixedTemplate)
+    : runs;
+
+  return (
+    <Box>
+      {/* No panel title — the hosting Prompts surface names this view. */}
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography variant="body2" color="textSecondary" sx={{ mb: 2 }}>
+            {t('configuration.promptOptimization.description', {
+              defaultValue:
+                'Optimize a seeded prompt template with GEPA: training examples are mined ' +
+                'from logged usage, candidate templates are scored against format and ' +
+                'correctness, and the winner is proposed for review. Applying writes a ' +
+                'group-scoped override — the base template is never modified.',
+            })}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
+            {!fixedTemplate && (
+              <FormControl size="small" sx={{ minWidth: 280 }}>
+                <InputLabel>Template</InputLabel>
+                <Select
+                  value={templateName}
+                  label="Template"
+                  onChange={(e) => setTemplateName(e.target.value)}
+                >
+                  {OPTIMIZABLE_TEMPLATES.map((tpl) => (
+                    <MenuItem key={tpl.name} value={tpl.name}>
+                      {tpl.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+            <FormControl size="small" sx={{ minWidth: 260 }}>
+              <InputLabel>Model</InputLabel>
+              <Select value={model} label="Model" onChange={(e) => setModel(e.target.value)}>
+                <MenuItem value="">
+                  <em>Default (dispatcher fast model)</em>
+                </MenuItem>
+                {models.map((key) => (
+                  <MenuItem key={key} value={key}>
+                    {key}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              size="small"
+              type="number"
+              label="Budget (LLM evals)"
+              value={budget}
+              onChange={(e) =>
+                setBudget(Math.max(8, Math.min(400, Number(e.target.value) || 40)))
+              }
+              sx={{ width: 160 }}
+            />
+            <Button
+              variant="contained"
+              onClick={handleStart}
+              disabled={starting || hasActiveRun}
+              startIcon={starting ? <CircularProgress size={16} /> : <AutoFixHighIcon />}
+            >
+              {starting
+                ? 'Starting…'
+                : hasActiveRun
+                  ? 'Run in progress…'
+                  : 'Start optimization'}
+            </Button>
+          </Box>
+        </CardContent>
+      </Card>
+
+      <Typography variant="subtitle1" sx={{ mb: 1 }}>
+        {t('configuration.promptOptimization.runs', { defaultValue: 'Runs' })}
+      </Typography>
+      {visibleRuns.length === 0 && (
+        <Typography variant="body2" color="textSecondary">
+          {t('configuration.promptOptimization.noRuns', {
+            defaultValue: 'No optimization runs yet.',
+          })}
+        </Typography>
+      )}
+      {visibleRuns.map((run) => (
+        <Card key={run.run_id} sx={{ mb: 1.5 }}>
+          <CardContent sx={{ pb: '12px !important' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+              <Chip size="small" label={run.status} color={statusColor(run.status)} />
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {run.template_name}
+              </Typography>
+              <Typography variant="caption" color="textSecondary">
+                {run.dataset_size} examples
+                {run.model ? ` · ${run.model}` : ''}
+                {run.created_at ? ` · ${new Date(run.created_at).toLocaleString()}` : ''}
+              </Typography>
+              {run.status === 'running' && <CircularProgress size={14} />}
+              {typeof run.initial_score === 'number' && typeof run.final_score === 'number' && (
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  label={`score ${run.initial_score.toFixed(2)} → ${run.final_score.toFixed(2)}`}
+                />
+              )}
+              {run.applied && <Chip size="small" color="success" variant="outlined" label="applied" />}
+              <Box sx={{ flexGrow: 1 }} />
+              {run.status === 'completed' && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  disabled={run.applied || applying === run.run_id}
+                  onClick={() => handleApply(run.run_id)}
+                >
+                  {applying === run.run_id ? 'Applying…' : run.applied ? 'Applied' : 'Apply'}
+                </Button>
+              )}
+              <Button
+                size="small"
+                onClick={() =>
+                  setExpandedRun(expandedRun === run.run_id ? null : run.run_id)
+                }
+                endIcon={expandedRun === run.run_id ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+              >
+                Details
+              </Button>
+            </Box>
+            <Collapse in={expandedRun === run.run_id}>
+              <Divider sx={{ my: 1.5 }} />
+              {run.error && (
+                <Alert severity="error" sx={{ mb: 1.5 }}>
+                  {run.error}
+                </Alert>
+              )}
+              {run.optimized_template ? (
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                  <Box sx={{ flex: 1, minWidth: 320 }}>
+                    <Typography variant="caption" color="textSecondary">
+                      Baseline template
+                    </Typography>
+                    <TextField
+                      fullWidth
+                      multiline
+                      minRows={8}
+                      maxRows={16}
+                      value={run.baseline_template || ''}
+                      InputProps={{ readOnly: true, sx: { fontFamily: 'monospace', fontSize: 12 } }}
+                    />
+                  </Box>
+                  <Box sx={{ flex: 1, minWidth: 320 }}>
+                    <Typography variant="caption" color="textSecondary">
+                      Optimized proposal
+                    </Typography>
+                    <TextField
+                      fullWidth
+                      multiline
+                      minRows={8}
+                      maxRows={16}
+                      value={run.optimized_template}
+                      InputProps={{ readOnly: true, sx: { fontFamily: 'monospace', fontSize: 12 } }}
+                    />
+                  </Box>
+                </Box>
+              ) : (
+                !run.error && (
+                  <Typography variant="body2" color="textSecondary">
+                    {run.status === 'running' || run.status === 'pending'
+                      ? 'Optimizing — candidate templates are being generated and scored…'
+                      : 'No proposal available.'}
+                  </Typography>
+                )
+              )}
+            </Collapse>
+          </CardContent>
+        </Card>
+      ))}
+
+      <Snackbar
+        open={notification.open}
+        autoHideDuration={5000}
+        onClose={() => setNotification((n) => ({ ...n, open: false }))}
+      >
+        <Alert
+          severity={notification.severity}
+          onClose={() => setNotification((n) => ({ ...n, open: false }))}
+        >
+          {notification.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default PromptOptimization;

--- a/src/frontend/src/components/Configuration/Prompts.test.tsx
+++ b/src/frontend/src/components/Configuration/Prompts.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Tests for the Prompts surface: the template list is the single entry point,
+ * and a row's Optimize action opens the optimization dialog scoped to that
+ * template (closable via the dialog's close button).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Prompts from './Prompts';
+
+vi.mock('./PromptConfiguration', () => ({
+  default: ({ onOptimize }: { onOptimize?: (name: string) => void }) => (
+    <button onClick={() => onOptimize && onOptimize('detect_intent')}>
+      fake-optimize-detect_intent
+    </button>
+  ),
+}));
+
+vi.mock('./PromptOptimization', () => ({
+  default: ({ fixedTemplate }: { fixedTemplate?: string }) => (
+    <div>fake-optimization-panel:{fixedTemplate}</div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Prompts', () => {
+  it('renders the template list without the optimization dialog', () => {
+    render(<Prompts />);
+    expect(screen.getByText('fake-optimize-detect_intent')).toBeInTheDocument();
+    expect(screen.queryByText(/fake-optimization-panel/)).not.toBeInTheDocument();
+  });
+
+  it('opens the optimization dialog scoped to the chosen template', async () => {
+    render(<Prompts />);
+    await userEvent.click(screen.getByText('fake-optimize-detect_intent'));
+    expect(
+      await screen.findByText('fake-optimization-panel:detect_intent'),
+    ).toBeInTheDocument();
+  });
+
+  it('closes the dialog via the close button', async () => {
+    render(<Prompts />);
+    await userEvent.click(screen.getByText('fake-optimize-detect_intent'));
+    await screen.findByText('fake-optimization-panel:detect_intent');
+    await userEvent.click(screen.getByTestId('CloseIcon').closest('button') as HTMLElement);
+    await waitFor(() =>
+      expect(
+        screen.queryByText('fake-optimization-panel:detect_intent'),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/src/frontend/src/components/Configuration/Prompts.tsx
+++ b/src/frontend/src/components/Configuration/Prompts.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import { useTranslation } from 'react-i18next';
+import PromptConfiguration from './PromptConfiguration';
+import PromptOptimization from './PromptOptimization';
+
+/**
+ * Prompts panel: the seeded template list is the single surface; each
+ * optimizable template's row carries an Optimize action that opens the
+ * GEPA optimization flow in a dialog scoped to that template.
+ */
+const Prompts: React.FC = () => {
+  const { t } = useTranslation();
+  const [optimizeTarget, setOptimizeTarget] = useState<string | null>(null);
+
+  return (
+    <Box>
+      <PromptConfiguration onOptimize={(name) => setOptimizeTarget(name)} />
+
+      <Dialog
+        open={optimizeTarget !== null}
+        onClose={() => setOptimizeTarget(null)}
+        fullWidth
+        maxWidth="lg"
+      >
+        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <AutoFixHighIcon fontSize="small" />
+          {t('configuration.prompts.optimizeTitle', { defaultValue: 'Optimize' })}{' '}
+          {optimizeTarget}
+          <Box sx={{ flexGrow: 1 }} />
+          <IconButton onClick={() => setOptimizeTarget(null)} size="small">
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          {optimizeTarget && <PromptOptimization fixedTemplate={optimizeTarget} />}
+        </DialogContent>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default Prompts;

--- a/src/frontend/src/components/Configuration/optimizableTemplates.test.ts
+++ b/src/frontend/src/components/Configuration/optimizableTemplates.test.ts
@@ -1,0 +1,28 @@
+/**
+ * The optimizable-templates list must mirror the backend's TEMPLATE_TASKS
+ * registry — the six wired templates, no duplicates, labels for the picker.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { OPTIMIZABLE_TEMPLATES } from './optimizableTemplates';
+
+describe('OPTIMIZABLE_TEMPLATES', () => {
+  it('lists exactly the six wired templates', () => {
+    expect(OPTIMIZABLE_TEMPLATES.map((t) => t.name)).toEqual([
+      'detect_intent',
+      'generate_agent',
+      'generate_task',
+      'generate_crew',
+      'generate_crew_plan',
+      'generate_job_name',
+    ]);
+  });
+
+  it('has unique names and a human label for each', () => {
+    const names = OPTIMIZABLE_TEMPLATES.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+    for (const template of OPTIMIZABLE_TEMPLATES) {
+      expect(template.label).toContain(template.name);
+    }
+  });
+});

--- a/src/frontend/src/components/Configuration/optimizableTemplates.ts
+++ b/src/frontend/src/components/Configuration/optimizableTemplates.ts
@@ -1,0 +1,12 @@
+// Templates with optimization wiring (training-data source + scorers) in the
+// backend's TEMPLATE_TASKS registry. Other seeded templates appear here as
+// their wiring is added. Shared by the Instructions list (per-template
+// Optimize action) and the Optimization panel (template picker).
+export const OPTIMIZABLE_TEMPLATES = [
+  { name: 'detect_intent', label: 'detect_intent — chat/canvas intent routing' },
+  { name: 'generate_agent', label: 'generate_agent — agent generation' },
+  { name: 'generate_task', label: 'generate_task — task generation' },
+  { name: 'generate_crew', label: 'generate_crew — full crew generation' },
+  { name: 'generate_crew_plan', label: 'generate_crew_plan — crew plan outline' },
+  { name: 'generate_job_name', label: 'generate_job_name — run naming' },
+];

--- a/src/frontend/src/components/Crew/CrewFlowDialog/CrewFlowDialog.tsx
+++ b/src/frontend/src/components/Crew/CrewFlowDialog/CrewFlowDialog.tsx
@@ -34,6 +34,8 @@ import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import PersonIcon from '@mui/icons-material/Person';
 import EditIcon from '@mui/icons-material/Edit';
 import UploadIcon from '@mui/icons-material/Upload';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import CrewOptimizeDialog from '../CrewOptimizeDialog';
 import FileUploadIcon from '@mui/icons-material/FileUpload';
 import EditFlowForm from '../../Flow/EditFlowForm';
 import { AgentService } from '../../../api/AgentService';
@@ -102,6 +104,8 @@ const CrewFlowSelectionDialog: React.FC<CrewFlowSelectionDialogProps> = ({
   hideFlowsTab = false,
 }): JSX.Element => {
   const [tabValue, setTabValue] = useState(initialTab);
+  // Crew whose prompts are being optimized (opens CrewOptimizeDialog).
+  const [optimizeCrew, setOptimizeCrew] = useState<CrewResponse | null>(null);
   
   // When showing only one tab, always use that tab's value
   useEffect(() => {
@@ -1509,6 +1513,17 @@ const CrewFlowSelectionDialog: React.FC<CrewFlowSelectionDialogProps> = ({
                                 {crew.name}
                               </Typography>
                               <Box>
+                                <Tooltip title="Optimize Prompts">
+                                  <IconButton
+                                    size="small"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setOptimizeCrew(crew);
+                                    }}
+                                  >
+                                    <AutoFixHighIcon fontSize="small" />
+                                  </IconButton>
+                                </Tooltip>
                                 <Tooltip title="Export Crew">
                                   <IconButton
                                     size="small"
@@ -1975,14 +1990,20 @@ const CrewFlowSelectionDialog: React.FC<CrewFlowSelectionDialogProps> = ({
         accept=".json"
         onChange={handleImportFlow}
       />
-      <input 
-        type="file" 
-        ref={bulkFileInputRef} 
-        style={{ display: 'none' }} 
+      <input
+        type="file"
+        ref={bulkFileInputRef}
+        style={{ display: 'none' }}
         accept=".json"
         onChange={handleBulkImport}
       />
 
+      <CrewOptimizeDialog
+        open={optimizeCrew !== null}
+        crewId={optimizeCrew?.id ?? null}
+        crewName={optimizeCrew?.name}
+        onClose={() => setOptimizeCrew(null)}
+      />
 
     </>
   );

--- a/src/frontend/src/components/Crew/CrewFlowDialog/CrewOptimizeEntry.test.tsx
+++ b/src/frontend/src/components/Crew/CrewFlowDialog/CrewOptimizeEntry.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * Catalog → Optimize Prompts entry point.
+ *
+ * Source-level guards, following CrewFeedback.test.tsx — the catalog dialog
+ * is heavy to mount. These pin the wiring that must not regress: the per-crew
+ * optimize action stops card-click propagation (clicking ✨ must never LOAD
+ * the crew), and CrewOptimizeDialog is mounted with the selected crew's
+ * id + name and a closer that clears the selection.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const dialogSrc = readFileSync(resolve(__dirname, 'CrewFlowDialog.tsx'), 'utf-8');
+
+describe('catalog optimize entry', () => {
+  it('has an Optimize Prompts action per crew card', () => {
+    expect(dialogSrc).toContain('title="Optimize Prompts"');
+    expect(dialogSrc).toContain('AutoFixHighIcon');
+  });
+
+  it('stops propagation so the click never loads the crew', () => {
+    const buttonBlock = dialogSrc.slice(
+      dialogSrc.indexOf('title="Optimize Prompts"'),
+      dialogSrc.indexOf('title="Export Crew"'),
+    );
+    expect(buttonBlock).toContain('e.stopPropagation()');
+    expect(buttonBlock).toContain('setOptimizeCrew(crew)');
+  });
+
+  it('mounts CrewOptimizeDialog wired to the selected crew', () => {
+    expect(dialogSrc).toContain('open={optimizeCrew !== null}');
+    expect(dialogSrc).toContain('crewId={optimizeCrew?.id ?? null}');
+    expect(dialogSrc).toContain('crewName={optimizeCrew?.name}');
+    expect(dialogSrc).toContain('onClose={() => setOptimizeCrew(null)}');
+  });
+});

--- a/src/frontend/src/components/Crew/CrewOptimizeDialog.test.tsx
+++ b/src/frontend/src/components/Crew/CrewOptimizeDialog.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * Tests for CrewOptimizeDialog.
+ *
+ * Focuses on the logic that has bitten in production:
+ * - judge scoping: assigned chips filtered by the crew's registry prefix,
+ *   the Assign menu limited to unassigned LIBRARY judges (other crews'
+ *   judges and same-name duplicates excluded)
+ * - evaluation answers sorted ungraded-first with header counts, rendered
+ *   as markdown (not raw text)
+ * - run cards exposing the honest-progress chips (executions, variants,
+ *   human notes)
+ * - the judge lifecycle: create (auto-assign), edit (full registry name),
+ *   delete (confirm dialog), and starting a run with the budget as a hard cap
+ */
+
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CrewOptimizeDialog from './CrewOptimizeDialog';
+import { PromptOptimizationService } from '../../api/PromptOptimizationService';
+import { ModelService } from '../../api/ModelService';
+
+// react-markdown 9.x is ESM-only; passthrough mock renders the raw string.
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => (
+    <div data-testid="md">{children}</div>
+  ),
+}));
+vi.mock('remark-gfm', () => ({ default: () => {} }));
+
+vi.mock('react-hot-toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../api/PromptOptimizationService', () => ({
+  PromptOptimizationService: {
+    listRuns: vi.fn(),
+    listCrewEvals: vi.fn(),
+    listJudges: vi.fn(),
+    startCrewOptimization: vi.fn(),
+    cancelRun: vi.fn(),
+    applyRun: vi.fn(),
+    addEvalFeedback: vi.fn(),
+    createJudge: vi.fn(),
+    assignJudge: vi.fn(),
+    updateJudge: vi.fn(),
+    deleteJudge: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/ModelService', () => {
+  const instance = { getEnabledModels: vi.fn() };
+  return { ModelService: { getInstance: () => instance } };
+});
+
+const service = PromptOptimizationService as unknown as Record<string, Mock>;
+const getEnabledModels = ModelService.getInstance().getEnabledModels as Mock;
+
+const CREW_ID = '88ab4478-823c-4f12-b1ca-8e74c568995e'; // prefix 88ab4478823c
+
+const JUDGES = [
+  {
+    name: 'accuracy',
+    full_name: 'crew_88ab4478823c__accuracy',
+    crew_id: '88ab4478823c',
+    instructions: 'Assigned criteria for {{ outputs }}',
+  },
+  // Library original of the assigned judge — must NOT appear in the menu.
+  { name: 'accuracy', full_name: 'accuracy', crew_id: null, instructions: 'lib copy' },
+  { name: 'citation', full_name: 'citation', crew_id: null, instructions: 'Cite sources' },
+  // Another crew's judge — must appear NOWHERE in this dialog.
+  {
+    name: 'foreign',
+    full_name: 'crew_deadbeef1234__foreign',
+    crew_id: 'deadbeef1234',
+    instructions: 'other crew',
+  },
+];
+
+const RUNS = [
+  {
+    run_id: 'run1',
+    template_name: 'crew:Gather apartments',
+    kind: 'crew',
+    crew_id: CREW_ID,
+    status: 'completed',
+    dataset_size: 1,
+    applied: false,
+    initial_score: 0.57,
+    final_score: 0.97,
+    executions_used: 10,
+    execution_cap: 10,
+    candidates_tried: 10,
+    human_feedback_count: 13,
+    baseline_fields: { 'task.t1.description': 'old' },
+    optimized_fields: { 'task.t1.description': 'new german-only' },
+    created_at: '2026-07-24T08:00:00+00:00',
+  },
+];
+
+const EVALS = [
+  {
+    trace_id: 'graded-older',
+    timestamp_ms: 1000,
+    deliverable: '| Location | Price |\n| Zurich | 499000 |',
+    assessment_count: 2,
+  },
+  {
+    trace_id: 'ungraded-newer',
+    timestamp_ms: 2000,
+    deliverable: 'Fresh ungraded answer',
+    assessment_count: 0,
+  },
+];
+
+const renderDialog = () =>
+  render(
+    <CrewOptimizeDialog
+      open
+      onClose={vi.fn()}
+      crewId={CREW_ID}
+      crewName="Gather apartments"
+    />,
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  service.listRuns.mockResolvedValue(RUNS);
+  service.listCrewEvals.mockResolvedValue(EVALS);
+  service.listJudges.mockResolvedValue(JUDGES);
+  getEnabledModels.mockResolvedValue({ 'qwen-30b': {} });
+});
+
+describe('judge scoping', () => {
+  it('shows assigned judges as chips and only unassigned library judges in the menu', async () => {
+    renderDialog();
+    // Assigned chip present
+    expect(await screen.findByText('accuracy')).toBeInTheDocument();
+    // Other crews' judges appear nowhere
+    expect(screen.queryByText('foreign')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Assign'));
+    const menu = await screen.findByRole('menu');
+    // Library judge available to assign
+    expect(within(menu).getByText('citation')).toBeInTheDocument();
+    // The library duplicate of the already-assigned name is excluded
+    expect(within(menu).queryByText('accuracy')).not.toBeInTheDocument();
+    expect(within(menu).queryByText('foreign')).not.toBeInTheDocument();
+  });
+
+  it('assigns a library judge to the crew', async () => {
+    service.assignJudge.mockResolvedValue({ full_name: 'crew_88ab4478823c__citation' });
+    renderDialog();
+    await screen.findByText('accuracy');
+    await userEvent.click(screen.getByText('Assign'));
+    await userEvent.click(within(await screen.findByRole('menu')).getByText('citation'));
+    await waitFor(() =>
+      expect(service.assignJudge).toHaveBeenCalledWith('citation', CREW_ID),
+    );
+  });
+});
+
+describe('judge lifecycle', () => {
+  it('opens the edit dialog from an assigned chip and updates by full name', async () => {
+    service.updateJudge.mockResolvedValue({ name: 'accuracy' });
+    renderDialog();
+    await userEvent.click(await screen.findByText('accuracy'));
+    expect(await screen.findByText(/Edit judge — accuracy/)).toBeInTheDocument();
+    // Prefilled with the judge's current instructions
+    expect(
+      screen.getByDisplayValue('Assigned criteria for {{ outputs }}'),
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(service.updateJudge).toHaveBeenCalledWith(
+        'crew_88ab4478823c__accuracy',
+        { instructions: 'Assigned criteria for {{ outputs }}', model: undefined },
+      ),
+    );
+  });
+
+  it('deletes a library judge after confirmation', async () => {
+    service.deleteJudge.mockResolvedValue(true);
+    renderDialog();
+    await screen.findByText('accuracy');
+    await userEvent.click(screen.getByText('Assign'));
+    const menu = await screen.findByRole('menu');
+    await userEvent.click(within(menu).getByTestId('DeleteOutlineIcon'));
+    expect(await screen.findByText(/Delete judge/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() =>
+      expect(service.deleteJudge).toHaveBeenCalledWith('citation'),
+    );
+  });
+
+  it('creates a judge auto-assigned to this crew', async () => {
+    service.createJudge.mockResolvedValue({ name: 'freshness' });
+    renderDialog();
+    await screen.findByText('accuracy');
+    await userEvent.click(screen.getByText('+ Create judge'));
+    await userEvent.type(screen.getByLabelText(/Judge name/), 'freshness');
+    await userEvent.type(
+      screen.getByLabelText(/Evaluation criteria/),
+      'Listings must be recent.',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Create judge' }));
+    await waitFor(() =>
+      expect(service.createJudge).toHaveBeenCalledWith(
+        'freshness',
+        'Listings must be recent.',
+        undefined,
+        CREW_ID,
+      ),
+    );
+  });
+});
+
+describe('runs and progress chips', () => {
+  it('renders the honest-progress chips for a completed run', async () => {
+    renderDialog();
+    expect(await screen.findByText('10/10 executions')).toBeInTheDocument();
+    expect(screen.getByText('10 variants tried')).toBeInTheDocument();
+    expect(screen.getByText('guided by 13 human notes')).toBeInTheDocument();
+    expect(screen.getByText('score 0.57 → 0.97')).toBeInTheDocument();
+  });
+
+  it('starts a crew run with the budget as the hard execution cap', async () => {
+    service.startCrewOptimization.mockResolvedValue({
+      run_id: 'r-new',
+      status: 'pending',
+      dataset_size: 1,
+    });
+    renderDialog();
+    await screen.findByText('10/10 executions');
+    await userEvent.click(screen.getByRole('button', { name: 'Start GEPA' }));
+    await waitFor(() => expect(service.startCrewOptimization).toHaveBeenCalled());
+    const request = service.startCrewOptimization.mock.calls[0][0];
+    expect(request.crew_id).toBe(CREW_ID);
+    expect(request.max_metric_calls).toBe(10); // the default budget
+  });
+});
+
+describe('evaluation answers', () => {
+  it('sorts ungraded answers first and shows the grading counts', async () => {
+    renderDialog();
+    expect(
+      await screen.findByText(/1 to grade, 1 graded/),
+    ).toBeInTheDocument();
+    const previews = screen.getAllByText(/Fresh ungraded answer|Location/);
+    // The ungraded (newer) answer's preview renders above the graded one.
+    expect(previews[0].textContent).toContain('Fresh ungraded answer');
+  });
+
+  it('renders the expanded answer as markdown, not raw text', async () => {
+    renderDialog();
+    await screen.findByText(/1 to grade, 1 graded/);
+    const gradeButtons = screen.getAllByRole('button', { name: 'Grade' });
+    await userEvent.click(gradeButtons[1]); // the graded, table-bearing answer
+    const markdown = await screen.findByTestId('md');
+    expect(markdown.textContent).toContain('| Location | Price |');
+  });
+
+  it('saves a grade with judge attribution riding the comment', async () => {
+    service.addEvalFeedback.mockResolvedValue(true);
+    renderDialog();
+    await screen.findByText(/1 to grade, 1 graded/);
+    await userEvent.click(screen.getAllByRole('button', { name: 'Grade' })[0]);
+    await userEvent.type(screen.getByLabelText(/Grade \(0-10\)/), '3');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(service.addEvalFeedback).toHaveBeenCalled());
+    const [traceId, value] = service.addEvalFeedback.mock.calls[0];
+    expect(traceId).toBe('ungraded-newer');
+    expect(value).toBe(3);
+  });
+});

--- a/src/frontend/src/components/Crew/CrewOptimizeDialog.tsx
+++ b/src/frontend/src/components/Crew/CrewOptimizeDialog.tsx
@@ -25,6 +25,8 @@ import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import GavelIcon from '@mui/icons-material/Gavel';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { toast } from 'react-hot-toast';
 import {
   CrewEval,
@@ -719,15 +721,69 @@ const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
                 </Box>
                 {expandedEval === ev.trace_id && (
                   <Box sx={{ mt: 1.5 }}>
-                    <TextField
-                      fullWidth
-                      multiline
-                      maxRows={10}
-                      size="small"
-                      label="Answer"
-                      value={ev.deliverable}
-                      InputProps={{ readOnly: true, sx: { fontSize: 13 } }}
-                    />
+                    <Typography
+                      variant="overline"
+                      sx={{ color: 'text.secondary', letterSpacing: 0.6 }}
+                    >
+                      Answer
+                    </Typography>
+                    {/* Rendered markdown, not raw text — crew deliverables are
+                        mostly GFM tables, unreadable as pipe soup. */}
+                    <Box
+                      sx={{
+                        border: 1,
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                        p: 1.5,
+                        maxHeight: 340,
+                        overflow: 'auto',
+                        fontSize: 13,
+                        lineHeight: 1.55,
+                        '& p': { m: 0, mb: 1 },
+                        '& h1, & h2, & h3, & h4': { m: 0, mb: 1, fontSize: 14, fontWeight: 600 },
+                        '& table': {
+                          borderCollapse: 'collapse',
+                          width: 'max-content',
+                          maxWidth: '100%',
+                          mb: 1,
+                        },
+                        '& th, & td': {
+                          border: 1,
+                          borderColor: 'divider',
+                          px: 1,
+                          py: 0.5,
+                          textAlign: 'left',
+                          verticalAlign: 'top',
+                        },
+                        '& th': { bgcolor: 'action.hover', fontWeight: 600 },
+                        '& code': {
+                          bgcolor: 'action.hover',
+                          px: 0.5,
+                          borderRadius: 0.5,
+                          fontSize: 12,
+                        },
+                        '& pre': { overflow: 'auto', m: 0, mb: 1 },
+                        '& ul, & ol': { m: 0, mb: 1, pl: 2.5 },
+                        '& a': { wordBreak: 'break-all' },
+                      }}
+                    >
+                      {ev.deliverable ? (
+                        <ReactMarkdown
+                          remarkPlugins={[remarkGfm]}
+                          components={{
+                            a: ({ node: _node, ...props }) => (
+                              <a {...props} target="_blank" rel="noreferrer" />
+                            ),
+                          }}
+                        >
+                          {ev.deliverable}
+                        </ReactMarkdown>
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          (empty deliverable)
+                        </Typography>
+                      )}
+                    </Box>
                     <Box
                       sx={{
                         display: 'flex',

--- a/src/frontend/src/components/Crew/CrewOptimizeDialog.tsx
+++ b/src/frontend/src/components/Crew/CrewOptimizeDialog.tsx
@@ -369,7 +369,7 @@ const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
                 ))}
               </Select>
             </FormControl>
-            <Tooltip title="HARD CAP on crew executions — the run never exceeds this number. Includes 1 validation + 1 baseline execution, so allow at least 6 for a real search. Executions have real side effects (tools, emails, database writes).">
+            <Tooltip title="HARD CAP on crew executions — the run never exceeds this number. The baseline costs 1 execution; each further execution evaluates one NEW candidate prompt set (re-evaluations are cached and free). Executions have real side effects (tools, emails, database writes).">
               <TextField
                 size="small"
                 type="number"
@@ -556,6 +556,26 @@ const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
                       variant="outlined"
                       label={`${run.executions_used}/${run.execution_cap} executions`}
                     />
+                  )}
+                {typeof run.candidates_tried === 'number' && run.candidates_tried > 1 && (
+                  <Tooltip title="Distinct prompt variants executed (baseline + GEPA candidates). Re-evaluations of an already-executed variant are cached and free.">
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={`${run.candidates_tried} variants tried`}
+                    />
+                  </Tooltip>
+                )}
+                {typeof run.human_feedback_count === 'number' &&
+                  run.human_feedback_count > 0 && (
+                    <Tooltip title="Your grades, comments and expectations on past evaluation answers — folded into this run's judge rubric AND into what the GEPA reflection model sees.">
+                      <Chip
+                        size="small"
+                        variant="outlined"
+                        color="secondary"
+                        label={`guided by ${run.human_feedback_count} human notes`}
+                      />
+                    </Tooltip>
                   )}
                 {typeof run.initial_score === 'number' &&
                   typeof run.final_score === 'number' && (

--- a/src/frontend/src/components/Crew/CrewOptimizeDialog.tsx
+++ b/src/frontend/src/components/Crew/CrewOptimizeDialog.tsx
@@ -8,9 +8,11 @@ import {
   Dialog,
   DialogContent,
   DialogTitle,
+  DialogActions,
   FormControl,
   IconButton,
   InputLabel,
+  ListItemText,
   Menu,
   MenuItem,
   Paper,
@@ -21,6 +23,8 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditIcon from '@mui/icons-material/Edit';
 import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -123,6 +127,12 @@ const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
   const [judgeCriteria, setJudgeCriteria] = useState('');
   const [judgeModel, setJudgeModel] = useState('');
   const [savingJudge, setSavingJudge] = useState(false);
+  const [editJudge, setEditJudge] = useState<LLMJudge | null>(null);
+  const [editInstructions, setEditInstructions] = useState('');
+  const [editModel, setEditModel] = useState('');
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [deleteJudgeTarget, setDeleteJudgeTarget] = useState<LLMJudge | null>(null);
+  const [deletingJudge, setDeletingJudge] = useState(false);
 
   const refreshRuns = useCallback(async () => {
     if (!crewId) return;
@@ -309,6 +319,56 @@ const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
     }
   };
 
+  const openEditJudge = (judge: LLMJudge) => {
+    setEditJudge(judge);
+    setEditInstructions(judge.instructions || '');
+    // Empty = keep the judge's current model; the stored value is an MLflow
+    // model URI, not a Kasal model key, so there is no reliable reverse map.
+    setEditModel('');
+  };
+
+  const handleUpdateJudge = async () => {
+    if (!editJudge) return;
+    setSavingEdit(true);
+    try {
+      await PromptOptimizationService.updateJudge(
+        editJudge.full_name || editJudge.name,
+        { instructions: editInstructions, model: editModel || undefined },
+      );
+      toast.success(
+        editJudge.crew_id
+          ? `Judge "${editJudge.name}" updated — the next run uses the new version`
+          : `Library judge "${editJudge.name}" updated`,
+      );
+      setEditJudge(null);
+      await refreshJudges();
+    } catch (e: unknown) {
+      const detail =
+        (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+        'Failed to update judge';
+      setError(detail);
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const handleDeleteLibraryJudge = async () => {
+    if (!deleteJudgeTarget) return;
+    setDeletingJudge(true);
+    try {
+      await PromptOptimizationService.deleteJudge(
+        deleteJudgeTarget.full_name || deleteJudgeTarget.name,
+      );
+      toast.success(`Judge "${deleteJudgeTarget.name}" deleted`);
+      setDeleteJudgeTarget(null);
+      await refreshJudges();
+    } catch {
+      setError('Failed to delete judge');
+    } finally {
+      setDeletingJudge(false);
+    }
+  };
+
   const crewPrefix = crewId ? crewId.replace(/-/g, '').slice(0, 12) : '';
   const assignedJudges = judges.filter((j) => j.crew_id === crewPrefix);
   const libraryJudges = judges.filter(
@@ -430,8 +490,10 @@ const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
                 size="small"
                 color="primary"
                 variant="outlined"
+                clickable
                 label={j.name}
-                title={j.instructions || ''}
+                title={`${j.instructions || ''}\n\nClick to edit this judge.`}
+                onClick={() => openEditJudge(j)}
                 onDelete={() => handleUnassignJudge(j.full_name || j.name)}
               />
             ))}
@@ -458,24 +520,53 @@ const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
                         void handleAssignJudge(j.name);
                       }}
                     >
-                      <Box>
-                        <Typography variant="body2">{j.name}</Typography>
-                        {j.instructions && (
-                          <Typography
-                            variant="caption"
-                            color="text.secondary"
-                            sx={{
-                              display: 'block',
-                              maxWidth: 320,
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {j.instructions}
-                          </Typography>
-                        )}
-                      </Box>
+                      <ListItemText
+                        primary={<Typography variant="body2">{j.name}</Typography>}
+                        secondary={
+                          j.instructions ? (
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              sx={{
+                                display: 'block',
+                                maxWidth: 320,
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {j.instructions}
+                            </Typography>
+                          ) : undefined
+                        }
+                      />
+                      <Tooltip title="Edit judge">
+                        <IconButton
+                          size="small"
+                          edge="end"
+                          sx={{ ml: 1 }}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setAssignAnchor(null);
+                            openEditJudge(j);
+                          }}
+                        >
+                          <EditIcon sx={{ fontSize: 16 }} />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Delete from library">
+                        <IconButton
+                          size="small"
+                          edge="end"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setAssignAnchor(null);
+                            setDeleteJudgeTarget(j);
+                          }}
+                        >
+                          <DeleteOutlineIcon sx={{ fontSize: 16 }} />
+                        </IconButton>
+                      </Tooltip>
                     </MenuItem>
                   ))}
                 </Menu>
@@ -871,6 +962,87 @@ const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
           </>
         )}
       </DialogContent>
+
+      {/* Edit judge — instructions and/or model; saving registers a new
+          version under the same registry name (latest version wins). */}
+      <Dialog
+        open={Boolean(editJudge)}
+        onClose={() => setEditJudge(null)}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <GavelIcon fontSize="small" color="primary" />
+          Edit judge — {editJudge?.name}
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+            {editJudge?.crew_id
+              ? 'This judge is assigned to this crew — changes apply to the next optimization run.'
+              : 'This is a shared library judge — copies already assigned to crews keep their current version until re-assigned.'}
+          </Typography>
+          <FormControl size="small" fullWidth sx={{ mb: 2 }}>
+            <InputLabel>Judge model</InputLabel>
+            <Select
+              value={editModel}
+              label="Judge model"
+              onChange={(e) => setEditModel(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>Keep current{editJudge?.model ? ` (${editJudge.model})` : ''}</em>
+              </MenuItem>
+              {models.map((key) => (
+                <MenuItem key={key} value={key}>
+                  {key}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            fullWidth
+            multiline
+            minRows={4}
+            maxRows={14}
+            size="small"
+            label="Evaluation criteria (plain language)"
+            value={editInstructions}
+            onChange={(e) => setEditInstructions(e.target.value)}
+            helperText="Reference the answer as {{ outputs }} — added automatically when missing."
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditJudge(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            disabled={savingEdit || (!editInstructions.trim() && !editModel)}
+            onClick={() => void handleUpdateJudge()}
+          >
+            {savingEdit ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete library judge — confirm first; crew-assigned copies survive. */}
+      <Dialog open={Boolean(deleteJudgeTarget)} onClose={() => setDeleteJudgeTarget(null)}>
+        <DialogTitle>Delete judge “{deleteJudgeTarget?.name}”?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary">
+            The judge is removed from the shared library. Crews that already have
+            it assigned keep their own copy until it is unassigned there.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteJudgeTarget(null)}>Cancel</Button>
+          <Button
+            color="error"
+            variant="contained"
+            disabled={deletingJudge}
+            onClick={() => void handleDeleteLibraryJudge()}
+          >
+            {deletingJudge ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Dialog>
   );
 };

--- a/src/frontend/src/components/Crew/CrewOptimizeDialog.tsx
+++ b/src/frontend/src/components/Crew/CrewOptimizeDialog.tsx
@@ -1,0 +1,802 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  IconButton,
+  InputLabel,
+  Menu,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import CloseIcon from '@mui/icons-material/Close';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import GavelIcon from '@mui/icons-material/Gavel';
+import { toast } from 'react-hot-toast';
+import {
+  CrewEval,
+  LLMJudge,
+  PromptOptimizationRun,
+  PromptOptimizationService,
+} from '../../api/PromptOptimizationService';
+import { ModelService } from '../../api/ModelService';
+
+interface CrewOptimizeDialogProps {
+  open: boolean;
+  crewId: string | null;
+  crewName?: string;
+  onClose: () => void;
+}
+
+const POLL_INTERVAL_MS = 10000;
+
+const statusColor = (
+  status: PromptOptimizationRun['status'],
+): 'default' | 'info' | 'success' | 'error' | 'warning' => {
+  switch (status) {
+    case 'completed':
+      return 'success';
+    case 'failed':
+      return 'error';
+    case 'cancelled':
+      return 'warning';
+    case 'running':
+      return 'info';
+    default:
+      return 'default';
+  }
+};
+
+/** Human label for a flattened crew field key like "agent.<id>.role". */
+const fieldLabel = (key: string): string => {
+  const [kind, , field] = key.split('.', 3);
+  return `${kind} ${field?.replace('_', ' ') ?? key}`;
+};
+
+const SectionHeader: React.FC<{ title: string; hint?: string }> = ({ title, hint }) => (
+  <Box sx={{ mt: 3, mb: 1 }}>
+    <Typography
+      variant="overline"
+      sx={{ letterSpacing: 1, color: 'text.secondary', lineHeight: 1.5 }}
+    >
+      {title}
+    </Typography>
+    {hint && (
+      <Typography variant="caption" color="text.secondary" display="block">
+        {hint}
+      </Typography>
+    )}
+  </Box>
+);
+
+/**
+ * GEPA optimization for a saved crew: every evaluation EXECUTES the crew for
+ * real and judges score the final deliverable. Evaluation answers are graded
+ * here (per judge) and proposals are applied back to the crew's records.
+ */
+const CrewOptimizeDialog: React.FC<CrewOptimizeDialogProps> = ({
+  open,
+  crewId,
+  crewName,
+  onClose,
+}) => {
+  const [models, setModels] = useState<string[]>([]);
+  const [model, setModel] = useState('');
+  const [budget, setBudget] = useState(10);
+  const [guidance, setGuidance] = useState('');
+  const [starting, setStarting] = useState(false);
+  const [applying, setApplying] = useState<string | null>(null);
+  const [runs, setRuns] = useState<PromptOptimizationRun[]>([]);
+  const [expandedRun, setExpandedRun] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<number | null>(null);
+
+  // Evaluation answers (local MLflow traces) gradable in-app.
+  const [evals, setEvals] = useState<CrewEval[]>([]);
+  const [expandedEval, setExpandedEval] = useState<string | null>(null);
+  const [evalGrade, setEvalGrade] = useState<Record<string, number>>({});
+  const [evalComment, setEvalComment] = useState<Record<string, string>>({});
+  const [evalExpectation, setEvalExpectation] = useState<Record<string, string>>({});
+  const [evalJudge, setEvalJudge] = useState<Record<string, string>>({});
+  const [submittingEval, setSubmittingEval] = useState<string | null>(null);
+
+  // Custom LLM judges (registered scorers) — created here, used automatically.
+  const [judges, setJudges] = useState<LLMJudge[]>([]);
+  const [assignAnchor, setAssignAnchor] = useState<HTMLElement | null>(null);
+  const [showJudgeForm, setShowJudgeForm] = useState(false);
+  const [judgeName, setJudgeName] = useState('');
+  const [judgeCriteria, setJudgeCriteria] = useState('');
+  const [judgeModel, setJudgeModel] = useState('');
+  const [savingJudge, setSavingJudge] = useState(false);
+
+  const refreshRuns = useCallback(async () => {
+    if (!crewId) return;
+    try {
+      const all = await PromptOptimizationService.listRuns();
+      setRuns(all.filter((r) => r.kind === 'crew' && r.crew_id === crewId));
+    } catch {
+      /* transient */
+    }
+  }, [crewId]);
+
+  const refreshEvals = useCallback(async () => {
+    if (!crewId) return;
+    try {
+      setEvals(await PromptOptimizationService.listCrewEvals(crewId));
+    } catch {
+      setEvals([]);
+    }
+  }, [crewId]);
+
+  const refreshJudges = useCallback(async () => {
+    try {
+      setJudges(await PromptOptimizationService.listJudges());
+    } catch {
+      setJudges([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    // Clear the previous crew's data FIRST — the dialog is a persistent
+    // component, and stale runs/evals from the last-opened crew would render
+    // until the (multi-second) MLflow fetch for this crew lands.
+    setRuns([]);
+    setEvals([]);
+    setExpandedRun(null);
+    setExpandedEval(null);
+    setError(null);
+    void refreshRuns();
+    void refreshEvals();
+    void refreshJudges();
+    (async () => {
+      try {
+        const enabled = await ModelService.getInstance().getEnabledModels();
+        setModels(Object.keys(enabled));
+      } catch {
+        setModels([]);
+      }
+    })();
+  }, [open, refreshRuns, refreshEvals, refreshJudges]);
+
+  const hasActiveRun = runs.some((r) => r.status === 'pending' || r.status === 'running');
+  useEffect(() => {
+    if (!open || !hasActiveRun) return;
+    pollRef.current = window.setInterval(() => {
+      void refreshRuns();
+      void refreshEvals();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) window.clearInterval(pollRef.current);
+    };
+  }, [open, hasActiveRun, refreshRuns, refreshEvals]);
+
+  const handleStart = async () => {
+    if (!crewId) return;
+    setStarting(true);
+    setError(null);
+    try {
+      const started = await PromptOptimizationService.startCrewOptimization({
+        crew_id: crewId,
+        model: model || undefined,
+        guidance: guidance || undefined,
+        max_metric_calls: budget,
+      });
+      setExpandedRun(started.run_id);
+      await refreshRuns();
+    } catch (e: unknown) {
+      const detail =
+        (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+        'Failed to start crew optimization';
+      setError(detail);
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const [cancelling, setCancelling] = useState<string | null>(null);
+  const handleCancel = async (runId: string) => {
+    setCancelling(runId);
+    try {
+      await PromptOptimizationService.cancelRun(runId);
+      toast.success('Stopping — the current execution finishes first');
+      await refreshRuns();
+    } catch {
+      setError('Failed to request stop');
+    } finally {
+      setCancelling(null);
+    }
+  };
+
+  const handleApply = async (runId: string) => {
+    setApplying(runId);
+    try {
+      await PromptOptimizationService.applyRun(runId);
+      toast.success('Optimized prompts applied to the crew');
+      await refreshRuns();
+    } catch {
+      setError('Failed to apply the optimized prompts');
+    } finally {
+      setApplying(null);
+    }
+  };
+
+  const handleEvalFeedback = async (traceId: string) => {
+    const grade = evalGrade[traceId];
+    const expectation = (evalExpectation[traceId] || '').trim();
+    if (grade === undefined && !expectation) return;
+    setSubmittingEval(traceId);
+    try {
+      // Judge attribution rides in the comment so the harvesting step can
+      // tell WHICH judge's criteria this grade speaks to.
+      const judge = evalJudge[traceId] || 'overall';
+      const note = evalComment[traceId] || '';
+      await PromptOptimizationService.addEvalFeedback(
+        traceId,
+        grade,
+        judge === 'overall' ? note || undefined : `[judge: ${judge}] ${note}`.trim(),
+        expectation || undefined,
+      );
+      toast.success('Assessment saved — the next run will use it');
+      await refreshEvals();
+      setExpandedEval(null);
+    } catch {
+      setError('Failed to save the assessment');
+    } finally {
+      setSubmittingEval(null);
+    }
+  };
+
+  const handleCreateJudge = async () => {
+    if (!crewId) return;
+    setSavingJudge(true);
+    try {
+      // Created from a crew's dialog → assigned to THIS crew.
+      await PromptOptimizationService.createJudge(
+        judgeName,
+        judgeCriteria,
+        judgeModel || undefined,
+        crewId,
+      );
+      toast.success('Judge created — it will grade the next optimization run');
+      setJudgeName('');
+      setJudgeCriteria('');
+      setShowJudgeForm(false);
+      await refreshJudges();
+    } catch (e: unknown) {
+      const detail =
+        (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+        'Failed to create judge';
+      setError(detail);
+    } finally {
+      setSavingJudge(false);
+    }
+  };
+
+  const handleUnassignJudge = async (fullName: string) => {
+    try {
+      // Deleting the crew-scoped copy unassigns; a library original remains.
+      await PromptOptimizationService.deleteJudge(fullName);
+      await refreshJudges();
+    } catch {
+      setError('Failed to unassign judge');
+    }
+  };
+
+  const handleAssignJudge = async (name: string) => {
+    if (!crewId) return;
+    try {
+      await PromptOptimizationService.assignJudge(name, crewId);
+      toast.success(`Judge "${name}" assigned to this crew`);
+      await refreshJudges();
+    } catch {
+      setError('Failed to assign judge');
+    }
+  };
+
+  const crewPrefix = crewId ? crewId.replace(/-/g, '').slice(0, 12) : '';
+  const assignedJudges = judges.filter((j) => j.crew_id === crewPrefix);
+  const libraryJudges = judges.filter(
+    (j) => !j.crew_id && !assignedJudges.some((a) => a.name === j.name),
+  );
+
+  const changedFields = (run: PromptOptimizationRun): string[] => {
+    const baseline = run.baseline_fields || {};
+    const optimized = run.optimized_fields || {};
+    return Object.keys(optimized).filter(
+      (k) => optimized[k] && optimized[k] !== baseline[k],
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1, pb: 1 }}>
+        <AutoFixHighIcon fontSize="small" color="primary" />
+        <Box>
+          <Typography variant="h6" component="span">
+            Optimize crew
+          </Typography>
+          {crewName && (
+            <Typography variant="h6" component="span" color="text.secondary">
+              {' '}
+              — {crewName}
+            </Typography>
+          )}
+        </Box>
+        <Box sx={{ flexGrow: 1 }} />
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          GEPA searches for better agent and task prompts. Every evaluation runs
+          the crew for real and your judges score the final deliverable — the
+          budget is the number of crew executions.
+        </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {/* Run configuration */}
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
+            <FormControl size="small" sx={{ minWidth: 230 }}>
+              <InputLabel>Model</InputLabel>
+              <Select value={model} label="Model" onChange={(e) => setModel(e.target.value)}>
+                <MenuItem value="">
+                  <em>Default</em>
+                </MenuItem>
+                {models.map((key) => (
+                  <MenuItem key={key} value={key}>
+                    {key}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Tooltip title="HARD CAP on crew executions — the run never exceeds this number. Includes 1 validation + 1 baseline execution, so allow at least 6 for a real search. Executions have real side effects (tools, emails, database writes).">
+              <TextField
+                size="small"
+                type="number"
+                label="Max crew executions"
+                value={budget}
+                onChange={(e) =>
+                  setBudget(Math.max(4, Math.min(40, Number(e.target.value) || 10)))
+                }
+                sx={{ width: 170 }}
+              />
+            </Tooltip>
+            <TextField
+              size="small"
+              label="Judging guidance (optional)"
+              placeholder="what does a good deliverable look like?"
+              value={guidance}
+              onChange={(e) => setGuidance(e.target.value)}
+              sx={{ flex: 1, minWidth: 220 }}
+            />
+            <Button
+              variant="contained"
+              onClick={handleStart}
+              disabled={starting || hasActiveRun || !crewId}
+              startIcon={starting ? <CircularProgress size={16} /> : <AutoFixHighIcon />}
+            >
+              {starting ? 'Starting…' : hasActiveRun ? 'Run in progress…' : 'Start GEPA'}
+            </Button>
+          </Box>
+
+          {/* Judges */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              flexWrap: 'wrap',
+              mt: 2,
+              pt: 1.5,
+              borderTop: '1px dashed',
+              borderColor: 'divider',
+            }}
+          >
+            <GavelIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+              Judges
+            </Typography>
+            <Chip
+              size="small"
+              variant="outlined"
+              label="Quality (built-in)"
+              title="Grades every deliverable 0-10 on completeness, specificity, and fidelity to the expected outputs"
+            />
+            {assignedJudges.map((j) => (
+              <Chip
+                key={j.full_name || j.name}
+                size="small"
+                color="primary"
+                variant="outlined"
+                label={j.name}
+                title={j.instructions || ''}
+                onDelete={() => handleUnassignJudge(j.full_name || j.name)}
+              />
+            ))}
+            {libraryJudges.length > 0 && (
+              <>
+                <Chip
+                  size="small"
+                  clickable
+                  variant="outlined"
+                  icon={<AddIcon sx={{ fontSize: 16 }} />}
+                  label="Assign"
+                  onClick={(e) => setAssignAnchor(e.currentTarget)}
+                />
+                <Menu
+                  anchorEl={assignAnchor}
+                  open={Boolean(assignAnchor)}
+                  onClose={() => setAssignAnchor(null)}
+                >
+                  {libraryJudges.map((j) => (
+                    <MenuItem
+                      key={j.full_name || j.name}
+                      onClick={() => {
+                        setAssignAnchor(null);
+                        void handleAssignJudge(j.name);
+                      }}
+                    >
+                      <Box>
+                        <Typography variant="body2">{j.name}</Typography>
+                        {j.instructions && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{
+                              display: 'block',
+                              maxWidth: 320,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {j.instructions}
+                          </Typography>
+                        )}
+                      </Box>
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </>
+            )}
+            <Button size="small" onClick={() => setShowJudgeForm((v) => !v)}>
+              {showJudgeForm ? 'Cancel' : '+ Create judge'}
+            </Button>
+          </Box>
+          {showJudgeForm && (
+            <Box sx={{ mt: 1.5 }}>
+              <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 1 }}>
+                <TextField
+                  size="small"
+                  label="Judge name"
+                  value={judgeName}
+                  onChange={(e) => setJudgeName(e.target.value)}
+                  sx={{ width: 200 }}
+                />
+                <FormControl size="small" sx={{ minWidth: 220 }}>
+                  <InputLabel>Judge model</InputLabel>
+                  <Select
+                    value={judgeModel}
+                    label="Judge model"
+                    onChange={(e) => setJudgeModel(e.target.value)}
+                  >
+                    <MenuItem value="">
+                      <em>Default</em>
+                    </MenuItem>
+                    {models.map((key) => (
+                      <MenuItem key={key} value={key}>
+                        {key}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box>
+              <TextField
+                fullWidth
+                multiline
+                minRows={2}
+                size="small"
+                label="Evaluation criteria (plain language)"
+                placeholder="e.g. Score 0-10: the answer must cite at least three named sources and include a structured summary table."
+                value={judgeCriteria}
+                onChange={(e) => setJudgeCriteria(e.target.value)}
+              />
+              <Box sx={{ mt: 1, textAlign: 'right' }}>
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={savingJudge || !judgeName.trim() || !judgeCriteria.trim()}
+                  onClick={handleCreateJudge}
+                >
+                  {savingJudge ? 'Creating…' : 'Create judge'}
+                </Button>
+              </Box>
+            </Box>
+          )}
+        </Paper>
+
+        {/* Runs */}
+        <SectionHeader title="Optimization runs" />
+        {runs.length === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            No optimization runs for this crew yet.
+          </Typography>
+        )}
+        {runs.map((run) => {
+          const changed = changedFields(run);
+          return (
+            <Paper key={run.run_id} variant="outlined" sx={{ p: 1.5, mb: 1 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+                <Chip size="small" label={run.status} color={statusColor(run.status)} />
+                {run.status === 'running' && <CircularProgress size={14} />}
+                {typeof run.executions_used === 'number' &&
+                  typeof run.execution_cap === 'number' && (
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={`${run.executions_used}/${run.execution_cap} executions`}
+                    />
+                  )}
+                {typeof run.initial_score === 'number' &&
+                  typeof run.final_score === 'number' && (
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={`score ${run.initial_score.toFixed(2)} → ${run.final_score.toFixed(2)}`}
+                    />
+                  )}
+                {run.applied && (
+                  <Chip size="small" color="success" variant="outlined" label="applied" />
+                )}
+                <Typography variant="caption" color="text.secondary">
+                  {run.created_at ? new Date(run.created_at).toLocaleString() : ''}
+                </Typography>
+                <Box sx={{ flexGrow: 1 }} />
+                {(run.status === 'running' || run.status === 'pending') && (
+                  <Button
+                    size="small"
+                    color="error"
+                    variant="outlined"
+                    disabled={cancelling === run.run_id}
+                    onClick={() => handleCancel(run.run_id)}
+                  >
+                    {cancelling === run.run_id ? 'Stopping…' : 'Stop'}
+                  </Button>
+                )}
+                {run.status === 'completed' && changed.length > 0 && (
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    disabled={run.applied || applying === run.run_id}
+                    onClick={() => handleApply(run.run_id)}
+                  >
+                    {applying === run.run_id
+                      ? 'Applying…'
+                      : run.applied
+                        ? 'Applied'
+                        : `Apply ${changed.length} changes`}
+                  </Button>
+                )}
+                <IconButton
+                  size="small"
+                  onClick={() =>
+                    setExpandedRun(expandedRun === run.run_id ? null : run.run_id)
+                  }
+                >
+                  {expandedRun === run.run_id ? (
+                    <ExpandLessIcon fontSize="small" />
+                  ) : (
+                    <ExpandMoreIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </Box>
+              {expandedRun === run.run_id && (
+                <Box sx={{ mt: 1.5 }}>
+                  {run.error && (
+                    <Alert severity="error" sx={{ mb: 1.5, whiteSpace: 'pre-wrap' }}>
+                      {run.error}
+                    </Alert>
+                  )}
+                  {run.status === 'completed' && changed.length === 0 && (
+                    <Alert severity="info">
+                      No field changes proposed — the baseline prompts won this
+                      run&apos;s search.
+                    </Alert>
+                  )}
+                  {changed.map((key) => (
+                    <Box key={key} sx={{ mb: 2 }}>
+                      <Chip
+                        size="small"
+                        variant="outlined"
+                        label={fieldLabel(key)}
+                        sx={{ mb: 0.5 }}
+                      />
+                      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                        <TextField
+                          fullWidth
+                          multiline
+                          maxRows={6}
+                          size="small"
+                          label="Current"
+                          value={run.baseline_fields?.[key] || ''}
+                          InputProps={{ readOnly: true, sx: { fontSize: 13 } }}
+                          sx={{ flex: 1, minWidth: 260 }}
+                        />
+                        <TextField
+                          fullWidth
+                          multiline
+                          maxRows={6}
+                          size="small"
+                          label="Proposed"
+                          value={run.optimized_fields?.[key] || ''}
+                          InputProps={{ readOnly: true, sx: { fontSize: 13 } }}
+                          sx={{ flex: 1, minWidth: 260 }}
+                        />
+                      </Box>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+            </Paper>
+          );
+        })}
+
+        {/* Evaluation answers */}
+        {evals.length > 0 && (
+          <>
+            <SectionHeader
+              title={`Evaluation answers — ${evals.filter((e) => e.assessment_count === 0).length} to grade, ${evals.filter((e) => e.assessment_count > 0).length} graded`}
+              hint="Grade answers against a judge's criteria (or overall) — the next run folds your grades into that judge's guidance."
+            />
+            {[...evals]
+              .sort((a, b) =>
+                a.assessment_count === b.assessment_count
+                  ? (b.timestamp_ms || 0) - (a.timestamp_ms || 0)
+                  : a.assessment_count - b.assessment_count,
+              )
+              .map((ev) => (
+              <Paper key={ev.trace_id} variant="outlined" sx={{ p: 1.5, mb: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                  <Typography variant="body2" sx={{ flex: 1 }} noWrap>
+                    {ev.deliverable.slice(0, 110) || '(empty deliverable)'}
+                  </Typography>
+                  {ev.assessment_count > 0 && (
+                    <Chip
+                      size="small"
+                      color="success"
+                      variant="outlined"
+                      label={`${ev.assessment_count} graded`}
+                    />
+                  )}
+                  <Button
+                    size="small"
+                    onClick={() =>
+                      setExpandedEval(expandedEval === ev.trace_id ? null : ev.trace_id)
+                    }
+                  >
+                    {expandedEval === ev.trace_id ? 'Hide' : 'Grade'}
+                  </Button>
+                </Box>
+                {expandedEval === ev.trace_id && (
+                  <Box sx={{ mt: 1.5 }}>
+                    <TextField
+                      fullWidth
+                      multiline
+                      maxRows={10}
+                      size="small"
+                      label="Answer"
+                      value={ev.deliverable}
+                      InputProps={{ readOnly: true, sx: { fontSize: 13 } }}
+                    />
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        gap: 2,
+                        mt: 1.5,
+                        alignItems: 'center',
+                        flexWrap: 'wrap',
+                      }}
+                    >
+                      <FormControl size="small" sx={{ minWidth: 170 }}>
+                        <InputLabel>Grading for</InputLabel>
+                        <Select
+                          value={evalJudge[ev.trace_id] ?? 'overall'}
+                          label="Grading for"
+                          onChange={(e) =>
+                            setEvalJudge((j) => ({ ...j, [ev.trace_id]: e.target.value }))
+                          }
+                        >
+                          <MenuItem value="overall">Overall quality</MenuItem>
+                          {assignedJudges.map((j) => (
+                            <MenuItem key={j.full_name || j.name} value={j.name}>
+                              {j.name}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                      <TextField
+                        size="small"
+                        type="number"
+                        label="Grade (0-10)"
+                        value={evalGrade[ev.trace_id] ?? ''}
+                        onChange={(e) =>
+                          setEvalGrade((g) => ({
+                            ...g,
+                            [ev.trace_id]: Math.max(
+                              0,
+                              Math.min(10, Number(e.target.value) || 0),
+                            ),
+                          }))
+                        }
+                        sx={{ width: 120 }}
+                      />
+                      <TextField
+                        size="small"
+                        label="What's wrong / right? (optional)"
+                        value={evalComment[ev.trace_id] ?? ''}
+                        onChange={(e) =>
+                          setEvalComment((c) => ({ ...c, [ev.trace_id]: e.target.value }))
+                        }
+                        sx={{ flex: 1, minWidth: 200 }}
+                      />
+                      <Button
+                        size="small"
+                        variant="contained"
+                        disabled={
+                          (evalGrade[ev.trace_id] === undefined &&
+                            !(evalExpectation[ev.trace_id] || '').trim()) ||
+                          submittingEval === ev.trace_id
+                        }
+                        onClick={() => handleEvalFeedback(ev.trace_id)}
+                      >
+                        {submittingEval === ev.trace_id ? 'Saving…' : 'Save'}
+                      </Button>
+                    </Box>
+                    <TextField
+                      fullWidth
+                      multiline
+                      minRows={2}
+                      size="small"
+                      label="Expectation — what SHOULD this answer contain? (optional)"
+                      placeholder="e.g. Must list the 4-3-3 formation with player roles, include FIFA 2026 defensive tricks, and cite at least two sources. No implementation action plan."
+                      value={evalExpectation[ev.trace_id] ?? ''}
+                      onChange={(e) =>
+                        setEvalExpectation((x) => ({
+                          ...x,
+                          [ev.trace_id]: e.target.value,
+                        }))
+                      }
+                      sx={{ mt: 1.5 }}
+                    />
+                  </Box>
+                )}
+              </Paper>
+            ))}
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CrewOptimizeDialog;

--- a/src/frontend/src/components/Documentation/Documentation.tsx
+++ b/src/frontend/src/components/Documentation/Documentation.tsx
@@ -89,6 +89,7 @@ const docSections: DocSection[] = [
       { label: 'Simple Migration Story', file: 'powerbi/02-simple-migration-story' },
       { label: 'Analytics Q&A Case Study', file: 'powerbi/powerbi-analytics-qa-case-study' },
       { label: 'End-to-End Migration Guide', file: 'powerbi/ucmv-migration-guide' },
+      { label: 'Thin Reports & Source Resolution', file: 'powerbi/thin-report-and-source-resolution' },
       { label: 'Pipeline Config Reference', file: 'UCMV_PIPELINE_CONFIG_GUIDE' },
       { label: 'Tool 72: Comprehensive Analysis', file: 'powerbi/tool-72-comprehensive-analysis' },
       { label: 'Tool 73: Measure Conversion', file: 'powerbi/tool-73-measure-conversion' },

--- a/src/frontend/src/components/Jobs/ReevaluationResultViewer.test.tsx
+++ b/src/frontend/src/components/Jobs/ReevaluationResultViewer.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Tests for ReevaluationResultViewer — the UCMV Re-evaluation report.
+ *
+ * The sweep re-tries measures that failed on PAST runs and proposes the ones today's
+ * transpiler can recover. This viewer must show the measure, why it failed before, and
+ * the NEW SQL — and must clearly say "nothing to gain" when a run is already at the
+ * current capability level.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ReevaluationResultViewer, {
+  isReevaluationResult,
+  type ReevaluationResult,
+} from './ReevaluationResultViewer';
+
+const withRecovery: ReevaluationResult = {
+  capability: { fingerprint: 'abc123def4567890', pattern_count: 24, skill_file_count: 10 },
+  settings: { use_llm: false },
+  datasets: [
+    {
+      dataset_id: 'ds-old',
+      workspace_id: 'ws1',
+      fingerprint_changed: true,
+      newly_translatable: [
+        {
+          original_name: 'Total Amount',
+          table_key: 'fact_sales',
+          previous_skip_reason: 'no matching pattern',
+          previous_category: 'complex DAX — needs manual translation',
+          new_sql: 'SUM(source.amount)',
+          confidence: 'high',
+          referenced_by: 7,
+        },
+      ],
+      still_failing_count: 3,
+      skipped_count: 2,
+    },
+  ],
+  summary: {
+    datasets_scanned: 1, measures_retried: 4, measures_recovered: 1,
+    datasets_with_recoveries: 1,
+  },
+};
+
+const noGains: ReevaluationResult = {
+  capability: { fingerprint: 'abc123def4567890' },
+  datasets: [
+    {
+      dataset_id: 'ds-current',
+      fingerprint_changed: false,
+      note: 'transpiler unchanged since this run — nothing to gain',
+      newly_translatable: [],
+      still_failing_count: 5,
+      skipped_count: 0,
+    },
+  ],
+  summary: {
+    datasets_scanned: 1, measures_retried: 0, measures_recovered: 0,
+    datasets_with_recoveries: 0,
+  },
+};
+
+describe('isReevaluationResult', () => {
+  it('detects a re-evaluation report', () => {
+    expect(isReevaluationResult(withRecovery)).toBe(true);
+  });
+
+  it('rejects unrelated shapes', () => {
+    expect(isReevaluationResult(null)).toBe(false);
+    expect(isReevaluationResult({})).toBe(false);
+    expect(isReevaluationResult({ datasets: [] })).toBe(false); // no summary
+    expect(isReevaluationResult({ yaml: {}, sql: {}, stats: {} })).toBe(false); // UCMV result
+  });
+});
+
+describe('ReevaluationResultViewer', () => {
+  it('shows summary tiles including the recovered count', () => {
+    render(<ReevaluationResultViewer result={withRecovery} />);
+    expect(screen.getByText('Now Recoverable')).toBeInTheDocument();
+    expect(screen.getByText('Datasets Scanned')).toBeInTheDocument();
+    expect(screen.getByText('Measures Retried')).toBeInTheDocument();
+  });
+
+  it('lists a recovered measure with its previous reason and NEW SQL', () => {
+    render(<ReevaluationResultViewer result={withRecovery} />);
+    expect(screen.getByText('Total Amount')).toBeInTheDocument();
+    expect(screen.getByText('no matching pattern')).toBeInTheDocument();
+    expect(screen.getByText('SUM(source.amount)')).toBeInTheDocument();
+    expect(screen.getByText('ds-old')).toBeInTheDocument();
+  });
+
+  it('states that nothing was applied automatically', () => {
+    render(<ReevaluationResultViewer result={withRecovery} />);
+    expect(screen.getByText(/nothing has been changed automatically/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the capability fingerprint', () => {
+    render(<ReevaluationResultViewer result={withRecovery} />);
+    expect(screen.getByText(/capability abc123def4567890/)).toBeInTheDocument();
+  });
+
+  it('explains a no-gain sweep instead of looking broken', () => {
+    render(<ReevaluationResultViewer result={noGains} />);
+    expect(screen.getByText(/No previously-failed measure became translatable/i)).toBeInTheDocument();
+    expect(screen.getByText(/transpiler unchanged since this run/i)).toBeInTheDocument();
+    expect(screen.getByText('transpiler unchanged')).toBeInTheDocument();
+  });
+
+  it('renders an error from the sweep', () => {
+    render(
+      <ReevaluationResultViewer
+        result={{ ...noGains, error: 'could not load stored extractions: db down' }}
+      />,
+    );
+    expect(screen.getByText(/db down/)).toBeInTheDocument();
+  });
+
+  it('tolerates a report with no datasets', () => {
+    render(<ReevaluationResultViewer result={{ datasets: [], summary: { datasets_scanned: 0 } }} />);
+    expect(screen.getByText('UCMV Re-evaluation')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/Jobs/ReevaluationResultViewer.tsx
+++ b/src/frontend/src/components/Jobs/ReevaluationResultViewer.tsx
@@ -1,0 +1,271 @@
+/**
+ * ReevaluationResultViewer — displays the UCMV Re-evaluation tool's report.
+ *
+ * WHY: Kasal's DAX→UC-Metric-View capability keeps improving, but those gains only
+ * ever helped NEW conversions. The re-evaluation sweep re-tries the measures that
+ * failed on PAST runs and reports which ones today's transpiler can recover. This
+ * viewer surfaces those proposals — measure, why it failed before, and the NEW SQL —
+ * so a human can decide to re-transpile.
+ *
+ * Read-only by design: the sweep proposes, the human applies through the normal
+ * UCMV route. See src/docs/powerbi/ucmv-reevaluation-recoverable-measures.md
+ */
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  Chip,
+  Divider,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Alert,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface RecoveredMeasure {
+  original_name: string;
+  table_key?: string;
+  view_name?: string;
+  dax_expression?: string;
+  previous_skip_reason?: string;
+  previous_category?: string;
+  new_sql: string;
+  confidence?: string;
+  dax_class?: string | null;
+  referenced_by?: number;
+}
+
+export interface ReevaluationDataset {
+  dataset_id?: string;
+  workspace_id?: string;
+  converted_at?: string;
+  conversion_id?: number | string;
+  fingerprint_changed?: boolean;
+  note?: string;
+  newly_translatable?: RecoveredMeasure[];
+  still_failing_count?: number;
+  skipped_count?: number;
+}
+
+export interface ReevaluationResult {
+  capability?: {
+    fingerprint?: string;
+    pattern_count?: number;
+    skill_file_count?: number;
+  };
+  settings?: Record<string, unknown>;
+  datasets?: ReevaluationDataset[];
+  summary?: {
+    datasets_scanned?: number;
+    measures_retried?: number;
+    measures_recovered?: number;
+    datasets_with_recoveries?: number;
+  };
+  error?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Detection helper                                                    */
+/* ------------------------------------------------------------------ */
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function isReevaluationResult(value: unknown): value is ReevaluationResult {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  const hasDatasets = Array.isArray(obj.datasets);
+  const summary = obj.summary as Record<string, unknown> | undefined;
+  const hasSummary =
+    typeof summary === 'object' && summary !== null && 'datasets_scanned' in summary;
+  return hasDatasets && hasSummary;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                           */
+/* ------------------------------------------------------------------ */
+
+const ReevaluationResultViewer: React.FC<{ result: ReevaluationResult }> = ({ result }) => {
+  const summary = result.summary || {};
+  const datasets = useMemo(
+    () => (Array.isArray(result.datasets) ? result.datasets : []),
+    [result.datasets],
+  );
+
+  // Datasets with actual proposals come first — that's what a reviewer acts on.
+  const ordered = useMemo(() => {
+    return [...datasets].sort(
+      (a, b) => (b.newly_translatable?.length ?? 0) - (a.newly_translatable?.length ?? 0),
+    );
+  }, [datasets]);
+
+  const recovered = summary.measures_recovered ?? 0;
+
+  return (
+    <Box display="flex" flexDirection="column" gap={2}>
+      <Box display="flex" alignItems="center" gap={1}>
+        <AutoFixHighIcon color="primary" />
+        <Typography variant="h6">UCMV Re-evaluation</Typography>
+        {result.capability?.fingerprint && (
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`capability ${result.capability.fingerprint}`}
+            title={`${result.capability.pattern_count ?? '?'} translator patterns, ${result.capability.skill_file_count ?? '?'} skill files`}
+          />
+        )}
+      </Box>
+
+      {result.error && <Alert severity="error">{result.error}</Alert>}
+
+      {/* Summary tiles */}
+      <Box display="flex" gap={2} flexWrap="wrap">
+        <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 150, textAlign: 'center' }}>
+          <Typography variant="h4" sx={{ fontWeight: 700 }}>
+            {summary.datasets_scanned ?? 0}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">Datasets Scanned</Typography>
+        </Paper>
+        <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 150, textAlign: 'center' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+            <CheckCircleIcon sx={{ color: recovered > 0 ? 'success.main' : 'text.disabled' }} />
+            <Typography
+              variant="h4"
+              sx={{ fontWeight: 700, color: recovered > 0 ? 'success.main' : 'text.secondary' }}
+            >
+              {recovered}
+            </Typography>
+          </Box>
+          <Typography variant="caption" color="text.secondary">Now Recoverable</Typography>
+        </Paper>
+        <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 150, textAlign: 'center' }}>
+          <Typography variant="h4" sx={{ fontWeight: 700 }}>
+            {summary.measures_retried ?? 0}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">Measures Retried</Typography>
+        </Paper>
+        <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 150, textAlign: 'center' }}>
+          <Typography variant="h4" sx={{ fontWeight: 700 }}>
+            {summary.datasets_with_recoveries ?? 0}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">Datasets w/ Gains</Typography>
+        </Paper>
+      </Box>
+
+      {recovered === 0 && !result.error && (
+        <Alert severity="info">
+          No previously-failed measure became translatable in this sweep. Either the
+          transpiler has not changed since those runs, or the remaining gaps are
+          permanent limitations (display artifacts, slicer scalars, prior-year
+          time-intelligence).
+        </Alert>
+      )}
+
+      {recovered > 0 && (
+        <Alert severity="success">
+          {recovered} measure{recovered === 1 ? '' : 's'} that previously failed can now
+          be transpiled. Re-run the UCMV generator for the affected dataset(s) to apply
+          — nothing has been changed automatically.
+        </Alert>
+      )}
+
+      <Divider />
+
+      {ordered.map((ds, i) => {
+        const items = ds.newly_translatable || [];
+        return (
+          <Accordion
+            key={`${ds.dataset_id || 'ds'}-${i}`}
+            variant="outlined"
+            disableGutters
+            defaultExpanded={items.length > 0}
+            sx={{ '&:before': { display: 'none' } }}
+          >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
+                <Typography variant="subtitle2" sx={{ fontFamily: 'monospace' }}>
+                  {ds.dataset_id || '(unknown dataset)'}
+                </Typography>
+                {items.length > 0 ? (
+                  <Chip size="small" color="success" label={`${items.length} recoverable`} />
+                ) : (
+                  <Chip size="small" variant="outlined" label="no gains" />
+                )}
+                {ds.still_failing_count ? (
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    color="warning"
+                    label={`${ds.still_failing_count} still failing`}
+                  />
+                ) : null}
+                {ds.fingerprint_changed === false && (
+                  <Chip size="small" variant="outlined" label="transpiler unchanged" />
+                )}
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails sx={{ p: 0 }}>
+              {ds.note && (
+                <Typography variant="caption" color="text.secondary" sx={{ px: 2, py: 1, display: 'block' }}>
+                  {ds.note}
+                </Typography>
+              )}
+              {items.length > 0 && (
+                <Table size="small" sx={{ tableLayout: 'fixed' }}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 600, width: '18%' }}>Measure</TableCell>
+                      <TableCell sx={{ fontWeight: 600, width: '22%' }}>Previously failed because</TableCell>
+                      <TableCell sx={{ fontWeight: 600, width: '38%' }}>New SQL</TableCell>
+                      <TableCell sx={{ fontWeight: 600, width: '10%' }}>Confidence</TableCell>
+                      <TableCell sx={{ fontWeight: 600, width: '8%' }} align="right" title="How many other measures reference this one">Used by</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {items.map((m, j) => (
+                      <TableRow key={`${m.original_name}-${j}`} hover>
+                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.75rem', wordBreak: 'break-word' }}>
+                          {m.original_name}
+                        </TableCell>
+                        <TableCell sx={{ fontSize: '0.7rem', wordBreak: 'break-word' }}>
+                          {m.previous_category && (
+                            <Chip size="small" variant="outlined" color="warning" label={m.previous_category} sx={{ fontSize: '0.6rem' }} />
+                          )}
+                          {m.previous_skip_reason && (
+                            <Typography variant="caption" display="block" color="text.secondary" sx={{ mt: 0.5 }}>
+                              {m.previous_skip_reason}
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-word', whiteSpace: 'pre-wrap', color: 'success.main' }}>
+                          {m.new_sql}
+                        </TableCell>
+                        <TableCell sx={{ fontSize: '0.7rem' }}>{m.confidence || '—'}</TableCell>
+                        <TableCell sx={{ fontSize: '0.75rem' }} align="right">
+                          {m.referenced_by && m.referenced_by > 0 ? m.referenced_by : '—'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default ReevaluationResultViewer;

--- a/src/frontend/src/components/Jobs/ShowResult.tsx
+++ b/src/frontend/src/components/Jobs/ShowResult.tsx
@@ -48,6 +48,7 @@ import { ResultValue } from '../../types/result';
 import { DatabricksService } from '../../api/DatabricksService';
 import UCMVResultViewer, { isUCMVResult, UCMVResult } from './UCMVResultViewer';
 import ValidatorResultViewer, { isValidatorResult } from './ValidatorResultViewer';
+import ReevaluationResultViewer, { isReevaluationResult } from './ReevaluationResultViewer';
 import { runService } from '../../api/ExecutionHistoryService';
 
 // eslint-disable-next-line react/prop-types
@@ -749,6 +750,9 @@ const ShowResult = memo<ShowResultProps>(({ open, onClose, result, run }) => {
             if (isValidatorResult(inner)) {
               return <ValidatorResultViewer result={inner as Parameters<typeof ValidatorResultViewer>[0]['result']} />;
             }
+            if (isReevaluationResult(inner)) {
+              return <ReevaluationResultViewer result={inner as Parameters<typeof ReevaluationResultViewer>[0]['result']} />;
+            }
           }
         } catch { /* not JSON */ }
       }
@@ -761,6 +765,11 @@ const ShowResult = memo<ShowResultProps>(({ open, onClose, result, run }) => {
       // UCMV Quality Validator result: green/amber/red quality report
       if (isValidatorResult(parsed)) {
         return <ValidatorResultViewer result={parsed as Parameters<typeof ValidatorResultViewer>[0]['result']} />;
+      }
+
+      // UCMV Re-evaluation sweep: measures today's transpiler can now recover
+      if (isReevaluationResult(parsed)) {
+        return <ReevaluationResultViewer result={parsed as Parameters<typeof ReevaluationResultViewer>[0]['result']} />;
       }
 
       // If there's only one key called 'Value', render its content directly
@@ -808,6 +817,9 @@ const ShowResult = memo<ShowResultProps>(({ open, onClose, result, run }) => {
                   }
                   if (isUCMVResult(innerParsed)) {
                     return <UCMVResultViewer result={innerParsed as Parameters<typeof UCMVResultViewer>[0]['result']} />;
+                  }
+                  if (isReevaluationResult(innerParsed)) {
+                    return <ReevaluationResultViewer result={innerParsed as Parameters<typeof ReevaluationResultViewer>[0]['result']} />;
                   }
                 } catch { /* not JSON, fall through */ }
               }

--- a/src/frontend/src/components/Jobs/UCMVResultViewer.tsx
+++ b/src/frontend/src/components/Jobs/UCMVResultViewer.tsx
@@ -33,6 +33,8 @@ import {
   Tooltip,
   Alert,
   Snackbar,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import StorageIcon from '@mui/icons-material/Storage';
@@ -48,6 +50,7 @@ import UndoIcon from '@mui/icons-material/Undo';
 import DownloadIcon from '@mui/icons-material/Download';
 import SaveIcon from '@mui/icons-material/Save';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
 import Button from '@mui/material/Button';
 import { Highlight, themes } from 'prism-react-renderer';
 import yaml from 'js-yaml';
@@ -90,6 +93,12 @@ export interface UCMVResult {
   fallback_extract?: FallbackExtractRow[];
   /** Number of UC metric views actually generated (0 → show the fallback table). */
   views_generated?: number;
+  /** Non-transpiled measures (DAX that could not be translated), flattened across
+   *  all specs, for the "Not transpiled" review panel. */
+  untranslatable_items?: UntranslatableItem[];
+  /** Reviewer annotations on non-transpiled items, keyed by `${table_key}::${original_name}`.
+   *  Persisted inside the result blob via the same save path as YAML edits. */
+  untranslatable_review?: Record<string, ReviewAnnotation>;
 }
 
 export interface FallbackExtractRow {
@@ -99,6 +108,39 @@ export interface FallbackExtractRow {
   measure_count: number;
   has_mquery: boolean;
 }
+
+/** One non-transpiled measure surfaced for review (mirrors the backend
+ *  `untranslatable_items` row from uc_metric_view_generator_tool). */
+export interface UntranslatableItem {
+  table_key: string;
+  view_name?: string;
+  original_name: string;
+  dax_expression: string;
+  skip_reason: string;
+  category: string;
+  dax_class?: string | null;
+  referenced_by: number;
+}
+
+/** Triage status a reviewer can assign to a non-transpiled item. */
+export type ReviewStatus = 'todo' | 'wont_fix' | 'hand_written' | 'needs_info';
+
+export interface ReviewAnnotation {
+  status?: ReviewStatus;
+  note?: string;
+}
+
+/** Stable per-item key for the review annotation map. */
+export const untranslatableKey = (item: { table_key: string; original_name: string }): string =>
+  `${item.table_key}::${item.original_name}`;
+
+/** Human labels + colors for the review status dropdown. */
+export const REVIEW_STATUS_OPTIONS: Array<{ value: ReviewStatus; label: string }> = [
+  { value: 'todo', label: 'To translate' },
+  { value: 'hand_written', label: 'Hand-written' },
+  { value: 'wont_fix', label: 'Not needed' },
+  { value: 'needs_info', label: 'Needs info' },
+];
 
 interface UCMVResultViewerProps {
   result: UCMVResult;
@@ -233,6 +275,143 @@ const FieldTable: React.FC<{
 };
 
 /* ------------------------------------------------------------------ */
+/*  Non-transpiled review panel                                        */
+/* ------------------------------------------------------------------ */
+
+/** Interactive review table for measures that were NOT transpiled (they land as
+ *  `-- comment` lines in the UCMV YAML). Reviewers see the original DAX + why it
+ *  was skipped, and can triage each with a status + free-text note. Read-only for
+ *  DAX/reason; Status/Note are editable and flow up via `onReviewChange`. */
+const NonTranspiledPanel: React.FC<{
+  items: UntranslatableItem[];
+  review: Record<string, ReviewAnnotation>;
+  editable: boolean;
+  onReviewChange: (key: string, patch: Partial<ReviewAnnotation>) => void;
+}> = ({ items, review, editable, onReviewChange }) => {
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+
+  // Distinct categories for the filter chip row.
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    items.forEach((i) => i.category && set.add(i.category));
+    return Array.from(set).sort();
+  }, [items]);
+
+  // Sort by impact (referenced_by desc), then filter.
+  const rows = useMemo(() => {
+    const sorted = [...items].sort((a, b) => (b.referenced_by ?? 0) - (a.referenced_by ?? 0));
+    return categoryFilter ? sorted.filter((i) => i.category === categoryFilter) : sorted;
+  }, [items, categoryFilter]);
+
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        These measures could not be transpiled and are not emitted as UC metric-view
+        measures (they appear as comments in the YAML). Review each and mark how it
+        should be handled.
+      </Typography>
+
+      {categories.length > 1 && (
+        <Box display="flex" gap={0.5} flexWrap="wrap" sx={{ mb: 1 }}>
+          <Chip
+            size="small"
+            label={`All (${items.length})`}
+            color={categoryFilter === null ? 'primary' : 'default'}
+            variant={categoryFilter === null ? 'filled' : 'outlined'}
+            onClick={() => setCategoryFilter(null)}
+          />
+          {categories.map((c) => (
+            <Chip
+              key={c}
+              size="small"
+              label={`${c} (${items.filter((i) => i.category === c).length})`}
+              color={categoryFilter === c ? 'primary' : 'default'}
+              variant={categoryFilter === c ? 'filled' : 'outlined'}
+              onClick={() => setCategoryFilter(c)}
+            />
+          ))}
+        </Box>
+      )}
+
+      <Table size="small" sx={{ tableLayout: 'fixed' }}>
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ fontWeight: 600, width: '18%' }}>Measure</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '30%' }}>DAX</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '18%' }}>Reason</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '6%' }} align="right" title="How many other measures reference this one">Used by</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '13%' }}>Status</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '15%' }}>Note</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((item) => {
+            const key = untranslatableKey(item);
+            const ann = review[key] || {};
+            return (
+              <TableRow key={key} hover>
+                <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem', wordBreak: 'break-word' }}>
+                  {item.original_name}
+                </TableCell>
+                <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.75rem', wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+                  {item.dax_expression || '—'}
+                </TableCell>
+                <TableCell sx={{ fontSize: '0.75rem', wordBreak: 'break-word' }}>
+                  {item.category ? <Chip size="small" label={item.category} variant="outlined" color="warning" /> : null}
+                  {item.skip_reason && (
+                    <Typography variant="caption" display="block" color="text.secondary" sx={{ mt: 0.5 }}>
+                      {item.skip_reason}
+                    </Typography>
+                  )}
+                </TableCell>
+                <TableCell sx={{ fontSize: '0.8rem' }} align="right">
+                  {item.referenced_by > 0 ? item.referenced_by : '—'}
+                </TableCell>
+                <TableCell>
+                  <Select
+                    size="small"
+                    fullWidth
+                    displayEmpty
+                    disabled={!editable}
+                    value={ann.status ?? ''}
+                    onChange={(e) =>
+                      onReviewChange(key, { status: (e.target.value || undefined) as ReviewStatus | undefined })
+                    }
+                    sx={{ fontSize: '0.75rem' }}
+                    renderValue={(v) =>
+                      v ? (REVIEW_STATUS_OPTIONS.find((o) => o.value === v)?.label ?? String(v)) : '—'
+                    }
+                  >
+                    <MenuItem value=""><em>—</em></MenuItem>
+                    {REVIEW_STATUS_OPTIONS.map((o) => (
+                      <MenuItem key={o.value} value={o.value} sx={{ fontSize: '0.8rem' }}>
+                        {o.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </TableCell>
+                <TableCell>
+                  <TextField
+                    size="small"
+                    fullWidth
+                    variant="standard"
+                    placeholder="Add note…"
+                    disabled={!editable}
+                    value={ann.note ?? ''}
+                    onChange={(e) => onReviewChange(key, { note: e.target.value })}
+                    InputProps={{ sx: { fontSize: '0.75rem' } }}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};
+
+/* ------------------------------------------------------------------ */
 /*  Joins table                                                        */
 /* ------------------------------------------------------------------ */
 
@@ -340,6 +519,20 @@ const UCMVResultViewer: React.FC<UCMVResultViewerProps> = ({ result, editable = 
   const [yamlErrors, setYamlErrors] = useState<Record<string, string>>({});
   // Track which views have been removed
   const [removedViews, setRemovedViews] = useState<Set<string>>(new Set());
+  // Reviewer annotations on non-transpiled items (seeded from the persisted result).
+  const [reviewAnnotations, setReviewAnnotations] = useState<Record<string, ReviewAnnotation>>(
+    () => result.untranslatable_review ?? {},
+  );
+  const untranslatableItems = useMemo<UntranslatableItem[]>(
+    () => (Array.isArray(result.untranslatable_items) ? result.untranslatable_items : []),
+    [result.untranslatable_items],
+  );
+  // Non-transpiled items belonging to the currently-selected view (matched by
+  // table_key or view_name — the sidebar selection is a view name/key).
+  const selectedUntranslatable = useMemo<UntranslatableItem[]>(
+    () => untranslatableItems.filter((i) => i.table_key === selected || i.view_name === selected),
+    [untranslatableItems, selected],
+  );
   // Save state
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -390,9 +583,14 @@ const UCMVResultViewer: React.FC<UCMVResultViewerProps> = ({ result, editable = 
 
   // Build the current full result (with edits applied) for parent
   const buildEditedResult = useCallback(
-    (overrides?: { yamlEdits?: Record<string, string>; removed?: Set<string> }): UCMVResult => {
+    (overrides?: {
+      yamlEdits?: Record<string, string>;
+      removed?: Set<string>;
+      reviewEdits?: Record<string, ReviewAnnotation>;
+    }): UCMVResult => {
       const edits = overrides?.yamlEdits ?? editingYaml;
       const removed = overrides?.removed ?? removedViews;
+      const review = overrides?.reviewEdits ?? reviewAnnotations;
       const newYaml: Record<string, string> = {};
       const newSql: Record<string, string> = {};
       const newStats: Record<string, UCMVStats> = {};
@@ -403,9 +601,25 @@ const UCMVResultViewer: React.FC<UCMVResultViewerProps> = ({ result, editable = 
         const s = result.stats as Record<string, UCMVStats>;
         if (s[name]) newStats[name] = s[name];
       }
-      return { ...result, yaml: newYaml, sql: newSql, stats: newStats };
+      // Fold reviewer annotations into the persisted result (round-trips via the
+      // same save path as YAML edits). Only keep non-empty annotations.
+      const untranslatable_review: Record<string, ReviewAnnotation> = {};
+      for (const [k, v] of Object.entries(review)) {
+        if (v && (v.status || (v.note && v.note.trim()))) untranslatable_review[k] = v;
+      }
+      return { ...result, yaml: newYaml, sql: newSql, stats: newStats, untranslatable_review };
     },
-    [editingYaml, removedViews, viewNames, result]
+    [editingYaml, removedViews, reviewAnnotations, viewNames, result]
+  );
+
+  // Update a reviewer annotation on a non-transpiled item; propagate upward.
+  const handleReviewChange = useCallback(
+    (key: string, patch: Partial<ReviewAnnotation>) => {
+      const next = { ...reviewAnnotations, [key]: { ...reviewAnnotations[key], ...patch } };
+      setReviewAnnotations(next);
+      onResultChange?.(buildEditedResult({ reviewEdits: next }));
+    },
+    [reviewAnnotations, buildEditedResult, onResultChange]
   );
 
   // Start editing a view
@@ -471,7 +685,18 @@ const UCMVResultViewer: React.FC<UCMVResultViewerProps> = ({ result, editable = 
   };
 
   const isEditing = selected in editingYaml;
-  const hasEdits = Object.keys(editingYaml).length > 0 || removedViews.size > 0;
+  // Review annotations count as edits too (they persist via the same save path).
+  const reviewDirty = useMemo(() => {
+    const norm = (r: Record<string, ReviewAnnotation>) => {
+      const out: Record<string, ReviewAnnotation> = {};
+      for (const [k, v] of Object.entries(r || {})) {
+        if (v && (v.status || (v.note && v.note.trim()))) out[k] = v;
+      }
+      return JSON.stringify(out);
+    };
+    return norm(reviewAnnotations) !== norm(result.untranslatable_review ?? {});
+  }, [reviewAnnotations, result.untranslatable_review]);
+  const hasEdits = Object.keys(editingYaml).length > 0 || removedViews.size > 0 || reviewDirty;
 
   const handleSave = useCallback(async () => {
     if (!onSave) return;
@@ -565,6 +790,15 @@ const UCMVResultViewer: React.FC<UCMVResultViewerProps> = ({ result, editable = 
         <Chip size="small" label={`${aggregateStats.activeViews} views`} />
         <Chip size="small" label={`${aggregateStats.totalMeasures} measures`} variant="outlined" />
         <Chip size="small" label={`${aggregateStats.totalDims} dimensions`} variant="outlined" />
+        {untranslatableItems.length > 0 && (
+          <Chip
+            size="small"
+            label={`${untranslatableItems.length} not transpiled`}
+            color="warning"
+            variant="outlined"
+            icon={<ReportProblemOutlinedIcon />}
+          />
+        )}
         {editable && hasEdits && (
           <Chip size="small" label="edited" color="warning" variant="filled" />
         )}
@@ -837,6 +1071,24 @@ const UCMVResultViewer: React.FC<UCMVResultViewerProps> = ({ result, editable = 
               defaultExpanded
             >
               <FieldTable fields={parsed.measures} showFormat />
+            </Section>
+          )}
+
+          {/* Not transpiled — non-emitted measures for review + annotation */}
+          {selectedUntranslatable.length > 0 && (
+            <Section
+              title="Not transpiled"
+              icon={<ReportProblemOutlinedIcon fontSize="small" color="warning" />}
+              count={selectedUntranslatable.length}
+            >
+              <Box sx={{ p: 1.5 }}>
+                <NonTranspiledPanel
+                  items={selectedUntranslatable}
+                  review={reviewAnnotations}
+                  editable={editable}
+                  onReviewChange={handleReviewChange}
+                />
+              </Box>
             </Section>
           )}
 

--- a/src/frontend/src/components/Jobs/UCMVResultViewer.tsx
+++ b/src/frontend/src/components/Jobs/UCMVResultViewer.tsx
@@ -120,6 +120,11 @@ export interface UntranslatableItem {
   category: string;
   dax_class?: string | null;
   referenced_by: number;
+  /** Actionable next-step for handling this measure (HOW), from the LLM's own
+   *  recipe or a class-based default. Emitted by the generator alongside the
+   *  terse skip_reason (WHY). */
+  proposal?: string;
+  explanation?: string | null;
 }
 
 /** Triage status a reviewer can assign to a non-transpiled item. */
@@ -336,12 +341,13 @@ const NonTranspiledPanel: React.FC<{
       <Table size="small" sx={{ tableLayout: 'fixed' }}>
         <TableHead>
           <TableRow>
-            <TableCell sx={{ fontWeight: 600, width: '18%' }}>Measure</TableCell>
-            <TableCell sx={{ fontWeight: 600, width: '30%' }}>DAX</TableCell>
-            <TableCell sx={{ fontWeight: 600, width: '18%' }}>Reason</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '15%' }}>Measure</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '24%' }}>DAX</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '14%' }}>Reason</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '16%' }} title="Suggested next step for handling this measure">Proposed approach</TableCell>
             <TableCell sx={{ fontWeight: 600, width: '6%' }} align="right" title="How many other measures reference this one">Used by</TableCell>
             <TableCell sx={{ fontWeight: 600, width: '13%' }}>Status</TableCell>
-            <TableCell sx={{ fontWeight: 600, width: '15%' }}>Note</TableCell>
+            <TableCell sx={{ fontWeight: 600, width: '12%' }}>Note</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -363,6 +369,13 @@ const NonTranspiledPanel: React.FC<{
                       {item.skip_reason}
                     </Typography>
                   )}
+                </TableCell>
+                <TableCell sx={{ fontSize: '0.75rem', wordBreak: 'break-word' }}>
+                  {item.proposal ? (
+                    <Typography variant="caption" display="block" color="text.secondary">
+                      {item.proposal}
+                    </Typography>
+                  ) : '—'}
                 </TableCell>
                 <TableCell sx={{ fontSize: '0.8rem' }} align="right">
                   {item.referenced_by > 0 ? item.referenced_by : '—'}

--- a/src/frontend/src/components/Jobs/UCMVResultViewer.untranslatable.test.tsx
+++ b/src/frontend/src/components/Jobs/UCMVResultViewer.untranslatable.test.tsx
@@ -23,6 +23,7 @@ const ITEMS: UntranslatableItem[] = [
     category: 'prior-year time-intelligence',
     dax_class: 'unsupported',
     referenced_by: 3,
+    proposal: 'Add a calendar date_py join or a window offset to express prior-year.',
   },
   {
     table_key: 'mv_fact_sales',
@@ -54,6 +55,12 @@ describe('UCMVResultViewer — Not transpiled panel', () => {
     expect(screen.getByText('YoY Growth')).toBeInTheDocument();
     expect(screen.getByText('Sales Color')).toBeInTheDocument();
     expect(screen.getByText(/SAMEPERIODLASTYEAR/)).toBeInTheDocument();
+  });
+
+  it('renders the Proposed approach column with the proposal text', () => {
+    render(<UCMVResultViewer result={makeResult()} />);
+    expect(screen.getByText('Proposed approach')).toBeInTheDocument();
+    expect(screen.getByText(/Add a calendar date_py join or a window offset/)).toBeInTheDocument();
   });
 
   it('sorts items by impact (referenced_by) descending', () => {

--- a/src/frontend/src/components/Jobs/UCMVResultViewer.untranslatable.test.tsx
+++ b/src/frontend/src/components/Jobs/UCMVResultViewer.untranslatable.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests for the "Not transpiled" review panel in UCMVResultViewer. The backend
+ * emits `untranslatable_items` (measures that could not be transpiled); the
+ * viewer surfaces them as reviewable rows and lets a reviewer assign a status +
+ * note, which round-trips via the existing onResultChange/onSave path as
+ * `untranslatable_review`.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import UCMVResultViewer, {
+  type UCMVResult,
+  type UntranslatableItem,
+  untranslatableKey,
+} from './UCMVResultViewer';
+
+const ITEMS: UntranslatableItem[] = [
+  {
+    table_key: 'mv_fact_sales',
+    view_name: 'mv_fact_sales',
+    original_name: 'YoY Growth',
+    dax_expression: 'CALCULATE([Sales], SAMEPERIODLASTYEAR(cal[date]))',
+    skip_reason: 'prior-year time-intelligence',
+    category: 'prior-year time-intelligence',
+    dax_class: 'unsupported',
+    referenced_by: 3,
+  },
+  {
+    table_key: 'mv_fact_sales',
+    view_name: 'mv_fact_sales',
+    original_name: 'Sales Color',
+    dax_expression: 'IF([Sales] > 0, "green", "red")',
+    skip_reason: 'display artifact',
+    category: 'display artifact',
+    dax_class: 'display_layer',
+    referenced_by: 0,
+  },
+];
+
+const makeResult = (overrides: Partial<UCMVResult> = {}): UCMVResult => ({
+  yaml: { mv_fact_sales: "version: '1.1'\nsource: cat.sch.fact_sales\nmeasures:\n  - name: total_sales\n    expr: SUM(source.amount)\n" },
+  sql: {},
+  stats: {},
+  views_generated: 1,
+  untranslatable_items: ITEMS,
+  ...overrides,
+});
+
+describe('UCMVResultViewer — Not transpiled panel', () => {
+  it('renders a section + header chip listing the non-transpiled items', () => {
+    render(<UCMVResultViewer result={makeResult()} />);
+    expect(screen.getByText('Not transpiled')).toBeInTheDocument();
+    expect(screen.getByText('2 not transpiled')).toBeInTheDocument();
+    // Both measures + their DAX are shown
+    expect(screen.getByText('YoY Growth')).toBeInTheDocument();
+    expect(screen.getByText('Sales Color')).toBeInTheDocument();
+    expect(screen.getByText(/SAMEPERIODLASTYEAR/)).toBeInTheDocument();
+  });
+
+  it('sorts items by impact (referenced_by) descending', () => {
+    render(<UCMVResultViewer result={makeResult()} />);
+    const html = document.body.innerHTML;
+    // YoY Growth (3) before Sales Color (0)
+    expect(html.indexOf('YoY Growth')).toBeLessThan(html.indexOf('Sales Color'));
+  });
+
+  it('hides the panel entirely when there are no items', () => {
+    render(<UCMVResultViewer result={makeResult({ untranslatable_items: [] })} />);
+    expect(screen.queryByText('Not transpiled')).not.toBeInTheDocument();
+    expect(screen.queryByText(/not transpiled$/)).not.toBeInTheDocument();
+  });
+
+  it('fires onResultChange with untranslatable_review when a note is entered', () => {
+    const onResultChange = vi.fn();
+    render(
+      <UCMVResultViewer result={makeResult()} editable onResultChange={onResultChange} />,
+    );
+    // Find the YoY Growth row, type into its Note field
+    const row = screen.getByText('YoY Growth').closest('tr')!;
+    const note = within(row).getByPlaceholderText('Add note…');
+    fireEvent.change(note, { target: { value: 'will hand-write' } });
+
+    expect(onResultChange).toHaveBeenCalled();
+    const lastArg = onResultChange.mock.calls.at(-1)![0] as UCMVResult;
+    const key = untranslatableKey(ITEMS[0]);
+    expect(lastArg.untranslatable_review?.[key]?.note).toBe('will hand-write');
+  });
+
+  it('pre-fills annotations from a persisted result', () => {
+    const key = untranslatableKey(ITEMS[0]);
+    render(
+      <UCMVResultViewer
+        result={makeResult({ untranslatable_review: { [key]: { note: 'saved note', status: 'hand_written' } } })}
+        editable
+      />,
+    );
+    const row = screen.getByText('YoY Growth').closest('tr')!;
+    const note = within(row).getByPlaceholderText('Add note…') as HTMLInputElement;
+    expect(note.value).toBe('saved note');
+  });
+
+  it('disables editing controls when not editable', () => {
+    render(<UCMVResultViewer result={makeResult()} />);
+    const row = screen.getByText('YoY Growth').closest('tr')!;
+    const note = within(row).getByPlaceholderText('Add note…') as HTMLInputElement;
+    expect(note).toBeDisabled();
+  });
+});

--- a/src/frontend/src/components/Jobs/ValidatorResultViewer.tsx
+++ b/src/frontend/src/components/Jobs/ValidatorResultViewer.tsx
@@ -112,6 +112,22 @@ export interface ValidatorResult {
     switch?: number;
     manual_override?: number;
   }>;
+  /** Non-transpiled measures passed through from the UCMV generator (not evaluated
+   *  here — they have no SQL). Lets reviewers see WHICH measures were not emitted
+   *  and why, next to the per-table quality counts. */
+  untranslatable_items?: ValidatorUntranslatableItem[];
+}
+
+/** One non-transpiled measure surfaced for review in the validation summary. */
+export interface ValidatorUntranslatableItem {
+  table_key: string;
+  view_name?: string;
+  original_name: string;
+  dax_expression?: string;
+  skip_reason?: string;
+  category?: string;
+  dax_class?: string | null;
+  referenced_by?: number;
 }
 
 /* ------------------------------------------------------------------ */
@@ -201,6 +217,13 @@ const ValidatorResultViewer: React.FC<{ result: ValidatorResult }> = ({ result }
     return base;
   }, [result]);
   const hasYaml = yamlData && Object.keys(yamlData).length > 0;
+
+  // Non-transpiled measures, highest-impact first (most-referenced at the top) so
+  // reviewers triage the measures other measures depend on before the leaves.
+  const untranslatableItems = useMemo<ValidatorUntranslatableItem[]>(() => {
+    const items = Array.isArray(result.untranslatable_items) ? result.untranslatable_items : [];
+    return [...items].sort((a, b) => (b.referenced_by ?? 0) - (a.referenced_by ?? 0));
+  }, [result.untranslatable_items]);
 
   const handleDownloadYaml = (tableName: string) => {
     if (!yamlData?.[tableName]) return;
@@ -309,6 +332,17 @@ const ValidatorResultViewer: React.FC<{ result: ValidatorResult }> = ({ result }
           </Box>
           <Typography variant="caption" color="text.secondary">Tables Passing</Typography>
         </Paper>
+        {untranslatableItems.length > 0 && (
+          <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 150, textAlign: 'center' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+              <WarningAmberIcon sx={{ color: 'warning.main' }} />
+              <Typography variant="h4" sx={{ fontWeight: 700, color: 'warning.main' }}>
+                {untranslatableItems.length}
+              </Typography>
+            </Box>
+            <Typography variant="caption" color="text.secondary">Not Transpiled</Typography>
+          </Paper>
+        )}
       </Box>
 
       {/* Overall progress bar */}
@@ -494,6 +528,68 @@ const ValidatorResultViewer: React.FC<{ result: ValidatorResult }> = ({ result }
           })}
         </TableBody>
       </Table>
+
+      {/* Not transpiled — which measures were NOT emitted, and why. The per-table
+          counts above say HOW MANY; this says WHICH + the reason, so a reviewer can
+          investigate without opening the YAML comments. */}
+      {untranslatableItems.length > 0 && (
+        <>
+          <Divider />
+          <Accordion variant="outlined" disableGutters sx={{ '&:before': { display: 'none' } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Box display="flex" alignItems="center" gap={1}>
+                <WarningAmberIcon sx={{ color: 'warning.main', fontSize: 20 }} />
+                <Typography variant="subtitle2">Not transpiled</Typography>
+                <Chip size="small" label={untranslatableItems.length} color="warning" variant="outlined" />
+                <Typography variant="caption" color="text.secondary">
+                  measures not emitted as UC metric-view measures — with the reason
+                </Typography>
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails sx={{ p: 0 }}>
+              <Table size="small" sx={{ tableLayout: 'fixed' }}>
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ fontWeight: 600, width: '18%' }}>Measure</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '16%' }}>Table</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '22%' }}>Reason</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '36%' }}>DAX</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '8%' }} align="right" title="How many other measures reference this one">Used by</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {untranslatableItems.map((item, i) => (
+                    <TableRow key={`${item.table_key}::${item.original_name}::${i}`} hover>
+                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.75rem', wordBreak: 'break-word' }}>
+                        {item.original_name}
+                      </TableCell>
+                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-word' }}>
+                        {item.view_name || item.table_key}
+                      </TableCell>
+                      <TableCell sx={{ fontSize: '0.7rem', wordBreak: 'break-word' }}>
+                        {item.category && (
+                          <Chip size="small" label={item.category} color="warning" variant="outlined" sx={{ fontSize: '0.65rem' }} />
+                        )}
+                        {item.skip_reason && (
+                          <Typography variant="caption" display="block" color="text.secondary" sx={{ mt: 0.5 }}>
+                            {item.skip_reason}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+                        {item.dax_expression || '—'}
+                      </TableCell>
+                      <TableCell sx={{ fontSize: '0.75rem' }} align="right">
+                        {item.referenced_by && item.referenced_by > 0 ? item.referenced_by : '—'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </AccordionDetails>
+          </Accordion>
+        </>
+      )}
 
       {/* YAML Viewer Dialog */}
       <Dialog

--- a/src/frontend/src/components/Jobs/ValidatorResultViewer.tsx
+++ b/src/frontend/src/components/Jobs/ValidatorResultViewer.tsx
@@ -128,6 +128,9 @@ export interface ValidatorUntranslatableItem {
   category?: string;
   dax_class?: string | null;
   referenced_by?: number;
+  /** Actionable next-step (HOW to handle it), from the generator's build_proposal. */
+  proposal?: string;
+  explanation?: string | null;
 }
 
 /* ------------------------------------------------------------------ */
@@ -550,10 +553,11 @@ const ValidatorResultViewer: React.FC<{ result: ValidatorResult }> = ({ result }
               <Table size="small" sx={{ tableLayout: 'fixed' }}>
                 <TableHead>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, width: '18%' }}>Measure</TableCell>
-                    <TableCell sx={{ fontWeight: 600, width: '16%' }}>Table</TableCell>
-                    <TableCell sx={{ fontWeight: 600, width: '22%' }}>Reason</TableCell>
-                    <TableCell sx={{ fontWeight: 600, width: '36%' }}>DAX</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '15%' }}>Measure</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '13%' }}>Table</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '18%' }}>Reason</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '18%' }} title="Suggested next step for handling this measure">Proposed approach</TableCell>
+                    <TableCell sx={{ fontWeight: 600, width: '28%' }}>DAX</TableCell>
                     <TableCell sx={{ fontWeight: 600, width: '8%' }} align="right" title="How many other measures reference this one">Used by</TableCell>
                   </TableRow>
                 </TableHead>
@@ -575,6 +579,13 @@ const ValidatorResultViewer: React.FC<{ result: ValidatorResult }> = ({ result }
                             {item.skip_reason}
                           </Typography>
                         )}
+                      </TableCell>
+                      <TableCell sx={{ fontSize: '0.7rem', wordBreak: 'break-word' }}>
+                        {item.proposal ? (
+                          <Typography variant="caption" display="block" color="text.secondary">
+                            {item.proposal}
+                          </Typography>
+                        ) : '—'}
                       </TableCell>
                       <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
                         {item.dax_expression || '—'}

--- a/src/frontend/src/components/Jobs/ValidatorResultViewer.untranslatable.test.tsx
+++ b/src/frontend/src/components/Jobs/ValidatorResultViewer.untranslatable.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for the "Not transpiled" section in ValidatorResultViewer — the final
+ * validation view. The per-table counts say HOW MANY measures were not emitted;
+ * this section says WHICH ones and WHY (reason + original DAX), so a reviewer can
+ * investigate without opening the YAML comment block.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ValidatorResultViewer, {
+  type ValidatorResult,
+  type ValidatorUntranslatableItem,
+} from './ValidatorResultViewer';
+
+const ITEMS: ValidatorUntranslatableItem[] = [
+  {
+    table_key: 'fact_sales',
+    view_name: 'mv_fact_sales',
+    original_name: 'YoY Growth',
+    dax_expression: 'CALCULATE([Sales], SAMEPERIODLASTYEAR(cal[date]))',
+    skip_reason: 'period-shift not expressible in a static UC metric view',
+    category: 'prior-year time-intelligence',
+    referenced_by: 4,
+  },
+  {
+    table_key: 'fact_sales',
+    view_name: 'mv_fact_sales',
+    original_name: 'Sales Color',
+    dax_expression: 'IF([Sales] > 0, "green", "red")',
+    skip_reason: 'formatting/label only — not a data measure',
+    category: 'display artifact',
+    referenced_by: 0,
+  },
+];
+
+const makeResult = (overrides: Partial<ValidatorResult> = {}): ValidatorResult => ({
+  summary: { tables_validated: 1, total_evaluated: 5, total_valid: 5 } as ValidatorResult['summary'],
+  per_table_summary: {
+    fact_sales: { evaluated: 5, valid: 5, equivalent: 0, review: 0, invalid: 0, total_measures: 7 },
+  },
+  untranslatable_items: ITEMS,
+  ...overrides,
+});
+
+describe('ValidatorResultViewer — Not transpiled section', () => {
+  it('shows a summary tile with the non-transpiled count', () => {
+    render(<ValidatorResultViewer result={makeResult()} />);
+    expect(screen.getByText('Not Transpiled')).toBeInTheDocument();
+  });
+
+  it('lists each non-transpiled measure with its reason and DAX', () => {
+    render(<ValidatorResultViewer result={makeResult()} />);
+    expect(screen.getByText('Not transpiled')).toBeInTheDocument();
+    expect(screen.getByText('YoY Growth')).toBeInTheDocument();
+    expect(screen.getByText('Sales Color')).toBeInTheDocument();
+    // Reason (category chip + skip_reason text)
+    expect(screen.getByText('prior-year time-intelligence')).toBeInTheDocument();
+    expect(screen.getByText(/period-shift not expressible/)).toBeInTheDocument();
+    // Original DAX visible for investigation
+    expect(screen.getByText(/SAMEPERIODLASTYEAR/)).toBeInTheDocument();
+  });
+
+  it('orders items by impact (referenced_by) descending', () => {
+    render(<ValidatorResultViewer result={makeResult()} />);
+    const html = document.body.innerHTML;
+    expect(html.indexOf('YoY Growth')).toBeLessThan(html.indexOf('Sales Color'));
+  });
+
+  it('renders nothing extra when there are no non-transpiled items', () => {
+    render(<ValidatorResultViewer result={makeResult({ untranslatable_items: [] })} />);
+    expect(screen.queryByText('Not transpiled')).not.toBeInTheDocument();
+    expect(screen.queryByText('Not Transpiled')).not.toBeInTheDocument();
+  });
+
+  it('tolerates a result with the field absent entirely (back-compat)', () => {
+    const r = makeResult();
+    delete r.untranslatable_items;
+    render(<ValidatorResultViewer result={r} />);
+    expect(screen.queryByText('Not transpiled')).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/Jobs/ValidatorResultViewer.untranslatable.test.tsx
+++ b/src/frontend/src/components/Jobs/ValidatorResultViewer.untranslatable.test.tsx
@@ -20,6 +20,7 @@ const ITEMS: ValidatorUntranslatableItem[] = [
     skip_reason: 'period-shift not expressible in a static UC metric view',
     category: 'prior-year time-intelligence',
     referenced_by: 4,
+    proposal: 'Add a calendar date_py join or a window offset to express prior-year.',
   },
   {
     table_key: 'fact_sales',
@@ -57,6 +58,12 @@ describe('ValidatorResultViewer — Not transpiled section', () => {
     expect(screen.getByText(/period-shift not expressible/)).toBeInTheDocument();
     // Original DAX visible for investigation
     expect(screen.getByText(/SAMEPERIODLASTYEAR/)).toBeInTheDocument();
+  });
+
+  it('renders the Proposed approach column with the proposal text', () => {
+    render(<ValidatorResultViewer result={makeResult()} />);
+    expect(screen.getByText('Proposed approach')).toBeInTheDocument();
+    expect(screen.getByText(/Add a calendar date_py join or a window offset/)).toBeInTheDocument();
   });
 
   it('orders items by impact (referenced_by) descending', () => {

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "node scripts/build-tasks.cjs prebuild",
-    "build": "cd frontend && npm install --include=dev && npm run build",
+    "build": "cd frontend && npm ci --include=dev && npm run build",
     "postbuild": "node scripts/build-tasks.cjs postbuild"
   }
 }


### PR DESCRIPTION
Stacked on #67 (`prompt-optimization`). Scoped to PowerBI M-Query pipeline performance.

## Status
Draft — opening early to track. First commit is the UCMV coverage evaluation +
best-effort roadmap doc (SC/PAAT/DCC analysis); the M-Query performance changes
land in follow-up commits.

## Included so far
- `docs(powerbi)`: UCMV coverage evaluation + best-effort roadmap — consolidates
  the SC (100% measure match, 74% coverage), PAAT (~10-19% ceiling) and DCC
  (~0-5% ceiling) dataset analyses and the repo changes they imply.

## Planned (M-Query performance)
- _To be filled in as the performance work lands._

## Base
Targets `prompt-optimization` (PR #67), not `main`, so the diff shows only the
M-Query work stacked on top of the prompt-optimization changes.

This pull request and its description were written by Isaac.