### PR TITLE
Simplify database settings and fix dropdown readability

### DIFF
--- a/src/frontend/src/features/configuration/components/DatabaseManagement.test.tsx
+++ b/src/frontend/src/features/configuration/components/DatabaseManagement.test.tsx
@@ -168,14 +168,14 @@ describe('DatabaseManagement', () => {
     renderWithProviders(<DatabaseManagement />);
 
     await waitFor(() => {
-      expect(screen.getByText('General')).toBeInTheDocument();
-      expect(screen.getByText('Databricks Import / Export')).toBeInTheDocument();
-      expect(screen.getByText('Lakebase')).toBeInTheDocument();
+      expect(screen.getByText('Data cleanup')).toBeInTheDocument();
+      expect(screen.getByText('Backups & restore')).toBeInTheDocument();
+      expect(screen.getByText('Connection')).toBeInTheDocument();
     });
   });
 
   describe('Database Information Display', () => {
-    it('renders sqlite database info with info alert', async () => {
+    it('renders a compact SQLite overview', async () => {
       setMockDatabaseInfo({
         success: true,
         database_type: 'sqlite',
@@ -193,12 +193,9 @@ describe('DatabaseManagement', () => {
         expect(screen.getByText(/Current Database Backend: SQLITE/)).toBeInTheDocument();
       });
 
-      // SQLite should render an 'info' severity alert
-      const alert = screen.getByRole('alert');
-      expect(alert).toHaveClass('MuiAlert-standardInfo');
-
-      // Should show type
-      expect(screen.getByText('sqlite')).toBeInTheDocument();
+      // Routine status is a quiet summary; alerts are reserved for failures.
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.getByText('10 tables')).toBeInTheDocument();
 
       // Should show path
       expect(screen.getByText('/data/kasal.db')).toBeInTheDocument();
@@ -208,7 +205,7 @@ describe('DatabaseManagement', () => {
       expect(screen.getByText('tasks (12 rows)')).toBeInTheDocument();
     });
 
-    it('renders lakebase database info with success alert when no connection error', async () => {
+    it('renders a compact Lakebase overview when connected', async () => {
       setMockDatabaseInfo({
         success: true,
         database_type: 'lakebase',
@@ -225,9 +222,7 @@ describe('DatabaseManagement', () => {
         expect(screen.getByText(/Current Database Backend: LAKEBASE/)).toBeInTheDocument();
       });
 
-      // Lakebase without connection_error should show 'success' severity
-      const alert = screen.getByRole('alert');
-      expect(alert).toHaveClass('MuiAlert-standardSuccess');
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
       // Should show instance name
       expect(screen.getByText(/Connected to Lakebase instance: my-lakebase-instance/)).toBeInTheDocument();
@@ -402,12 +397,12 @@ describe('DatabaseManagement', () => {
       });
 
       // Table count header
-      expect(screen.getByText('Tables (3)')).toBeInTheDocument();
+      expect(screen.getByText('3 tables')).toBeInTheDocument();
     });
   });
 
   describe('Alert severity logic', () => {
-    it('uses info severity for non-lakebase database types', async () => {
+    it('keeps routine SQLite status out of alerts', async () => {
       setMockDatabaseInfo({
         success: true,
         database_type: 'sqlite',
@@ -416,12 +411,12 @@ describe('DatabaseManagement', () => {
       renderWithProviders(<DatabaseManagement />);
 
       await waitFor(() => {
-        const alert = screen.getByRole('alert');
-        expect(alert).toHaveClass('MuiAlert-standardInfo');
+        expect(screen.getByText(/Current Database Backend: SQLITE/)).toBeInTheDocument();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
       });
     });
 
-    it('uses info severity for postgresql database type', async () => {
+    it('keeps routine PostgreSQL status out of alerts', async () => {
       setMockDatabaseInfo({
         success: true,
         database_type: 'postgresql',
@@ -432,12 +427,12 @@ describe('DatabaseManagement', () => {
       renderWithProviders(<DatabaseManagement />);
 
       await waitFor(() => {
-        const alert = screen.getByRole('alert');
-        expect(alert).toHaveClass('MuiAlert-standardInfo');
+        expect(screen.getByText(/Current Database Backend: POSTGRESQL/)).toBeInTheDocument();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
       });
     });
 
-    it('uses success severity for lakebase without connection error', async () => {
+    it('keeps routine Lakebase status out of alerts', async () => {
       setMockDatabaseInfo({
         success: true,
         database_type: 'lakebase',
@@ -447,8 +442,8 @@ describe('DatabaseManagement', () => {
       renderWithProviders(<DatabaseManagement />);
 
       await waitFor(() => {
-        const alert = screen.getByRole('alert');
-        expect(alert).toHaveClass('MuiAlert-standardSuccess');
+        expect(screen.getByText(/Current Database Backend: LAKEBASE/)).toBeInTheDocument();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
       });
     });
 
@@ -474,9 +469,9 @@ describe('DatabaseManagement', () => {
   describe('Lakebase tab - connect form visibility', () => {
     const navigateToLakebaseTab = async () => {
       await waitFor(() => {
-        expect(screen.getByText('Lakebase')).toBeInTheDocument();
+        expect(screen.getByText('Connection')).toBeInTheDocument();
       });
-      fireEvent.click(screen.getByText('Lakebase'));
+      expect(screen.getByRole('button', { name: /Connection choose/ })).toHaveAttribute('aria-expanded', 'true');
     };
 
     it('shows connect form when lakebase is selected but not connected', async () => {
@@ -487,18 +482,18 @@ describe('DatabaseManagement', () => {
       fireEvent.click(screen.getByText('Databricks Lakebase'));
 
       await waitFor(() => {
-        expect(screen.getByText('Connect to Existing Lakebase Instance')).toBeInTheDocument();
+        expect(screen.getByText('Connect a Lakebase instance')).toBeInTheDocument();
       });
     });
 
-    it('shows prerequisites alert when not connected', async () => {
+    it('offers setup prerequisites on demand when not connected', async () => {
       renderWithProviders(<DatabaseManagement />);
       await navigateToLakebaseTab();
 
       fireEvent.click(screen.getByText('Databricks Lakebase'));
 
       await waitFor(() => {
-        expect(screen.getByText('Databricks App Setup')).toBeInTheDocument();
+        expect(screen.getByText('Before you connect')).toBeInTheDocument();
       });
     });
 
@@ -519,11 +514,11 @@ describe('DatabaseManagement', () => {
       fireEvent.click(screen.getByText('Databricks Lakebase'));
 
       await waitFor(() => {
-        expect(screen.queryByText('Connect to Existing Lakebase Instance')).not.toBeInTheDocument();
+        expect(screen.queryByText('Connect a Lakebase instance')).not.toBeInTheDocument();
       });
     });
 
-    it('hides prerequisites alert when instance is enabled and READY', async () => {
+    it('hides setup prerequisites when instance is enabled and READY', async () => {
       mockDatabaseStoreState.lakebaseConfig = {
         enabled: true,
         instance_name: 'kasal-lakebase1',
@@ -540,7 +535,7 @@ describe('DatabaseManagement', () => {
       fireEvent.click(screen.getByText('Databricks Lakebase'));
 
       await waitFor(() => {
-        expect(screen.queryByText('Databricks App Setup')).not.toBeInTheDocument();
+        expect(screen.queryByText('Before you connect')).not.toBeInTheDocument();
       });
     });
 
@@ -561,7 +556,7 @@ describe('DatabaseManagement', () => {
       fireEvent.click(screen.getByText('Databricks Lakebase'));
 
       await waitFor(() => {
-        expect(screen.getByText('Connect to Existing Lakebase Instance')).toBeInTheDocument();
+        expect(screen.getByText('Connect a Lakebase instance')).toBeInTheDocument();
       });
     });
 
@@ -582,7 +577,7 @@ describe('DatabaseManagement', () => {
       fireEvent.click(screen.getByText('Databricks Lakebase'));
 
       await waitFor(() => {
-        expect(screen.getByText('Current Status')).toBeInTheDocument();
+        expect(screen.getByText('READY')).toBeInTheDocument();
         expect(screen.getByText('View in Databricks')).toBeInTheDocument();
         expect(screen.getByText('Refresh Status')).toBeInTheDocument();
       });
@@ -595,7 +590,7 @@ describe('DatabaseManagement', () => {
       fireEvent.click(screen.getByText('Databricks Lakebase'));
 
       await waitFor(() => {
-        expect(screen.getByText('Connect to Existing Lakebase Instance')).toBeInTheDocument();
+        expect(screen.getByText('Connect a Lakebase instance')).toBeInTheDocument();
       });
 
       expect(screen.queryByText('Create New Instance')).not.toBeInTheDocument();
@@ -636,9 +631,7 @@ describe('DatabaseManagement', () => {
         expect(screen.getByText(/Current Database Backend: LAKEBASE/)).toBeInTheDocument();
       });
 
-      // Verify no warning-colored text is present in the alert
-      const alert = screen.getByRole('alert');
-      expect(alert).toHaveClass('MuiAlert-standardSuccess');
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
 
     it('renders connection error alongside instance name', async () => {

--- a/src/frontend/src/features/configuration/components/DatabaseManagement.tsx
+++ b/src/frontend/src/features/configuration/components/DatabaseManagement.tsx
@@ -10,7 +10,6 @@ import {
   Alert,
   TextField,
   CircularProgress,
-  Paper,
   List,
   ListItem,
   ListItemText,
@@ -23,16 +22,11 @@ import {
   DialogContentText,
   Chip,
   Grid,
-  Card,
-  CardContent,
   FormControl,
-  Select,
-  FormHelperText,
   Divider,
   FormControlLabel,
   RadioGroup,
   Radio,
-  FormLabel,
 } from '@mui/material';
 import {
   CloudUpload as UploadIcon,
@@ -51,6 +45,8 @@ import {
 } from '@mui/icons-material';
 import { apiClient, config } from '../../../shared/api/client';
 import { useDatabaseStore } from '../../../store/databaseStore';
+import DatabaseOverview, { type DatabaseInfo } from './DatabaseOverview';
+import LakebaseSetupOptions from './LakebaseSetupOptions';
 import LakebasePreflightPanel from './LakebasePreflightPanel';
 import { APIKeysService } from '../../../api/config/APIKeysService';
 
@@ -70,21 +66,6 @@ function isErrorWithResponse(error: unknown): error is ErrorWithResponse {
   return typeof error === 'object' && error !== null && 'response' in error;
 }
 
-interface DatabaseInfo {
-  success: boolean;
-  database_path?: string;
-  database_type?: string;
-  size_mb?: number;
-  created_at?: string;
-  modified_at?: string;
-  tables?: Record<string, number>;
-  total_tables?: number;
-  error?: string;
-  lakebase_enabled?: boolean;
-  lakebase_instance?: string;
-  lakebase_endpoint?: string;
-  connection_error?: string;
-}
 
 interface BackupFile {
   filename: string;
@@ -743,384 +724,37 @@ const DatabaseManagement: React.FC = () => {
   }
 
   return (
-    <Box>
+    <Box sx={{ maxWidth: 880, '& > .MuiAccordion-root': { mb: 1 }, '& .MuiAccordionSummary-content': { my: 1 } }}>
       <Typography data-settings-page-title variant="h6" fontWeight={600} sx={{ mb: 0.5 }}>
         Database Management
       </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 2.5 }}>
-        Check database health, manage backups, and configure storage.
-        Open a section to view its settings and maintenance actions.
-      </Typography>
 
-      {/* General — open by default; the others fold away until needed. */}
-      <Accordion defaultExpanded disableGutters variant="outlined" sx={{ borderRadius: 2, '&:before': { display: 'none' } }}>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <StorageIcon fontSize="small" color="primary" />
-            <Typography fontWeight={600}>General</Typography>
-            <Typography variant="caption" color="text.secondary">
-              status, backups &amp; maintenance
-            </Typography>
-          </Box>
-        </AccordionSummary>
-        <AccordionDetails>
-        {loading && !databaseInfo && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 4, justifyContent: 'center' }}>
-            <CircularProgress size={24} />
-            <Typography color="text.secondary">Loading database information...</Typography>
-          </Box>
-        )}
-        {databaseInfo && (
-          <Card sx={{ mb: 3 }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Database Information
-              </Typography>
-              <Grid container spacing={2}>
-                <Grid item xs={12}>
-                  <Alert severity={
-                    databaseInfo.database_type === 'lakebase'
-                      ? (databaseInfo.connection_error ? 'error' : 'success')
-                      : 'info'
-                  }>
-                    {/* connection_error means Lakebase is CONFIGURED but the
-                        connection failed, so the app is really serving requests
-                        from the fallback database. Reporting the configured
-                        backend as the current one told the user they were on
-                        Lakebase when they were not — and every read they then
-                        did (crews, agents) came from somewhere else entirely. */}
-                    <Typography variant="body2" fontWeight="bold">
-                      {databaseInfo.connection_error
-                        ? `Current Database Backend: FALLBACK (${databaseInfo.database_type?.toUpperCase()} configured but unreachable)`
-                        : `Current Database Backend: ${databaseInfo.database_type?.toUpperCase()}`}
-                    </Typography>
-                    {databaseInfo.database_type === 'lakebase' && databaseInfo.lakebase_instance && (
-                      <Typography variant="caption" display="block">
-                        {databaseInfo.connection_error
-                          ? `Configured Lakebase instance (NOT in use): ${databaseInfo.lakebase_instance}`
-                          : `Connected to Lakebase instance: ${databaseInfo.lakebase_instance}`}
-                      </Typography>
-                    )}
-                    {databaseInfo.connection_error && (
-                      <Typography variant="caption" display="block" color="warning.dark" sx={{ mt: 0.5 }}>
-                        {databaseInfo.connection_error}
-                      </Typography>
-                    )}
-                  </Alert>
-                </Grid>
-                <Grid item xs={12} md={6}>
-                  <Typography variant="body2" color="text.secondary">Type</Typography>
-                  <Typography variant="body1">{databaseInfo.database_type}</Typography>
-                </Grid>
+      {/* Success/Error Messages */}
+      {success && (
+        <Alert severity="success" onClose={() => setSuccess(null)} sx={{ mb: 2 }}>
+          {success}
+        </Alert>
+      )}
+      {error && (
+        <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 2 }}>
+          <Typography sx={{ whiteSpace: 'pre-line' }}>{error}</Typography>
+        </Alert>
+      )}
 
-                {/* Lakebase-specific information */}
-                {databaseInfo.database_type === 'lakebase' && databaseInfo.lakebase_endpoint && (
-                  <Grid item xs={12}>
-                    <Typography variant="body2" color="text.secondary">Endpoint</Typography>
-                    <Typography variant="body1" sx={{ wordBreak: 'break-all' }}>
-                      {databaseInfo.lakebase_endpoint}
-                    </Typography>
-                  </Grid>
-                )}
-
-                {/* SQLite/PostgreSQL-specific information */}
-                {databaseInfo.database_type !== 'lakebase' && (
-                  <>
-                    <Grid item xs={12} md={6}>
-                      <Typography variant="body2" color="text.secondary">Size</Typography>
-                      <Typography variant="body1">{formatSize(databaseInfo.size_mb || 0)}</Typography>
-                    </Grid>
-                    {databaseInfo.database_path && (
-                      <Grid item xs={12}>
-                        <Typography variant="body2" color="text.secondary">Path</Typography>
-                        <Typography variant="body1" sx={{ wordBreak: 'break-all' }}>
-                          {databaseInfo.database_path}
-                        </Typography>
-                      </Grid>
-                    )}
-                    <Grid item xs={12} md={6}>
-                      <Typography variant="body2" color="text.secondary">Created</Typography>
-                      <Typography variant="body1">{formatDate(databaseInfo.created_at || '')}</Typography>
-                    </Grid>
-                    <Grid item xs={12} md={6}>
-                      <Typography variant="body2" color="text.secondary">Modified</Typography>
-                      <Typography variant="body1">{formatDate(databaseInfo.modified_at || '')}</Typography>
-                    </Grid>
-                  </>
-                )}
-                {databaseInfo.tables && (
-                  <Grid item xs={12}>
-                    <Typography variant="body2" color="text.secondary">
-                      Tables ({databaseInfo.total_tables})
-                    </Typography>
-                    <Box sx={{ mt: 1 }}>
-                      {Object.entries(databaseInfo.tables).map(([table, count]) => (
-                        <Chip
-                          key={table}
-                          label={`${table} (${count} rows)`}
-                          size="small"
-                          sx={{ m: 0.5 }}
-                        />
-                      ))}
-                    </Box>
-                  </Grid>
-                )}
-              </Grid>
-            </CardContent>
-          </Card>
-        )}
-        {/* Data Housekeeping Card */}
-        <Card sx={{ mb: 3 }}>
-          <CardContent>
-            <Typography variant="h6" gutterBottom>
-              Data Housekeeping
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Delete execution history, traces, logs, and LLM logs older than a specified date.
-              This can reduce database size and speed up migrations.
-            </Typography>
-            <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', flexWrap: 'wrap' }}>
-              <TextField
-                type="date"
-                label="Cutoff Date"
-                value={housekeepingDate}
-                onChange={(e) => {
-                  setHousekeepingDate(e.target.value);
-                  setHousekeepingResult(null);
-                }}
-                InputLabelProps={{ shrink: true }}
-                helperText="Records older than this date will be deleted"
-                sx={{ minWidth: 200 }}
-              />
-              <Button
-                variant="outlined"
-                color="warning"
-                startIcon={housekeepingLoading ? <CircularProgress size={18} /> : <DeleteSweepIcon />}
-                onClick={() => setShowHousekeepingConfirm(true)}
-                disabled={housekeepingLoading || !housekeepingDate}
-                sx={{ mt: 1 }}
-              >
-                {housekeepingLoading ? 'Running...' : 'Run Housekeeping'}
-              </Button>
-            </Box>
-            {housekeepingResult && housekeepingResult.success && (
-              <Alert severity="success" sx={{ mt: 2 }}>
-                <Typography variant="body2" fontWeight="bold">
-                  Housekeeping completed — {housekeepingResult.total_deleted} records deleted
-                </Typography>
-                <Box sx={{ mt: 1 }}>
-                  {housekeepingResult.deleted && Object.entries(housekeepingResult.deleted).map(([table, count]) => (
-                    <Chip
-                      key={table}
-                      label={`${table}: ${count}`}
-                      size="small"
-                      sx={{ m: 0.5 }}
-                      color={count > 0 ? 'primary' : 'default'}
-                      variant={count > 0 ? 'filled' : 'outlined'}
-                    />
-                  ))}
-                </Box>
-              </Alert>
-            )}
-            {housekeepingResult && !housekeepingResult.success && (
-              <Alert severity="error" sx={{ mt: 2 }}>
-                {housekeepingResult.error || 'Housekeeping failed'}
-              </Alert>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Housekeeping Confirmation Dialog */}
-        <Dialog open={showHousekeepingConfirm} onClose={() => setShowHousekeepingConfirm(false)}>
-          <DialogTitle>Confirm Data Housekeeping</DialogTitle>
-          <DialogContent>
-            <DialogContentText>
-              This will permanently delete all records older than <strong>{housekeepingDate}</strong> from the following tables:
-            </DialogContentText>
-            <Box sx={{ mt: 1, ml: 2 }}>
-              <Typography variant="body2">• executionhistory (+ taskstatus, errortrace)</Typography>
-              <Typography variant="body2">• execution_trace</Typography>
-              <Typography variant="body2">• execution_logs</Typography>
-              <Typography variant="body2">• llmlog</Typography>
-            </Box>
-            <DialogContentText sx={{ mt: 2 }}>
-              This action cannot be undone. Are you sure?
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setShowHousekeepingConfirm(false)}>Cancel</Button>
-            <Button
-              color="warning"
-              variant="contained"
-              onClick={async () => {
-                setShowHousekeepingConfirm(false);
-                setHousekeepingLoading(true);
-                setHousekeepingResult(null);
-                try {
-                  const response = await apiClient.post('/database-management/housekeeping', {
-                    cutoff_date: housekeepingDate,
-                  });
-                  setHousekeepingResult(response.data);
-                  // Refresh database info to show updated row counts
-                  loadDatabaseInfo();
-                } catch (err) {
-                  if (isErrorWithResponse(err)) {
-                    setHousekeepingResult({
-                      success: false,
-                      error: err.response?.data?.detail || err.response?.data?.error || err.message || 'Housekeeping failed',
-                    });
-                  } else {
-                    setHousekeepingResult({ success: false, error: 'Housekeeping failed' });
-                  }
-                } finally {
-                  setHousekeepingLoading(false);
-                }
-              }}
-            >
-              Delete Old Data
-            </Button>
-          </DialogActions>
-        </Dialog>
-        </AccordionDetails>
-      </Accordion>
-
-      <Accordion disableGutters variant="outlined" sx={{ mt: 1.5, borderRadius: 2, '&:before': { display: 'none' } }}>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <CloudIcon fontSize="small" color="primary" />
-            <Typography fontWeight={600}>Databricks Import / Export</Typography>
-            <Typography variant="caption" color="text.secondary">
-              move the database to and from a volume
-            </Typography>
-          </Box>
-        </AccordionSummary>
-        <AccordionDetails>
-        <Card>
-          <CardContent>
-            <Typography variant="h6" gutterBottom>
-              Databricks Volume Settings
-            </Typography>
-            <Grid container spacing={2} sx={{ mb: 3 }}>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  label="Catalog"
-                  value={catalog}
-                  onChange={(e) => setCatalog(e.target.value)}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  label="Schema"
-                  value={schema}
-                  onChange={(e) => setSchema(e.target.value)}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  label="Volume Name"
-                  value={volumeName}
-                  onChange={(e) => setVolumeName(e.target.value)}
-                />
-              </Grid>
-            </Grid>
-
-            <Box sx={{ display: 'flex', gap: 2, mb: 3, flexDirection: 'row', alignItems: 'flex-start' }}>
-              <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                <Button
-                  variant="contained"
-                  startIcon={<UploadIcon />}
-                  onClick={() => setExportDialog(true)}
-                  disabled={!hasDatabricksApiKey}
-                >
-                  Export to Volume
-                </Button>
-                {!hasDatabricksApiKey && (
-                  <FormHelperText error sx={{ ml: 1, mt: 0.5 }}>
-                    Please set DATABRICKS_API_KEY in API Keys before exporting
-                  </FormHelperText>
-                )}
-              </Box>
-              <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                <Button
-                  variant="outlined"
-                  startIcon={<DownloadIcon />}
-                  onClick={() => {
-                    loadBackups();
-                    setImportDialog(true);
-                  }}
-                  disabled={!hasDatabricksApiKey}
-                >
-                  Import from Volume
-                </Button>
-                {!hasDatabricksApiKey && (
-                  <FormHelperText error sx={{ ml: 1, mt: 0.5 }}>
-                    Please set DATABRICKS_API_KEY in API Keys before importing
-                  </FormHelperText>
-                )}
-              </Box>
-              <Button
-                variant="outlined"
-                startIcon={<RefreshIcon />}
-                onClick={loadBackups}
-              >
-                List Backups
-              </Button>
-            </Box>
-
-            {backups && backups.backups && backups.backups.length > 0 && (
-              <Box>
-                <Typography variant="subtitle1" gutterBottom>
-                  Available Backups ({backups.total_backups})
-                </Typography>
-                {backups.volume_path && (
-                  <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                    Volume Path: {backups.volume_path}
-                  </Typography>
-                )}
-                <List>
-                  {backups.backups.map((backup) => (
-                    <ListItem key={backup.filename} divider>
-                      <ListItemText
-                        primary={backup.filename}
-                        secondary={`${formatSize(backup.size_mb)} • ${formatDate(backup.created_at)}`}
-                      />
-                      <ListItemSecondaryAction>
-                        {backup.databricks_url && (
-                          <IconButton
-                            edge="end"
-                            onClick={() => window.open(backup.databricks_url, '_blank')}
-                            title="View in Databricks"
-                          >
-                            <OpenInNewIcon />
-                          </IconButton>
-                        )}
-                      </ListItemSecondaryAction>
-                    </ListItem>
-                  ))}
-                </List>
-              </Box>
-            )}
-          </CardContent>
-        </Card>
-        </AccordionDetails>
-      </Accordion>
-
+      {databaseInfo && <DatabaseOverview info={databaseInfo} formatSize={formatSize} formatDate={formatDate} />}
       {showLakebase && (
-      <Accordion disableGutters variant="outlined" sx={{ mt: 1.5, borderRadius: 2, '&:before': { display: 'none' } }}>
+      <Accordion defaultExpanded disableGutters variant="outlined" sx={{ mt: 1.5, borderRadius: 2, '&:before': { display: 'none' } }}>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <DataObjectIcon fontSize="small" color="primary" />
-            <Typography fontWeight={600}>Lakebase</Typography>
+            <DataObjectIcon fontSize="small" color="action" />
+            <Typography fontWeight={600}>Connection</Typography>
             <Typography variant="caption" color="text.secondary">
-              managed Postgres backend
+              choose where Kasal stores data
             </Typography>
           </Box>
         </AccordionSummary>
         <AccordionDetails>
-        <Paper sx={{ p: 3 }}>
+        <Box>
           {!configLoaded ? (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 4, justifyContent: 'center' }}>
               <CircularProgress size={24} />
@@ -1129,13 +763,8 @@ const DatabaseManagement: React.FC = () => {
           ) : (
           <>
           {/* Radio Button Selection - Same style as Memory Backend */}
-          <FormControl component="fieldset" sx={{ mb: 3 }}>
-            <FormLabel component="legend">
-              <Typography variant="h6" sx={{ mb: 2 }}>
-                Database Backend Configuration
-              </Typography>
-            </FormLabel>
-            <RadioGroup
+          <FormControl component="fieldset" fullWidth sx={{ mb: 2 }}>
+            <RadioGroup aria-label="Database backend" row sx={{ gap: 2 }}
               value={lakebaseBackend}
               onChange={(e) => {
                 const newValue = e.target.value as 'disabled' | 'lakebase';
@@ -1158,9 +787,9 @@ const DatabaseManagement: React.FC = () => {
                 control={<Radio />}
                 label={
                   <Box>
-                    <Typography variant="body1">Disabled</Typography>
+                    <Typography variant="body1">Default database</Typography>
                     <Typography variant="caption" color="text.secondary">
-                      Use default SQLite/PostgreSQL database
+                      SQLite or PostgreSQL
                     </Typography>
                   </Box>
                 }
@@ -1172,7 +801,7 @@ const DatabaseManagement: React.FC = () => {
                   <Box>
                     <Typography variant="body1">Databricks Lakebase</Typography>
                     <Typography variant="caption" color="text.secondary">
-                      Fully-managed PostgreSQL OLTP engine within Databricks
+                      Managed PostgreSQL in Databricks
                     </Typography>
                   </Box>
                 }
@@ -1187,8 +816,8 @@ const DatabaseManagement: React.FC = () => {
 
               {/* Databricks App Setup Prerequisites - only show when not connected */}
               {!(lakebaseConfig.enabled && lakebaseConfig.instance_status === 'READY') && (
-                <Alert severity="info" icon={<InfoIcon />} sx={{ mb: 3 }}>
-                  <Typography variant="subtitle2" sx={{ mb: 0.5 }}>Databricks App Setup</Typography>
+                <Box component="details" sx={{ mb: 2, typography: 'body2', color: 'text.secondary', '& summary': { cursor: 'pointer', py: 0.5, color: 'text.primary' } }}>
+                  <Box component="summary">Before you connect</Box>
                   <Typography variant="body2" component="div">
                     Before connecting, ensure your App&apos;s service principal has Lakebase access:
                     <ol style={{ margin: '4px 0 0 0', paddingLeft: '20px' }}>
@@ -1204,15 +833,11 @@ const DatabaseManagement: React.FC = () => {
                       Databricks Lakebase App docs <OpenInNewIcon sx={{ fontSize: 14, verticalAlign: 'middle', ml: 0.5 }} />
                     </a>
                   </Typography>
-                </Alert>
+                </Box>
               )}
 
               {/* Current Status Section */}
-              <Box sx={{ mb: 3 }}>
-                <Typography variant="subtitle1" sx={{ mb: 2, display: 'flex', alignItems: 'center' }}>
-                  <StorageIcon sx={{ mr: 1 }} />
-                  Current Status
-                </Typography>
+              {lakebaseConfig.enabled && <Box sx={{ mb: 2 }}>
 
                 <Grid container spacing={2} alignItems="center">
                   <Grid item>
@@ -1249,7 +874,7 @@ const DatabaseManagement: React.FC = () => {
 
                 {/* View in Databricks Button */}
                 {lakebaseConfig.instance_status === 'READY' && (
-                  <Box sx={{ mt: 2 }}>
+                  <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                     <Button
                       variant="outlined"
                       size="small"
@@ -1284,7 +909,7 @@ const DatabaseManagement: React.FC = () => {
                     )}
                   </Box>
                 )}
-              </Box>
+              </Box>}
 
               {!(lakebaseConfig.enabled && lakebaseConfig.instance_status === 'READY') && (
               <>
@@ -1292,9 +917,9 @@ const DatabaseManagement: React.FC = () => {
 
               {/* Connect to Existing Instance Form */}
               <Box sx={{ mb: 3 }}>
-                  <Paper sx={{ p: 2, backgroundColor: 'background.default' }}>
+                  <Box>
                     <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 'bold' }}>
-                      Connect to Existing Lakebase Instance
+                      Connect a Lakebase instance
                     </Typography>
                     <Grid container spacing={2}>
                       <Grid item xs={12}>
@@ -1306,7 +931,7 @@ const DatabaseManagement: React.FC = () => {
                             value={lakebaseConfig.instance_name}
                             onChange={(e) => setLakebaseConfig({ ...lakebaseConfig, instance_name: e.target.value })}
                             helperText={
-                              <Box component="span" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                              <Box component="span" sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 0.5 }}>
                                 Could not load instances. Enter the name manually.
                                 <Button size="small" onClick={() => loadLakebaseInstances('', 1)} sx={{ minWidth: 'auto', p: 0, textTransform: 'none' }}>
                                   Retry
@@ -1422,7 +1047,7 @@ const DatabaseManagement: React.FC = () => {
                                       </>
                                     ),
                                   }}
-                                  helperText="Search and select a Lakebase instance from your workspace"
+                                  helperText="Search instances or enter a name"
                                 />
                               )}
                             />
@@ -1447,71 +1072,14 @@ const DatabaseManagement: React.FC = () => {
                             endpoint: e.target.value,
                             instance_status: e.target.value ? 'READY' : 'NOT_CREATED'
                           })}
-                          helperText="Auto-populated from selected instance, or enter manually"
+                          helperText="Filled from your instance. Override only if needed."
                           placeholder="instance-xxxx.database.cloud.databricks.com"
                         />
                       </Grid>
 
                       {/* Setup Option */}
                       <Grid item xs={12}>
-                        <FormControl component="fieldset">
-                          <FormLabel component="legend" sx={{ mb: 1 }}>
-                            Setup Option
-                          </FormLabel>
-                          <RadioGroup
-                            value={migrationOption}
-                            onChange={(e) => setMigrationOption(e.target.value as 'recreate' | 'use' | 'schema_only' | 'use_expand')}
-                          >
-                            <FormControlLabel
-                              value="recreate"
-                              control={<Radio />}
-                              label={
-                                <Box>
-                                  <Typography variant="body2" fontWeight="bold">Migrate Schema & Data</Typography>
-                                  <Typography variant="caption" color="error">
-                                    Drops the existing Lakebase schema, then copies all data from the current database
-                                  </Typography>
-                                </Box>
-                              }
-                            />
-                            <FormControlLabel
-                              value="schema_only"
-                              control={<Radio />}
-                              label={
-                                <Box>
-                                  <Typography variant="body2" fontWeight="bold">Schema Only</Typography>
-                                  <Typography variant="caption" color="error">
-                                    Drops the existing Lakebase schema and recreates it EMPTY — no data is copied
-                                  </Typography>
-                                </Box>
-                              }
-                            />
-                            <FormControlLabel
-                              value="use"
-                              control={<Radio />}
-                              label={
-                                <Box>
-                                  <Typography variant="body2" fontWeight="bold">Use Existing Data</Typography>
-                                  <Typography variant="caption" color="text.secondary">
-                                    Instance already has Kasal schema and data — just connect
-                                  </Typography>
-                                </Box>
-                              }
-                            />
-                            <FormControlLabel
-                              value="use_expand"
-                              control={<Radio />}
-                              label={
-                                <Box>
-                                  <Typography variant="body2" fontWeight="bold">Use &amp; Expand Existing Schema &amp; Data</Typography>
-                                  <Typography variant="caption" color="text.secondary">
-                                    Connect and add any missing tables/columns — keeps all existing data
-                                  </Typography>
-                                </Box>
-                              }
-                            />
-                          </RadioGroup>
-                        </FormControl>
+                        <LakebaseSetupOptions value={migrationOption} onChange={setMigrationOption} />
                       </Grid>
 
                       <Grid item xs={12}>
@@ -1628,7 +1196,7 @@ const DatabaseManagement: React.FC = () => {
                         </Button>
                       </Grid>
                     </Grid>
-                  </Paper>
+                  </Box>
                 </Box>
               </>
               )}
@@ -1636,10 +1204,248 @@ const DatabaseManagement: React.FC = () => {
           )}
           </>
           )}
-        </Paper>
+        </Box>
         </AccordionDetails>
       </Accordion>
       )}
+
+      <Accordion disableGutters variant="outlined" sx={{ mt: 1.5, borderRadius: 2, '&:before': { display: 'none' } }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <CloudIcon fontSize="small" color="action" />
+            <Typography fontWeight={600}>Backups &amp; restore</Typography>
+            <Typography variant="caption" color="text.secondary">
+              import or export a database snapshot
+            </Typography>
+          </Box>
+        </AccordionSummary>
+        <AccordionDetails>
+        <Box>
+            <Grid container spacing={2} sx={{ mb: 3 }}>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  fullWidth
+                  label="Catalog"
+                  value={catalog}
+                  onChange={(e) => setCatalog(e.target.value)}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  fullWidth
+                  label="Schema"
+                  value={schema}
+                  onChange={(e) => setSchema(e.target.value)}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  fullWidth
+                  label="Volume Name"
+                  value={volumeName}
+                  onChange={(e) => setVolumeName(e.target.value)}
+                />
+              </Grid>
+            </Grid>
+
+            {!hasDatabricksApiKey && <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Add a Databricks API key in API Keys to import or export backups.
+            </Typography>}
+            <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                <Button
+                  variant="contained"
+                  startIcon={<UploadIcon />}
+                  onClick={() => setExportDialog(true)}
+                  disabled={!hasDatabricksApiKey}
+                >
+                  Export to Volume
+                </Button>
+              </Box>
+              <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                <Button
+                  variant="outlined"
+                  startIcon={<DownloadIcon />}
+                  onClick={() => {
+                    loadBackups();
+                    setImportDialog(true);
+                  }}
+                  disabled={!hasDatabricksApiKey}
+                >
+                  Import from Volume
+                </Button>
+              </Box>
+              <Button
+                variant="outlined"
+                startIcon={<RefreshIcon />}
+                onClick={loadBackups}
+              >
+                List Backups
+              </Button>
+            </Box>
+
+            {backups && backups.backups && backups.backups.length > 0 && (
+              <Box>
+                <Typography variant="subtitle1" gutterBottom>
+                  Available Backups ({backups.total_backups})
+                </Typography>
+                {backups.volume_path && (
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    Volume Path: {backups.volume_path}
+                  </Typography>
+                )}
+                <List>
+                  {backups.backups.map((backup) => (
+                    <ListItem key={backup.filename} divider>
+                      <ListItemText
+                        primary={backup.filename}
+                        secondary={`${formatSize(backup.size_mb)} • ${formatDate(backup.created_at)}`}
+                      />
+                      <ListItemSecondaryAction>
+                        {backup.databricks_url && (
+                          <IconButton
+                            edge="end"
+                            onClick={() => window.open(backup.databricks_url, '_blank')}
+                            title="View in Databricks"
+                          >
+                            <OpenInNewIcon />
+                          </IconButton>
+                        )}
+                      </ListItemSecondaryAction>
+                    </ListItem>
+                  ))}
+                </List>
+              </Box>
+            )}
+        </Box>
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion disableGutters variant="outlined" sx={{ borderRadius: 2, '&:before': { display: 'none' } }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <DeleteSweepIcon fontSize="small" color="action" />
+            <Typography fontWeight={600}>Data cleanup</Typography>
+            <Typography variant="caption" color="text.secondary">
+              remove older activity
+            </Typography>
+          </Box>
+        </AccordionSummary>
+        <AccordionDetails>
+        {loading && !databaseInfo && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 4, justifyContent: 'center' }}>
+            <CircularProgress size={24} />
+            <Typography color="text.secondary">Loading database information...</Typography>
+          </Box>
+        )}
+        <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Delete execution history, traces, logs, and LLM logs older than a specified date.
+              This can reduce database size and speed up migrations.
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+              <TextField
+                type="date"
+                label="Cutoff Date"
+                value={housekeepingDate}
+                onChange={(e) => {
+                  setHousekeepingDate(e.target.value);
+                  setHousekeepingResult(null);
+                }}
+                InputLabelProps={{ shrink: true }}
+                helperText="Records older than this date will be deleted"
+                sx={{ minWidth: 200 }}
+              />
+              <Button
+                variant="outlined"
+                color="warning"
+                startIcon={housekeepingLoading ? <CircularProgress size={18} /> : <DeleteSweepIcon />}
+                onClick={() => setShowHousekeepingConfirm(true)}
+                disabled={housekeepingLoading || !housekeepingDate}
+                sx={{ mt: 1 }}
+              >
+                {housekeepingLoading ? 'Running...' : 'Run Housekeeping'}
+              </Button>
+            </Box>
+            {housekeepingResult && housekeepingResult.success && (
+              <Alert severity="success" sx={{ mt: 2 }}>
+                <Typography variant="body2" fontWeight="bold">
+                  Housekeeping completed — {housekeepingResult.total_deleted} records deleted
+                </Typography>
+                <Box sx={{ mt: 1 }}>
+                  {housekeepingResult.deleted && Object.entries(housekeepingResult.deleted).map(([table, count]) => (
+                    <Chip
+                      key={table}
+                      label={`${table}: ${count}`}
+                      size="small"
+                      sx={{ m: 0.5 }}
+                      color={count > 0 ? 'primary' : 'default'}
+                      variant={count > 0 ? 'filled' : 'outlined'}
+                    />
+                  ))}
+                </Box>
+              </Alert>
+            )}
+            {housekeepingResult && !housekeepingResult.success && (
+              <Alert severity="error" sx={{ mt: 2 }}>
+                {housekeepingResult.error || 'Housekeeping failed'}
+              </Alert>
+            )}
+        </Box>
+
+        {/* Housekeeping Confirmation Dialog */}
+        <Dialog open={showHousekeepingConfirm} onClose={() => setShowHousekeepingConfirm(false)}>
+          <DialogTitle>Confirm Data Housekeeping</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              This will permanently delete all records older than <strong>{housekeepingDate}</strong> from the following tables:
+            </DialogContentText>
+            <Box sx={{ mt: 1, ml: 2 }}>
+              <Typography variant="body2">• executionhistory (+ taskstatus, errortrace)</Typography>
+              <Typography variant="body2">• execution_trace</Typography>
+              <Typography variant="body2">• execution_logs</Typography>
+              <Typography variant="body2">• llmlog</Typography>
+            </Box>
+            <DialogContentText sx={{ mt: 2 }}>
+              This action cannot be undone. Are you sure?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setShowHousekeepingConfirm(false)}>Cancel</Button>
+            <Button
+              color="warning"
+              variant="contained"
+              onClick={async () => {
+                setShowHousekeepingConfirm(false);
+                setHousekeepingLoading(true);
+                setHousekeepingResult(null);
+                try {
+                  const response = await apiClient.post('/database-management/housekeeping', {
+                    cutoff_date: housekeepingDate,
+                  });
+                  setHousekeepingResult(response.data);
+                  // Refresh database info to show updated row counts
+                  loadDatabaseInfo();
+                } catch (err) {
+                  if (isErrorWithResponse(err)) {
+                    setHousekeepingResult({
+                      success: false,
+                      error: err.response?.data?.detail || err.response?.data?.error || err.message || 'Housekeeping failed',
+                    });
+                  } else {
+                    setHousekeepingResult({ success: false, error: 'Housekeeping failed' });
+                  }
+                } finally {
+                  setHousekeepingLoading(false);
+                }
+              }}
+            >
+              Delete Old Data
+            </Button>
+          </DialogActions>
+        </Dialog>
+        </AccordionDetails>
+      </Accordion>
 
       {/* Export Dialog */}
       <Dialog open={exportDialog} onClose={() => setExportDialog(false)} maxWidth="sm" fullWidth>
@@ -1749,18 +1555,6 @@ const DatabaseManagement: React.FC = () => {
             <Button onClick={() => setExportResult(null)}>Close</Button>
           </DialogActions>
         </Dialog>
-      )}
-
-      {/* Success/Error Messages */}
-      {success && (
-        <Alert severity="success" onClose={() => setSuccess(null)} sx={{ mt: 2 }}>
-          {success}
-        </Alert>
-      )}
-      {error && (
-        <Alert severity="error" onClose={() => setError(null)} sx={{ mt: 2 }}>
-          <Typography sx={{ whiteSpace: 'pre-line' }}>{error}</Typography>
-        </Alert>
       )}
 
       {/* Confirmation Dialog for Disabling Lakebase */}

--- a/src/frontend/src/features/configuration/components/DatabaseOverview.tsx
+++ b/src/frontend/src/features/configuration/components/DatabaseOverview.tsx
@@ -1,0 +1,68 @@
+import { Accordion, AccordionDetails, AccordionSummary, Alert, Box, Chip, Typography } from '@mui/material';
+import { ExpandMore, Storage } from '@mui/icons-material';
+
+export interface DatabaseInfo {
+  success: boolean;
+  database_path?: string;
+  database_type?: string;
+  size_mb?: number;
+  created_at?: string;
+  modified_at?: string;
+  tables?: Record<string, number>;
+  total_tables?: number;
+  error?: string;
+  lakebase_enabled?: boolean;
+  lakebase_instance?: string;
+  lakebase_endpoint?: string;
+  connection_error?: string;
+}
+
+interface Props {
+  info: DatabaseInfo;
+  formatSize: (size: number) => string;
+  formatDate: (date: string) => string;
+}
+
+/** Keep health visible; technical metadata and row counts are available on demand. */
+export default function DatabaseOverview({ info, formatSize, formatDate }: Props) {
+  const backend = info.database_type?.toUpperCase() || 'Unknown';
+  const records = Object.values(info.tables || {}).reduce((sum, count) => sum + count, 0);
+  return <Box component="section" aria-label="Database overview" sx={{ mb: 2 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap', py: 1 }}>
+      <Box sx={{ p: 1, borderRadius: 2, bgcolor: 'action.hover', display: 'flex' }}><Storage color="action" fontSize="small" /></Box>
+      <Box sx={{ flex: 1, minWidth: 180 }}>
+        <Typography variant="subtitle2">Current Database Backend: {info.connection_error ? 'FALLBACK' : backend}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {info.connection_error ? `${backend} configured but unreachable` : 'Storage used by this installation'}
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        {info.total_tables != null && <Typography variant="body2">{info.total_tables} tables</Typography>}
+        {info.tables && <Typography variant="body2" color="text.secondary">{records.toLocaleString()} rows</Typography>}
+        {info.database_type !== 'lakebase' && <Typography variant="body2" color="text.secondary">{formatSize(info.size_mb || 0)}</Typography>}
+      </Box>
+    </Box>
+    {info.database_type === 'lakebase' && info.lakebase_instance && <Typography variant="body2" sx={{ my: 1, overflowWrap: 'anywhere' }}>
+      {info.connection_error ? `Configured Lakebase instance (NOT in use): ${info.lakebase_instance}` : `Connected to Lakebase instance: ${info.lakebase_instance}`}
+    </Typography>}
+    {info.connection_error && <Alert severity="error" sx={{ my: 1 }}>{info.connection_error}</Alert>}
+    {info.error && !info.connection_error && <Alert severity="error" sx={{ my: 1 }}>{info.error}</Alert>}
+    <Accordion disableGutters elevation={0}>
+      <AccordionSummary expandIcon={<ExpandMore />} sx={{ '&&': { minHeight: 36, px: 0 }, '& .MuiAccordionSummary-content': { my: 0.5 } }}>
+        <Typography variant="caption" color="text.secondary">Database details</Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{ '&&': { px: 0, py: 1 } }}>
+        <Box component="dl" sx={{ m: 0, display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '100px minmax(0, 1fr)' }, gap: 1, fontSize: 13,
+          '& dt': { color: 'text.secondary' }, '& dd': { m: 0, overflowWrap: 'anywhere' } }}>
+          {info.lakebase_endpoint && <><Box component="dt">Endpoint</Box><Box component="dd">{info.lakebase_endpoint}</Box></>}
+          {info.database_path && <><Box component="dt">Path</Box><Box component="dd">{info.database_path}</Box></>}
+          {info.created_at && <><Box component="dt">Created</Box><Box component="dd">{formatDate(info.created_at)}</Box></>}
+          {info.modified_at && <><Box component="dt">Modified</Box><Box component="dd">{formatDate(info.modified_at)}</Box></>}
+        </Box>
+        {info.tables && <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 1.5, maxHeight: 200, overflowY: 'auto' }}>
+          {Object.entries(info.tables).map(([table, count]) => <Chip key={table} label={`${table} (${count} rows)`} size="small" variant="outlined" />)}
+        </Box>}
+      </AccordionDetails>
+    </Accordion>
+  </Box>;
+}

--- a/src/frontend/src/features/configuration/components/LakebaseSetupOptions.tsx
+++ b/src/frontend/src/features/configuration/components/LakebaseSetupOptions.tsx
@@ -1,0 +1,25 @@
+import { Alert, Box, MenuItem, TextField, Typography } from '@mui/material';
+
+const options = {
+  use: { label: 'Use existing data', description: 'Connect to an instance that already has the Kasal schema and data.' },
+  use_expand: { label: 'Use and expand schema', description: 'Keep existing data and add any missing tables or columns.' },
+  recreate: { label: 'Migrate schema and data', description: 'Replaces the existing Lakebase schema and copies data from the current database. Existing Lakebase data will be deleted.' },
+  schema_only: { label: 'Create an empty schema', description: 'Replaces the existing Lakebase schema with an empty one. Existing Lakebase data will be deleted; no data is copied.' },
+};
+
+type SetupOption = keyof typeof options;
+
+export default function LakebaseSetupOptions({ value, onChange }: {
+  value: SetupOption;
+  onChange: (value: SetupOption) => void;
+}) {
+  const replacesData = value === 'recreate' || value === 'schema_only';
+  return <Box>
+    <TextField select fullWidth label="Setup option" value={value} onChange={event => onChange(event.target.value as SetupOption)}>
+      {Object.entries(options).map(([id, option]) => <MenuItem key={id} value={id}>{option.label}</MenuItem>)}
+    </TextField>
+    {replacesData
+      ? <Alert severity="warning" sx={{ mt: 1 }}>{options[value].description}</Alert>
+      : <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>{options[value].description}</Typography>}
+  </Box>;
+}

--- a/src/frontend/src/features/configuration/components/SettingsContent.tsx
+++ b/src/frontend/src/features/configuration/components/SettingsContent.tsx
@@ -34,6 +34,14 @@ export default function SettingsContent({ children }: { children: ReactNode }) {
           '&&': { border: 0, borderRadius: 16, backgroundImage: 'none', boxShadow: 'none', backgroundColor: surface },
           '& .MuiPaper-root': { backgroundColor: 'transparent' },
           '&.MuiDialog-paper, &.MuiPopover-paper, &.MuiMenu-paper': kasalStageSurface(dark),
+          // Autocomplete lists float over the form; transparent section surfaces
+          // would let the fields underneath show through their options.
+          '&&.MuiAutocomplete-paper': {
+            ...kasalStageSurface(dark),
+            marginBlock: 6,
+            borderRadius: 12,
+            boxShadow: `0 8px 24px ${alpha('#000', dark ? 0.3 : 0.12)}`,
+          },
         } } },
         MuiCardContent: { styleOverrides: { root: { padding: 24, '&:last-child': { paddingBottom: 24 } } } },
         MuiButton: { defaultProps: { disableElevation: true }, styleOverrides: { root: {


### PR DESCRIPTION
Database settings showed nested sections, lengthy setup choices, and transparent instance dropdowns that let the fields beneath show through. This update puts a compact database overview and connection settings first, with database details, backups, and cleanup available on demand.

- Replace the four long Lakebase setup choices with a selector and an explanation of the selected option. Keep data-replacement warnings and existing confirmations visible.
- Use opaque, theme-matched autocomplete surfaces; remove nested cards and duplicate backup setup messages; show connection diagnostics for enabled instances.
- Extract overview and setup presentation into focused components, and retain the fallback-database error display.

Validation: 37 configuration tests pass; TypeScript passes; full frontend lint reports zero errors (487 existing warnings). Browser checks with mocked API data cover light/dark themes, mobile width, instance selection and endpoint population, setup choices, destructive-operation warnings, backup prerequisites, and cleanup confirmation. No live database was changed.

Targets `contrib/unified-kasal-platform`, the branch created from the earlier contribution, so this PR contains only the database UI update.
